### PR TITLE
Fi 705 add the ability to build only non umls valuesets

### DIFF
--- a/lib/app/utils/terminology.rb
+++ b/lib/app/utils/terminology.rb
@@ -88,7 +88,7 @@ module Inferno
           cs = vs.code_system_set(k)
           filename = "#{root_dir}/#{bloom_file_name(k)}"
           save_to_file(cs, filename, type)
-          validators << { url: k, file: File.basename(filename), count: cs.length, type: type.to_s, code_systems: k }
+          validators << { url: k, file: name_by_type(File.basename(filename), type), count: cs.length, type: type.to_s, code_systems: k }
         end
       end
       # Write manifest for loading later

--- a/lib/app/utils/terminology.rb
+++ b/lib/app/utils/terminology.rb
@@ -60,90 +60,71 @@ module Inferno
     # @param selected_module [Symbol]/[String], the name of the module to build validators for, or :all (default)
     # @param [String] minimum_binding_strength the lowest binding strength for which we should build validators
     # @param [Boolean] include_umls a flag to determine if we should build validators that require UMLS
-    def self.create_validators(type, selected_module = :all, minimum_binding_strength = 'example', include_umls = true)
+    def self.create_validators(type: :bloom, selected_module: :all, minimum_binding_strength: 'example', include_umls: true)
       strengths = ['example', 'preferred', 'extensible', 'required'].drop_while { |s| s != minimum_binding_strength }
       validators = []
-      valuesets = if selected_module == :all
-                    @known_valuesets
-                  else
-                    # get the list of unique value set URL strings where the corresponding
-                    # strength attribute is in the strengths array from above
-                    module_vs_urls = Inferno::Module.get(selected_module)
-                      .value_sets
-                      .keep_if { |vs| strengths.include? vs[:strength] }
-                      .collect { |vs| vs[:value_set_url] }
-                      .compact
-                      .uniq
-                    module_valuesets = @known_valuesets.keep_if { |key, _| module_vs_urls.include?(key) }
-                    # Throw an error message for each missing valueset
-                    # But don't halt the rake task
-                    (module_vs_urls - module_valuesets.keys).each do |missing_vs_url|
-                      Inferno.logger.error "Inferno doesn't know about valueset #{missing_vs_url} for module #{selected_module}"
-                    end
-                    module_valuesets
-                  end
+      valuesets = get_module_valuesets(selected_module, strengths)
       umls_code_systems = Set.new(Inferno::Terminology::Valueset::SAB.keys)
+      root_dir = "resources/terminology/validators/#{type}"
+      FileUtils.mkdir_p(root_dir)
+
+      valuesets.each do |k, vs|
+        next if SKIP_SYS.include? k
+        next if !include_umls && !umls_code_systems.disjoint?(Set.new(vs.included_code_systems))
+
+        Inferno.logger.debug "Processing #{k}"
+        filename = "#{root_dir}/#{(URI(vs.url).host + URI(vs.url).path).gsub(%r{[./]}, '_')}"
+        begin
+          save_to_file(vs.valueset, filename, type)
+          validators << { url: k, file: File.basename(filename), count: vs.count, type: type.to_s, code_systems: vs.included_code_systems }
+        rescue Valueset::UnknownCodeSystemException, Valueset::FilterOperationException, UnknownValueSetException => e
+          Inferno.logger.warn "#{e.message} for ValueSet: #{k}"
+          next
+        end
+      end
+      if include_umls
+        vs = Inferno::Terminology::Valueset.new(@db)
+        Inferno::Terminology::Valueset::SAB.each do |k, _v|
+          Inferno.logger.debug "Processing #{k}"
+          cs = vs.code_system_set(k)
+          filename = "#{root_dir}/#{bloom_file_name(k)}"
+          save_to_file(cs, filename, type)
+          validators << { url: k, file: File.basename(filename), count: cs.length, type: type.to_s, code_systems: k }
+        end
+      end
+      # Write manifest for loading later
+      File.write("#{root_dir}/manifest.yml", validators.to_yaml)
+    end
+
+    def self.get_module_valuesets(selected_module, strengths)
+      if selected_module == :all
+        @known_valuesets
+      else
+        # get the list of unique value set URL strings where the corresponding
+        # strength attribute is in the strengths array from above
+        module_vs_urls = Inferno::Module.get(selected_module)
+          .value_sets
+          .keep_if { |vs| strengths.include? vs[:strength] }
+          .collect { |vs| vs[:value_set_url] }
+          .compact
+          .uniq
+        module_valuesets = @known_valuesets.keep_if { |key, _| module_vs_urls.include?(key) }
+        # Throw an error message for each missing valueset
+        # But don't halt the rake task
+        (module_vs_urls - module_valuesets.keys).each do |missing_vs_url|
+          Inferno.logger.error "Inferno doesn't know about valueset #{missing_vs_url} for module #{selected_module}"
+        end
+        module_valuesets
+      end
+    end
+
+    # Chooses which filetype to save the validator as, based on the type variable passed in
+    def self.save_to_file(codeset, filename, type)
       case type
       when :bloom
