### PR TITLE
FI-693: Default to external validator

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -38,7 +38,7 @@ include_extras: true
 badge_text: PROGRAM EDITION
 
 # Resource validator options: must be one of "internal" or "external". external_resource_validator_url is only used if resource_validator is set to external.
-resource_validator: internal
+resource_validator: external
 external_resource_validator_url: http://validator_service:4567
 
 # module options: one or more must be set.  The first option in the list will be checked by default

--- a/lib/app/utils/resource_validator_factory.rb
+++ b/lib/app/utils/resource_validator_factory.rb
@@ -7,6 +7,8 @@ module Inferno
   class App
     module ResourceValidatorFactory
       def self.new_validator(selected_validator, external_validator_url)
+        return Inferno::FHIRModelsValidator.new if ENV['RACK_ENV'] == 'test'
+
         case selected_validator
         when 'internal'
           Inferno::FHIRModelsValidator.new


### PR DESCRIPTION
This branch defaults to using the external validator and adds special handling so that the internal validator is used in tests

**Submitter:**
- [x] This pull request describes why these changes were made
- [x] Internal ticket links to this PR
- [x] Internal ticket is properly labeled (Community/Program)
- [x] Internal ticket has a justification for its Community/Program label
- [x] Code diff has been reviewed for extraneous/missing code
- n/a Tests are included and test edge cases
- n/a Tests/code quality metrics have been run locally and pass


**Reviewer 1:**

Name: @arscan 
- [x] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- n/a The tests appropriately test the new code, including edge cases
- n/a You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
