### PR TITLE
FI-685 Test resource count only if validate_all resource is true

### DIFF
--- a/lib/modules/onc_program/bulk_data_group_validation_sequence.rb
+++ b/lib/modules/onc_program/bulk_data_group_validation_sequence.rb
@@ -93,7 +93,7 @@ module Inferno
           assert errors.empty?, "Failed Profile validation for resource #{line_count}: #{errors}"
         end
 
-        if file.key?('count')
+        if file.key?('count') && validate_all
           warning do
             assert file['count'].to_s == line_count.to_s, "Count in status output (#{file['count']}) did not match actual number of resources returned (#{line_count})"
           end


### PR DESCRIPTION
The changes fix the warning display on validation result, like "Count in status output (27) did not match actual number of resources returned (0)". The fix disables the count check if tester does not choose to validate all resources in bulk export. 

**Submitter:**
- [x] This pull request describes why these changes were made
- [x] Internal ticket for this PR:
- [x] Internal ticket links to this PR
- [x] Internal ticket is properly labeled (Community/Program)
- [x] Internal ticket has a justification for its Community/Program label
- [x] Code diff has been reviewed for extraneous/missing code
- [x] Tests are included and test edge cases
- [x] Tests/code quality metrics have been run locally and pass


**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
