### PR TITLE
FI-681: Fix EHR launch scopes

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -18,7 +18,7 @@ bind: '0.0.0.0'
 disable_tls_tests: false
 
 # Default scopes
-default_scopes: launch launch/patient offline_access openid profile user/*.* patient/*.*
+default_scopes: launch user/*.read openid fhirUser offline_access
 
 # Log Level: unkown, fatal, error, warn, info, debug
 log_level: info

--- a/lib/modules/onc_program_module.yml
+++ b/lib/modules/onc_program_module.yml
@@ -78,7 +78,6 @@ test_sets:
             title: EHR Launch with Practitioner Scope
             description: Perform EHR SMART launch sequence and test OpenID Connect and token refresh functionality.
             variable_defaults:
-              scopes: launch user/*.read openid fhirUser offline_access
               confidential_client: 'true'
           - sequence: OncOpenIDConnectSequence
             prefix: EHC


### PR DESCRIPTION
This branch fixes the obsolete program EHR launch scopes (particularly the use of `profile` instead of `fhirUser`).

The default set in the module yaml didn't work because those defaults are only used when the input is blank, which is not the case for scopes (https://github.com/onc-healthit/inferno-program/blob/master/public/js/app.js#L196).

**Submitter:**
- [x] This pull request describes why these changes were made
- [x] Internal ticket for this PR: https://oncprojectracking.healthit.gov/support/browse/FI-681
- [x] Internal ticket links to this PR
- [x] Internal ticket is properly labeled (Community/Program)
- [x] Internal ticket has a justification for its Community/Program label
- [x] Code diff has been reviewed for extraneous/missing code
- n/a Tests are included and test edge cases
- n/a Tests/code quality metrics have been run locally and pass


**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name: @okeefm
- [x] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