-        root_dir = 'resources/terminology/validators/bloom'
-        FileUtils.mkdir_p(root_dir)
-        valuesets.each do |k, vs|
-          next if SKIP_SYS.include? k
-          next if !include_umls && !umls_code_systems.disjoint?(Set.new(vs.included_code_systems))
-
-          Inferno.logger.debug "Processing #{k}"
-          filename = "#{root_dir}/#{(URI(vs.url).host + URI(vs.url).path).gsub(%r{[./]}, '_')}.msgpack"
-          begin
-            save_bloom_to_file(vs.valueset, filename)
-            validators << { url: k, file: File.basename(filename), count: vs.count, type: 'bloom', code_systems: vs.included_code_systems }
-          rescue Valueset::UnknownCodeSystemException => e
-            binding.pry
-            Inferno.logger.warn "#{e.message} for ValueSet: #{k}"
-            next
-          rescue Valueset::FilterOperationException => e
-            Inferno.logger.warn "#{e.message} for ValueSet: #{k}"
-            next
-          rescue UnknownValueSetException => e
-            Inferno.logger.warn "#{e.message} for ValueSet: #{url}"
-            next
-          end
-        end
-        if include_umls
-          vs = Inferno::Terminology::Valueset.new(@db)
-          Inferno::Terminology::Valueset::SAB.each do |k, _v|
-            Inferno.logger.debug "Processing #{k}"
-            cs = vs.code_system_set(k)
-            filename = "#{root_dir}/#{bloom_file_name(k)}.msgpack"
-            save_bloom_to_file(cs, filename)
-            validators << { url: k, file: File.basename(filename), count: cs.length, type: 'bloom', code_systems: k }
-          end
-        end
-        # Write manifest for loading later
-        File.write("#{root_dir}/manifest.yml", validators.to_yaml)
+        save_bloom_to_file(codeset, "#{filename}.msgpack")
       when :csv
-        root_dir = 'resources/terminology/validators/csv'
-        FileUtils.mkdir_p(root_dir)
-        @known_valuesets.each do |k, vs|
-          next if SKIP_SYS.include? k
-          next unless umls_code_systems.disjoint?(Set.new(vs.included_code_systems)) && !include_umls 
-
-          Inferno.logger.debug "Processing #{k}"
-          filename = "#{root_dir}/#{bloom_file_name(vs.url)}.csv"
-          save_csv_to_file(vs.valueset, filename)
-          validators << { url: k, file: File.basename(filename), count: vs.count, type: 'csv', code_systems: vs.included_code_systems }
-        end
-        if include_umls
-          vs = Inferno::Terminology::Valueset.new(@db)
-          Inferno::Terminology::Valueset::SAB.each do |k, _v|
-            Inferno.logger.debug "Processing #{k}"
-            cs = vs.code_system_set(k)
-            filename = "#{root_dir}/#{bloom_file_name(k)}.csv"
-            save_csv_to_file(cs, filename)
-            validators << { url: k, file: File.basename(filename), count: cs.length, type: 'csv', code_systems: k }
-          end
-        end
-        # Write manifest for loading later
-        File.write("#{root_dir}/manifest.yml", validators.to_yaml)
+        save_csv_to_file(codeset, "#{filename}.csv")
       else
         raise 'Unknown Validator Type!'
       end

