### PR TITLE
FI-660: Persist data between docker runs

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,7 @@ services:
       context: ./
     volumes:
       - ./config.yml:/var/www/inferno/config.yml
+      - ./data:/var/www/inferno/data
       - type: bind
         source: "./resources/terminology/validators"
         target: "/var/www/inferno/resources/terminology/validators"


### PR DESCRIPTION
This branch mounts the `data` directory in the inferno docker image so that the data will be persisted across docker runs.

**Submitter:**
- [x] This pull request describes why these changes were made
- [x] Internal ticket links to this PR
- [x] Internal ticket is properly labeled (Community/Program)
- [x] Internal ticket has a justification for its Community/Program label
- [x] Code diff has been reviewed for extraneous/missing code
- n/a Tests are included and test edge cases
- n/a Tests/code quality metrics have been run locally and pass


**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name: @okeefm 
- [x] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
