### PR TITLE
FI-678: Update clinical notes sequence to check all patients

### DIFF
--- a/lib/modules/us_core_guidance/clinicalnotes_sequence.rb
+++ b/lib/modules/us_core_guidance/clinicalnotes_sequence.rb
@@ -52,57 +52,65 @@ module Inferno
       attr_accessor :document_attachments, :report_attachments
 
       def test_clinical_notes_document_reference(category_code)
-        # TODO: update to only skip if no patient has the information we need
-        patient_id = @instance.patient_ids.split(',').first
+        skip_if_known_not_supported(:DocumentReference, [:search])
 
-        search_params = { 'patient': patient_id, 'type': category_code }
         resource_class = 'DocumentReference'
+        patient_ids = @instance.patient_ids.split(',')
 
-        skip_if_known_not_supported(:DocumentReference, [:read])
+        resources_found = patient_ids.any? do |patient_id|
+          search_params = { 'patient': patient_id, 'type': category_code }
 
-        reply = get_resource_by_params(versioned_resource_class(resource_class), search_params)
-        assert_response_ok(reply)
-        assert_bundle_response(reply)
+          reply = get_resource_by_params(versioned_resource_class(resource_class), search_params)
+          assert_response_ok(reply)
+          assert_bundle_response(reply)
 
-        resources_found = reply&.resource&.entry&.any? { |entry| entry&.resource&.resourceType == resource_class }
+          next if reply&.resource&.entry&.none? { |entry| entry&.resource&.resourceType == resource_class }
+
+          self.document_attachments = ClinicalNoteAttachment.new(resource_class) if document_attachments.nil?
+
+          document_references = fetch_all_bundled_resources(reply)
+
+          document_references&.each do |document|
+            document&.content&.select { |content| !document_attachments.attachment.key?(content&.attachment&.url) }&.each do |content|
+              document_attachments.attachment[content.attachment.url] = document.id
+            end
+          end
+
+          true
+        end
 
         skip "No #{resource_class} resources with type #{category_code} appear to be available. Please use patients with more information." unless resources_found
-
-        self.document_attachments = ClinicalNoteAttachment.new(resource_class) if document_attachments.nil?
-
-        document_references = fetch_all_bundled_resources(reply)
-
-        document_references&.each do |document|
-          document&.content&.select { |content| !document_attachments.attachment.key?(content&.attachment&.url) }&.each do |content|
-            document_attachments.attachment[content.attachment.url] = document.id
-          end
-        end
       end
 
       def test_clinical_notes_diagnostic_report(category_code)
-        # TODO: update to only skip if no patient has the information we need
-        patient_id = @instance.patient_ids.split(',').first
+        skip_if_known_not_supported(:DiagnosticReport, [:search])
 
-        search_params = { 'patient': patient_id, 'category': category_code }
         resource_class = 'DiagnosticReport'
+        patient_ids = @instance.patient_ids.split(',')
 
-        reply = get_resource_by_params(versioned_resource_class(resource_class), search_params)
-        assert_response_ok(reply)
-        assert_bundle_response(reply)
+        resources_found = patient_ids.any? do |patient_id|
+          search_params = { 'patient': patient_id, 'category': category_code }
 
-        resources_found = reply&.resource&.entry&.any? { |entry| entry&.resource&.resourceType == resource_class }
+          reply = get_resource_by_params(versioned_resource_class(resource_class), search_params)
+          assert_response_ok(reply)
+          assert_bundle_response(reply)
+
+          next if reply&.resource&.entry&.none? { |entry| entry&.resource&.resourceType == resource_class }
+
+          self.report_attachments = ClinicalNoteAttachment.new(resource_class) if report_attachments.nil?
+
+          diagnostic_reports = fetch_all_bundled_resources(reply)
+
+          diagnostic_reports&.each do |report|
+            report&.presentedForm&.select { |attachment| !report_attachments.attachment.key?(attachment&.url) }&.each do |attachment|
+              report_attachments.attachment[attachment.url] = report.id
+            end
+          end
+
+          true
+        end
 
         skip "No #{resource_class} resources with category #{category_code} appear to be available. Please use patients with more information." unless resources_found
-
-        self.report_attachments = ClinicalNoteAttachment.new(resource_class) if report_attachments.nil?
-
-        diagnostic_reports = fetch_all_bundled_resources(reply)
-
-        diagnostic_reports&.each do |report|
-          report&.presentedForm&.select { |attachment| !report_attachments.attachment.key?(attachment&.url) }&.each do |attachment|
-            report_attachments.attachment[attachment.url] = report.id
-          end
-        end
       end
 
       test :have_consultation_note do

--- a/lib/modules/us_core_guidance/clinicalnotes_sequence.rb
+++ b/lib/modules/us_core_guidance/clinicalnotes_sequence.rb
@@ -64,7 +64,7 @@ module Inferno
           assert_response_ok(reply)
           assert_bundle_response(reply)
 
-          next if reply&.resource&.entry&.none? { |entry| entry&.resource&.resourceType == resource_class }
+          next unless reply&.resource&.entry&.any? { |entry| entry&.resource&.resourceType == resource_class }
 
           self.document_attachments = ClinicalNoteAttachment.new(resource_class) if document_attachments.nil?
 
@@ -95,7 +95,7 @@ module Inferno
           assert_response_ok(reply)
           assert_bundle_response(reply)
 
-          next if reply&.resource&.entry&.none? { |entry| entry&.resource&.resourceType == resource_class }
+          next unless reply&.resource&.entry&.any? { |entry| entry&.resource&.resourceType == resource_class }
 
           self.report_attachments = ClinicalNoteAttachment.new(resource_class) if report_attachments.nil?
 


### PR DESCRIPTION
This branch updates the clinical notes guidance sequence to check all patient ids for each note type rather than only checking the first patient.

**Submitter:**
- [x] This pull request describes why these changes were made
- [x] Internal ticket links to this PR
- [x] Internal ticket is properly labeled (Community/Program)
- [x] Internal ticket has a justification for its Community/Program label
- [x] Code diff has been reviewed for extraneous/missing code
- n/a Tests are included and test edge cases
- [x] Tests/code quality metrics have been run locally and pass


**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