--- a/lib/app/utils/terminology.rb
+++ b/lib/app/utils/terminology.rb
@@ -63,12 +63,11 @@ module Inferno
     def self.create_validators(type: :bloom, selected_module: :all, minimum_binding_strength: 'example', include_umls: true)
       strengths = ['example', 'preferred', 'extensible', 'required'].drop_while { |s| s != minimum_binding_strength }
       validators = []
-      valuesets = get_module_valuesets(selected_module, strengths)
       umls_code_systems = Set.new(Inferno::Terminology::Valueset::SAB.keys)
       root_dir = "resources/terminology/validators/#{type}"
       FileUtils.mkdir_p(root_dir)
 
-      valuesets.each do |k, vs|
+      get_module_valuesets(selected_module, strengths).each do |k, vs|
         next if SKIP_SYS.include? k
         next if !include_umls && !umls_code_systems.disjoint?(Set.new(vs.included_code_systems))
 

--- a/lib/app/utils/terminology.rb
+++ b/lib/app/utils/terminology.rb
@@ -75,7 +75,7 @@ module Inferno
         filename = "#{root_dir}/#{(URI(vs.url).host + URI(vs.url).path).gsub(%r{[./]}, '_')}"
         begin
           save_to_file(vs.valueset, filename, type)
-          validators << { url: k, file: File.basename(filename), count: vs.count, type: type.to_s, code_systems: vs.included_code_systems }
+          validators << { url: k, file: name_by_type(File.basename(filename), type), count: vs.count, type: type.to_s, code_systems: vs.included_code_systems }
         rescue Valueset::UnknownCodeSystemException, Valueset::FilterOperationException, UnknownValueSetException => e
           Inferno.logger.warn "#{e.message} for ValueSet: #{k}"
           next
@@ -121,9 +121,20 @@ module Inferno
     def self.save_to_file(codeset, filename, type)
       case type
       when :bloom
-        save_bloom_to_file(codeset, "#{filename}.msgpack")
+        save_bloom_to_file(codeset, name_by_type(filename, type))
       when :csv
-        save_csv_to_file(codeset, "#{filename}.csv")
+        save_csv_to_file(codeset, name_by_type(filename, type))
+      else
+        raise 'Unknown Validator Type!'
+      end
+    end
+
+    def self.name_by_type(filename, type)
+      case type
+      when :bloom
+        "#{filename}.msgpack"
+      when :csv
+        "#{filename}.csv"
       else
         raise 'Unknown Validator Type!'
       end

--- a/lib/tasks/tasks.rake
+++ b/lib/tasks/tasks.rake
@@ -814,12 +814,10 @@ namespace :terminology do |_argv|
 
   desc 'Create only non-UMLS validators'
   task :create_non_umls_vs_validators, [:module, :minimum_binding_strength] do |_t, args|
-    args.with_defaults(database: File.join(TEMP_DIR, 'umls.db'),
-                       type: 'bloom',
+    args.with_defaults(type: 'bloom',
                        module: :all,
                        minimum_binding_strength: 'example')
     validator_type = args.type.to_sym
-    Inferno::Terminology.register_umls_db args.database
     Inferno::Terminology.load_valuesets_from_directory(Inferno::Terminology::PACKAGE_DIR, true)
     Inferno::Terminology.create_validators(type: validator_type,
                                            selected_module: args.module,

--- a/lib/tasks/tasks.rake
+++ b/lib/tasks/tasks.rake
@@ -809,7 +809,7 @@ namespace :terminology do |_argv|
     validator_type = args.type.to_sym
     Inferno::Terminology.register_umls_db args.database
     Inferno::Terminology.load_valuesets_from_directory(Inferno::Terminology::PACKAGE_DIR, true)
-    Inferno::Terminology.create_validators(validator_type)
+    Inferno::Terminology.create_validators(type: validator_type)
   end
 
   desc 'Create only non-UMLS validators'
@@ -821,7 +821,10 @@ namespace :terminology do |_argv|
     validator_type = args.type.to_sym
     Inferno::Terminology.register_umls_db args.database
     Inferno::Terminology.load_valuesets_from_directory(Inferno::Terminology::PACKAGE_DIR, true)
-    Inferno::Terminology.create_validators(validator_type, args.module, args.minimum_binding_strength, false)
+    Inferno::Terminology.create_validators(type: validator_type,
+                                           selected_module: args.module,
+                                           minimum_binding_strength: args.minimum_binding_strength,
+                                           include_umls: false)
   end
 
   desc 'Create ValueSet Validators for a given module'
@@ -829,7 +832,9 @@ namespace :terminology do |_argv|
     args.with_defaults(module: 'all', minimum_binding_strength: 'example')
     Inferno::Terminology.register_umls_db File.join(TEMP_DIR, 'umls.db')
     Inferno::Terminology.load_valuesets_from_directory(Inferno::Terminology::PACKAGE_DIR, true)
-    Inferno::Terminology.create_validators(:bloom, args.module, args.minimum_binding_strength)
+    Inferno::Terminology.create_validators(type: :bloom,
+                                           selected_module: args.module,
+                                           minimum_binding_strength: args.minimum_binding_strength)
   end
 
   desc 'Number of codes in ValueSet'

--- a/lib/tasks/tasks.rake
+++ b/lib/tasks/tasks.rake
@@ -812,6 +812,18 @@ namespace :terminology do |_argv|
     Inferno::Terminology.create_validators(validator_type)
   end
 
+  desc 'Create only non-UMLS validators'
+  task :create_non_umls_vs_validators, [:module, :minimum_binding_strength] do |_t, args|
+    args.with_defaults(database: File.join(TEMP_DIR, 'umls.db'),
+                       type: 'bloom',
+                       module: :all,
+                       minimum_binding_strength: 'example')
+    validator_type = args.type.to_sym
+    Inferno::Terminology.register_umls_db args.database
+    Inferno::Terminology.load_valuesets_from_directory(Inferno::Terminology::PACKAGE_DIR, true)
+    Inferno::Terminology.create_validators(validator_type, args.module, args.minimum_binding_strength, false)
+  end
+
   desc 'Create ValueSet Validators for a given module'
   task :create_module_vs_validators, [:module, :minimum_binding_strength] do |_t, args|
     args.with_defaults(module: 'all', minimum_binding_strength: 'example')


### PR DESCRIPTION
This Pull Request adds the `create_non_umls_vs_validators` rake task. This task allows the Inferno user to build a subset of valueset validators that don't require the download/parsing of the UMLS Metathesaurus (a task that can take many hours, depending on computing resources). This will give Inferno users a way to get some validators up and running, so they can see what the terminology validation does, without having to go through the long process of downloading those files.

Additionally, this PR refactors much of the `create_validators` method, because it was starting to get large and repeated itself in many places. Also, the parameters in the `create_validators` method signature have been changed to named params with defaults, because we were starting to pass in quite a lot of them.

To test:
* checkout the branch
* run `rm -rf resources/terminology/validators/bloom && bundle exec rake terminology:create_non_umls_vs_validators["uscore_v3.1.0","preferred"]`, to create all the non-UMLS validators with a binding >= `preferred` for the US Core 3.1.0 module
* Check the `resources/terminology/validators/bloom/manifest.yml` file that gets generated to ensure it doesn't contain any references to UMLS code systems (the values of the `SAB` hash in `lib/app/utils/valueset.rb`), and that it otherwise looks normal.

**Submitter:**
- [x] This pull request describes why these changes were made
- [x] Code diff has been reviewed for extraneous/missing code
- [x] Tests are included and test edge cases
- [x] Tests/code quality metrics have been run locally and pass


**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
