### PR TITLE
Fi 650 bulk data must support

### DIFF
--- a/generator/uscore/templates/sequence.rb.erb
+++ b/generator/uscore/templates/sequence.rb.erb
@@ -25,7 +25,10 @@ module Inferno
         @instance.patient_ids.split(',').map(&:strip)
       end
 
-      @resources_found = false<% tests.each do |test|%>
+      @resources_found = false
+      <%=must_support_constants%>
+      <% tests.each do |test|%>
+
 
 <% if test[:key].present? %>
       test :<%= test[:key] %> do

--- a/generator/uscore/uscore_generator.rb
+++ b/generator/uscore/uscore_generator.rb
@@ -538,6 +538,7 @@ module Inferno
           # class is mapped to local_class in fhir_models. Update this after it
           # has been added to the description so that the description contains
           # the original path
+          element[:path] = 'local_class' if element[:path] == 'class'
           element[:path] = element[:path].gsub('.class', '.local_class')
         end
 

--- a/lib/modules/onc_program/bulk_data_group_validation_sequence.rb
+++ b/lib/modules/onc_program/bulk_data_group_validation_sequence.rb
@@ -118,7 +118,7 @@ module Inferno
           assert errors.empty?, "Failed Profile validation for resource #{line_count}: #{errors}"
         end
 
-        assert_must_supports_found(must_supports)
+        assert_must_supports_found(must_supports) if lines_to_validate.positive?
 
         if file.key?('count') && validate_all
           warning do

--- a/lib/modules/onc_program/bulk_data_group_validation_sequence.rb
+++ b/lib/modules/onc_program/bulk_data_group_validation_sequence.rb
@@ -397,8 +397,6 @@ module Inferno
           )
         end
 
-        must_supports = Inferno::Sequence::USCore310DeviceSequence::MUST_SUPPORTS
-        test_output_for_must_support('Device', must_supports)
         test_output_against_profile('Device')
       end
 

--- a/lib/modules/onc_program/bulk_data_group_validation_sequence.rb
+++ b/lib/modules/onc_program/bulk_data_group_validation_sequence.rb
@@ -118,7 +118,7 @@ module Inferno
           assert errors.empty?, "Failed Profile validation for resource #{line_count}: #{errors}"
         end
 
-        assert_must_supports_found(must_supports) if lines_to_validate.positive?
+        assert_must_supports_found(must_supports) if validate_all || lines_to_validate.positive?
 
         if file.key?('count') && validate_all
           warning do

--- a/lib/modules/onc_program/test/bulk_group_validation_sequence_test.rb
+++ b/lib/modules/onc_program/test/bulk_group_validation_sequence_test.rb
@@ -469,7 +469,7 @@ describe Inferno::Sequence::BulkDataGroupExportValidationSequence do
       file = @output.find { |line| line['type'] == 'Patient' }
       file['count'] = @patient_export.lines.count + 1
 
-      @sequence.check_file_request(file, 'Patient', true, 0)
+      @sequence.check_file_request(file, 'Patient', true, 0, [])
 
       assert @sequence.instance_variable_get(:@test_warnings).include?("Count in status output (#{file['count']}) did not match actual number of resources returned (#{@patient_export.lines.count})")
     end
@@ -478,7 +478,7 @@ describe Inferno::Sequence::BulkDataGroupExportValidationSequence do
       file = @output.find { |line| line['type'] == 'Patient' }
       file['count'] = @patient_export.lines.count + 1
 
-      @sequence.check_file_request(file, 'Patient', false, 1)
+      @sequence.check_file_request(file, 'Patient', false, 1, [])
 
       assert !@sequence.instance_variable_get(:@test_warnings).include?("Count in status output (#{file['count']}) did not match actual number of resources returned (#{@patient_export.lines.count})")
     end
@@ -486,7 +486,7 @@ describe Inferno::Sequence::BulkDataGroupExportValidationSequence do
     it 'does not warn count does match number of resources' do
       file = @output.find { |line| line['type'] == 'Patient' }
 
-      @sequence.check_file_request(file, 'Patient', true, 0)
+      @sequence.check_file_request(file, 'Patient', true, 0, [])
 
       assert !@sequence.instance_variable_get(:@test_warnings).include?("Count in status output (#{file['count']}) did not match actual number of resources returned (#{@patient_export.lines.count})")
     end

--- a/lib/modules/onc_program/test/bulk_group_validation_sequence_test.rb
+++ b/lib/modules/onc_program/test/bulk_group_validation_sequence_test.rb
@@ -262,7 +262,7 @@ describe Inferno::Sequence::BulkDataGroupExportValidationSequence do
 
     it 'skip when output is nil' do
       error = assert_raises(Inferno::SkipException) do
-        @sequence.test_output_against_profile('Patient', nil, '1')
+        @sequence.test_output_against_profile('Patient', [], nil, '1')
       end
 
       assert error.message == 'Bulk Data Server response does not have output data'
@@ -270,7 +270,7 @@ describe Inferno::Sequence::BulkDataGroupExportValidationSequence do
 
     it 'skip when resource is not exported' do
       error = assert_raises(Inferno::SkipException) do
-        @sequence.test_output_against_profile('Observation', @output, '1')
+        @sequence.test_output_against_profile('Observation', [], @output, '1')
       end
 
       assert error.message == 'Bulk Data Server export does not have Observation data'
@@ -285,7 +285,7 @@ describe Inferno::Sequence::BulkDataGroupExportValidationSequence do
           body: @patient_export
         )
 
-      pass_exception = assert_raises(Inferno::PassException) { @sequence.test_output_against_profile('Patient', @output, '1') }
+      pass_exception = assert_raises(Inferno::PassException) { @sequence.test_output_against_profile('Patient', [], @output, '1') }
       assert_match(/^Successfully validated [\d]+ resource/, pass_exception.message)
     end
 
@@ -299,10 +299,67 @@ describe Inferno::Sequence::BulkDataGroupExportValidationSequence do
         )
 
       error = assert_raises(Inferno::AssertionException) do
-        @sequence.test_output_against_profile('Patient', @output, '1')
+        @sequence.test_output_against_profile('Patient', [], @output, '1')
       end
 
       assert_match(/Content type/, error.message)
+    end
+
+    it 'passes when all must supports are found' do
+      stub_request(:get, @patient_file_location)
+        .with(headers: @file_request_headers)
+        .to_return(
+          status: 200,
+          headers: { content_type: 'application/fhir+ndjson' },
+          body: @patient_export
+        )
+
+      must_supports = [
+        {
+          profile: nil,
+          must_support_info: {
+            extensions: [],
+            slices: [],
+            elements: [
+              {
+                path: 'name'
+              }
+            ]
+          }
+        }
+      ]
+      pass_exception = assert_raises(Inferno::PassException) { @sequence.test_output_against_profile('Patient', must_supports, @output, '1') }
+      assert_match(/^Successfully validated [\d]+ resource/, pass_exception.message)
+    end
+
+    it 'fails when not all must supports are found' do
+      stub_request(:get, @patient_file_location)
+        .with(headers: @file_request_headers)
+        .to_return(
+          status: 200,
+          headers: { content_type: 'application/fhir+ndjson' },
+          body: @patient_export
+        )
+
+      must_supports = [
+        {
+          profile: nil,
+          must_support_info: {
+            extensions: [],
+            slices: [],
+            elements: [
+              {
+                path: 'name'
+              },
+              {
+                path: 'address.period'
+              }
+            ]
+          }
+        }
+      ]
+      assertion_exception = assert_raises(Inferno::AssertionException) { @sequence.test_output_against_profile('Patient', must_supports, @output, '1') }
+      assert_match('Could not verify presence of the following must support elements: address.period', assertion_exception.message)
     end
   end
 
@@ -323,7 +380,7 @@ describe Inferno::Sequence::BulkDataGroupExportValidationSequence do
 
     it 'succeeds when NDJSON is valid and saves patient ids as seen' do
       file = @output.find { |line| line['type'] == 'Patient' }
-      @sequence.check_file_request(file, 'Patient', true, 1)
+      @sequence.check_file_request(file, 'Patient', true, 1, [])
       diff = @sequence.patient_ids_seen ^ Set.new(['ac1bdb14-fea1-4912-8d7c-e3ecec74b0d7',
                                                    '8a7c11ff-25f0-433e-882a-4f43b8fb7dc4',
                                                    '9f83799e-76db-41fa-8c1f-e1a532c30a52',
@@ -333,18 +390,18 @@ describe Inferno::Sequence::BulkDataGroupExportValidationSequence do
 
     it 'succeeds when lines_to_validate is greater than lines of output file' do
       file = @output.find { |line| line['type'] == 'Patient' }
-      @sequence.check_file_request(file, 'Patient', false, 100)
+      @sequence.check_file_request(file, 'Patient', false, 100, [])
     end
 
     it 'skip validation when lines_to_validate is less than 1' do
       file = @output.find { |line| line['type'] == 'Patient' }
-      @sequence.check_file_request(file, 'Condition', false, 0)
+      @sequence.check_file_request(file, 'Condition', false, 0, [])
     end
 
     it 'fails when output file type is different from resource type' do
       file = @output.find { |line| line['type'] == 'Patient' }
       error = assert_raises(Inferno::AssertionException) do
-        @sequence.check_file_request(file, 'Condition', true, 1)
+        @sequence.check_file_request(file, 'Condition', true, 1, [])
       end
 
       assert_match(/^Resource type/, error.message)
@@ -363,7 +420,7 @@ describe Inferno::Sequence::BulkDataGroupExportValidationSequence do
       error = assert_raises(Inferno::AssertionException) do
         file = @output.find { |line| line['type'] == 'Patient' }
         file['url'] = 'https://www.example.com/wrong_patient_export.json'
-        @sequence.check_file_request(file, 'Patient', true, 1)
+        @sequence.check_file_request(file, 'Patient', true, 1, [])
       end
 
       assert_match(/invalid code '001'/, error.message)
@@ -381,12 +438,12 @@ describe Inferno::Sequence::BulkDataGroupExportValidationSequence do
 
       file = @output.find { |line| line['type'] == 'Patient' }
       file['url'] = 'https://www.example.com/wrong_patient_export.json'
-      @sequence.check_file_request(file, 'Patient', false, 1)
+      @sequence.check_file_request(file, 'Patient', false, 1, [])
     end
 
     it 'succeeds when NDJSON is valid and has at least two patients' do
       file = @output.find { |line| line['type'] == 'Patient' }
-      @sequence.check_file_request(file, 'Patient', false, 0)
+      @sequence.check_file_request(file, 'Patient', false, 0, [])
       assert @sequence.has_min_patient_count
     end
 
@@ -404,7 +461,7 @@ describe Inferno::Sequence::BulkDataGroupExportValidationSequence do
 
       file = @output.find { |line| line['type'] == 'Patient' }
       file['url'] = 'https://www.example.com/single_patient_export.json'
-      @sequence.check_file_request(file, 'Patient', false, 0)
+      @sequence.check_file_request(file, 'Patient', false, 0, [])
       assert !@sequence.has_min_patient_count
     end
 

--- a/lib/modules/uscore_v3.1.0/bodyheight_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/bodyheight_sequence.rb
@@ -88,6 +88,84 @@ module Inferno
 
       @resources_found = false
 
+      MUST_SUPPORTS = {
+        extensions: [],
+        slices: [
+          {
+            name: 'Observation.category:VSCat',
+            path: 'category',
+            discriminator: {
+              type: 'value',
+              values: [
+                {
+                  path: 'coding.code',
+                  value: 'vital-signs'
+                },
+                {
+                  path: 'coding.system',
+                  value: 'http://terminology.hl7.org/CodeSystem/observation-category'
+                }
+              ]
+            }
+          },
+          {
+            name: 'Observation.value[x]:valueQuantity',
+            path: 'value',
+            discriminator: {
+              type: 'type',
+              code: 'Quantity'
+            }
+          }
+        ],
+        elements: [
+          {
+            path: 'status'
+          },
+          {
+            path: 'category'
+          },
+          {
+            path: 'category.coding'
+          },
+          {
+            path: 'category.coding.system',
+            fixed_value: 'http://terminology.hl7.org/CodeSystem/observation-category'
+          },
+          {
+            path: 'category.coding.code',
+            fixed_value: 'vital-signs'
+          },
+          {
+            path: 'code'
+          },
+          {
+            path: 'subject'
+          },
+          {
+            path: 'effective'
+          },
+          {
+            path: 'value'
+          },
+          {
+            path: 'value.value'
+          },
+          {
+            path: 'value.unit'
+          },
+          {
+            path: 'value.system',
+            fixed_value: 'http://unitsofmeasure.org'
+          },
+          {
+            path: 'value.code'
+          },
+          {
+            path: 'dataAbsentReason'
+          }
+        ]
+      }.freeze
+
       test :search_by_patient_code do
         metadata do
           id '01'
@@ -522,33 +600,33 @@ module Inferno
             US Core Responders SHALL be capable of populating all data elements as part of the query results as specified by the US Core Server Capability Statement.
             This will look through all Observation resources returned from prior searches to see if any of them provide the following must support elements:
 
-            Observation.status
+            status
 
-            Observation.category
+            category
 
-            Observation.category.coding
+            category.coding
 
-            Observation.category.coding.system
+            category.coding.system
 
-            Observation.category.coding.code
+            category.coding.code
 
-            Observation.code
+            code
 
-            Observation.subject
+            subject
 
-            Observation.effective[x]
+            effective[x]
 
-            Observation.value[x]
+            value[x]
 
-            Observation.value[x].value
+            value[x].value
 
-            Observation.value[x].unit
+            value[x].unit
 
-            Observation.value[x].system
+            value[x].system
 
-            Observation.value[x].code
+            value[x].code
 
-            Observation.dataAbsentReason
+            dataAbsentReason
 
             Observation.category:VSCat
 
@@ -560,62 +638,16 @@ module Inferno
 
         skip_if_not_found(resource_type: 'Observation', delayed: false)
 
-        must_support_slices = [
-          {
-            name: 'Observation.category:VSCat',
-            path: 'Observation.category',
-            discriminator: {
-              type: 'value',
-              values: [
-                {
-                  path: 'coding.code',
-                  value: 'vital-signs'
-                },
-                {
-                  path: 'coding.system',
-                  value: 'http://terminology.hl7.org/CodeSystem/observation-category'
-                }
-              ]
-            }
-          },
-          {
-            name: 'Observation.value[x]:valueQuantity',
-            path: 'Observation.value',
-            discriminator: {
-              type: 'type',
-              code: 'Quantity'
-            }
-          }
-        ]
-        missing_slices = must_support_slices.reject do |slice|
-          truncated_path = slice[:path].gsub('Observation.', '')
+        missing_slices = MUST_SUPPORTS[:slices].reject do |slice|
           @observation_ary&.values&.flatten&.any? do |resource|
-            slice_found = find_slice(resource, truncated_path, slice[:discriminator])
+            slice_found = find_slice(resource, slice[:path], slice[:discriminator])
             slice_found.present?
           end
         end
 
-        must_support_elements = [
-          { path: 'Observation.status' },
-          { path: 'Observation.category' },
-          { path: 'Observation.category.coding' },
-          { path: 'Observation.category.coding.system', fixed_value: 'http://terminology.hl7.org/CodeSystem/observation-category' },
-          { path: 'Observation.category.coding.code', fixed_value: 'vital-signs' },
-          { path: 'Observation.code' },
-          { path: 'Observation.subject' },
-          { path: 'Observation.effective' },
-          { path: 'Observation.value' },
-          { path: 'Observation.value.value' },
-          { path: 'Observation.value.unit' },
-          { path: 'Observation.value.system', fixed_value: 'http://unitsofmeasure.org' },
-          { path: 'Observation.value.code' },
-          { path: 'Observation.dataAbsentReason' }
-        ]
-
-        missing_must_support_elements = must_support_elements.reject do |element|
-          truncated_path = element[:path].gsub('Observation.', '')
+        missing_must_support_elements = MUST_SUPPORTS[:elements].reject do |element|
           @observation_ary&.values&.flatten&.any? do |resource|
-            value_found = resolve_element_from_path(resource, truncated_path) { |value| element[:fixed_value].blank? || value == element[:fixed_value] }
+            value_found = resolve_element_from_path(resource, element[:path]) { |value| element[:fixed_value].blank? || value == element[:fixed_value] }
             value_found.present?
           end
         end

--- a/lib/modules/uscore_v3.1.0/bodytemp_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/bodytemp_sequence.rb
@@ -88,6 +88,84 @@ module Inferno
 
       @resources_found = false
 
+      MUST_SUPPORTS = {
+        extensions: [],
+        slices: [
+          {
+            name: 'Observation.category:VSCat',
+            path: 'category',
+            discriminator: {
+              type: 'value',
+              values: [
+                {
+                  path: 'coding.code',
+                  value: 'vital-signs'
+                },
+                {
+                  path: 'coding.system',
+                  value: 'http://terminology.hl7.org/CodeSystem/observation-category'
+                }
+              ]
+            }
+          },
+          {
+            name: 'Observation.value[x]:valueQuantity',
+            path: 'value',
+            discriminator: {
+              type: 'type',
+              code: 'Quantity'
+            }
+          }
+        ],
+        elements: [
+          {
+            path: 'status'
+          },
+          {
+            path: 'category'
+          },
+          {
+            path: 'category.coding'
+          },
+          {
+            path: 'category.coding.system',
+            fixed_value: 'http://terminology.hl7.org/CodeSystem/observation-category'
+          },
+          {
+            path: 'category.coding.code',
+            fixed_value: 'vital-signs'
+          },
+          {
+            path: 'code'
+          },
+          {
+            path: 'subject'
+          },
+          {
+            path: 'effective'
+          },
+          {
+            path: 'value'
+          },
+          {
+            path: 'value.value'
+          },
+          {
+            path: 'value.unit'
+          },
+          {
+            path: 'value.system',
+            fixed_value: 'http://unitsofmeasure.org'
+          },
+          {
+            path: 'value.code'
+          },
+          {
+            path: 'dataAbsentReason'
+          }
+        ]
+      }.freeze
+
       test :search_by_patient_code do
         metadata do
           id '01'
@@ -522,33 +600,33 @@ module Inferno
             US Core Responders SHALL be capable of populating all data elements as part of the query results as specified by the US Core Server Capability Statement.
             This will look through all Observation resources returned from prior searches to see if any of them provide the following must support elements:
 
-            Observation.status
+            status
 
-            Observation.category
+            category
 
-            Observation.category.coding
+            category.coding
 
-            Observation.category.coding.system
+            category.coding.system
 
-            Observation.category.coding.code
+            category.coding.code
 
-            Observation.code
+            code
 
-            Observation.subject
+            subject
 
-            Observation.effective[x]
+            effective[x]
 
-            Observation.value[x]
+            value[x]
 
-            Observation.value[x].value
+            value[x].value
 
-            Observation.value[x].unit
+            value[x].unit
 
-            Observation.value[x].system
+            value[x].system
 
-            Observation.value[x].code
+            value[x].code
 
-            Observation.dataAbsentReason
+            dataAbsentReason
 
             Observation.category:VSCat
 
@@ -560,62 +638,16 @@ module Inferno
 
         skip_if_not_found(resource_type: 'Observation', delayed: false)
 
-        must_support_slices = [
-          {
-            name: 'Observation.category:VSCat',
-            path: 'Observation.category',
-            discriminator: {
-              type: 'value',
-              values: [
-                {
-                  path: 'coding.code',
-                  value: 'vital-signs'
-                },
-                {
-                  path: 'coding.system',
-                  value: 'http://terminology.hl7.org/CodeSystem/observation-category'
-                }
-              ]
-            }
-          },
-          {
-            name: 'Observation.value[x]:valueQuantity',
-            path: 'Observation.value',
-            discriminator: {
-              type: 'type',
-              code: 'Quantity'
-            }
-          }
-        ]
-        missing_slices = must_support_slices.reject do |slice|
-          truncated_path = slice[:path].gsub('Observation.', '')
+        missing_slices = MUST_SUPPORTS[:slices].reject do |slice|
           @observation_ary&.values&.flatten&.any? do |resource|
-            slice_found = find_slice(resource, truncated_path, slice[:discriminator])
+            slice_found = find_slice(resource, slice[:path], slice[:discriminator])
             slice_found.present?
           end
         end
 
-        must_support_elements = [
-          { path: 'Observation.status' },
-          { path: 'Observation.category' },
-          { path: 'Observation.category.coding' },
-          { path: 'Observation.category.coding.system', fixed_value: 'http://terminology.hl7.org/CodeSystem/observation-category' },
-          { path: 'Observation.category.coding.code', fixed_value: 'vital-signs' },
-          { path: 'Observation.code' },
-          { path: 'Observation.subject' },
-          { path: 'Observation.effective' },
-          { path: 'Observation.value' },
-          { path: 'Observation.value.value' },
-          { path: 'Observation.value.unit' },
-          { path: 'Observation.value.system', fixed_value: 'http://unitsofmeasure.org' },
-          { path: 'Observation.value.code' },
-          { path: 'Observation.dataAbsentReason' }
-        ]
-
-        missing_must_support_elements = must_support_elements.reject do |element|
-          truncated_path = element[:path].gsub('Observation.', '')
+        missing_must_support_elements = MUST_SUPPORTS[:elements].reject do |element|
           @observation_ary&.values&.flatten&.any? do |resource|
-            value_found = resolve_element_from_path(resource, truncated_path) { |value| element[:fixed_value].blank? || value == element[:fixed_value] }
+            value_found = resolve_element_from_path(resource, element[:path]) { |value| element[:fixed_value].blank? || value == element[:fixed_value] }
             value_found.present?
           end
         end

--- a/lib/modules/uscore_v3.1.0/bodyweight_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/bodyweight_sequence.rb
@@ -88,6 +88,84 @@ module Inferno
 
       @resources_found = false
 
+      MUST_SUPPORTS = {
+        extensions: [],
+        slices: [
+          {
+            name: 'Observation.category:VSCat',
+            path: 'category',
+            discriminator: {
+              type: 'value',
+              values: [
+                {
+                  path: 'coding.code',
+                  value: 'vital-signs'
+                },
+                {
+                  path: 'coding.system',
+                  value: 'http://terminology.hl7.org/CodeSystem/observation-category'
+                }
+              ]
+            }
+          },
+          {
+            name: 'Observation.value[x]:valueQuantity',
+            path: 'value',
+            discriminator: {
+              type: 'type',
+              code: 'Quantity'
+            }
+          }
+        ],
+        elements: [
+          {
+            path: 'status'
+          },
+          {
+            path: 'category'
+          },
+          {
+            path: 'category.coding'
+          },
+          {
+            path: 'category.coding.system',
+            fixed_value: 'http://terminology.hl7.org/CodeSystem/observation-category'
+          },
+          {
+            path: 'category.coding.code',
+            fixed_value: 'vital-signs'
+          },
+          {
+            path: 'code'
+          },
+          {
+            path: 'subject'
+          },
+          {
+            path: 'effective'
+          },
+          {
+            path: 'value'
+          },
+          {
+            path: 'value.value'
+          },
+          {
+            path: 'value.unit'
+          },
+          {
+            path: 'value.system',
+            fixed_value: 'http://unitsofmeasure.org'
+          },
+          {
+            path: 'value.code'
+          },
+          {
+            path: 'dataAbsentReason'
+          }
+        ]
+      }.freeze
+
       test :search_by_patient_code do
         metadata do
           id '01'
@@ -522,33 +600,33 @@ module Inferno
             US Core Responders SHALL be capable of populating all data elements as part of the query results as specified by the US Core Server Capability Statement.
             This will look through all Observation resources returned from prior searches to see if any of them provide the following must support elements:
 
-            Observation.status
+            status
 
-            Observation.category
+            category
 
-            Observation.category.coding
+            category.coding
 
-            Observation.category.coding.system
+            category.coding.system
 
-            Observation.category.coding.code
+            category.coding.code
 
-            Observation.code
+            code
 
-            Observation.subject
+            subject
 
-            Observation.effective[x]
+            effective[x]
 
-            Observation.value[x]
+            value[x]
 
-            Observation.value[x].value
+            value[x].value
 
-            Observation.value[x].unit
+            value[x].unit
 
-            Observation.value[x].system
+            value[x].system
 
-            Observation.value[x].code
+            value[x].code
 
-            Observation.dataAbsentReason
+            dataAbsentReason
 
             Observation.category:VSCat
 
@@ -560,62 +638,16 @@ module Inferno
 
         skip_if_not_found(resource_type: 'Observation', delayed: false)
 
-        must_support_slices = [
-          {
-            name: 'Observation.category:VSCat',
-            path: 'Observation.category',
-            discriminator: {
-              type: 'value',
-              values: [
-                {
-                  path: 'coding.code',
-                  value: 'vital-signs'
-                },
-                {
-                  path: 'coding.system',
-                  value: 'http://terminology.hl7.org/CodeSystem/observation-category'
-                }
-              ]
-            }
-          },
-          {
-            name: 'Observation.value[x]:valueQuantity',
-            path: 'Observation.value',
-            discriminator: {
-              type: 'type',
-              code: 'Quantity'
-            }
-          }
-        ]
-        missing_slices = must_support_slices.reject do |slice|
-          truncated_path = slice[:path].gsub('Observation.', '')
+        missing_slices = MUST_SUPPORTS[:slices].reject do |slice|
           @observation_ary&.values&.flatten&.any? do |resource|
-            slice_found = find_slice(resource, truncated_path, slice[:discriminator])
+            slice_found = find_slice(resource, slice[:path], slice[:discriminator])
             slice_found.present?
           end
         end
 
-        must_support_elements = [
-          { path: 'Observation.status' },
-          { path: 'Observation.category' },
-          { path: 'Observation.category.coding' },
-          { path: 'Observation.category.coding.system', fixed_value: 'http://terminology.hl7.org/CodeSystem/observation-category' },
-          { path: 'Observation.category.coding.code', fixed_value: 'vital-signs' },
-          { path: 'Observation.code' },
-          { path: 'Observation.subject' },
-          { path: 'Observation.effective' },
-          { path: 'Observation.value' },
-          { path: 'Observation.value.value' },
-          { path: 'Observation.value.unit' },
-          { path: 'Observation.value.system', fixed_value: 'http://unitsofmeasure.org' },
-          { path: 'Observation.value.code' },
-          { path: 'Observation.dataAbsentReason' }
-        ]
-
-        missing_must_support_elements = must_support_elements.reject do |element|
-          truncated_path = element[:path].gsub('Observation.', '')
+        missing_must_support_elements = MUST_SUPPORTS[:elements].reject do |element|
           @observation_ary&.values&.flatten&.any? do |resource|
-            value_found = resolve_element_from_path(resource, truncated_path) { |value| element[:fixed_value].blank? || value == element[:fixed_value] }
+            value_found = resolve_element_from_path(resource, element[:path]) { |value| element[:fixed_value].blank? || value == element[:fixed_value] }
             value_found.present?
           end
         end

--- a/lib/modules/uscore_v3.1.0/headcircum_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/headcircum_sequence.rb
@@ -88,6 +88,84 @@ module Inferno
 
       @resources_found = false
 
+      MUST_SUPPORTS = {
+        extensions: [],
+        slices: [
+          {
+            name: 'Observation.category:VSCat',
+            path: 'category',
+            discriminator: {
+              type: 'value',
+              values: [
+                {
+                  path: 'coding.code',
+                  value: 'vital-signs'
+                },
+                {
+                  path: 'coding.system',
+                  value: 'http://terminology.hl7.org/CodeSystem/observation-category'
+                }
+              ]
+            }
+          },
+          {
+            name: 'Observation.value[x]:valueQuantity',
+            path: 'value',
+            discriminator: {
+              type: 'type',
+              code: 'Quantity'
+            }
+          }
+        ],
+        elements: [
+          {
+            path: 'status'
+          },
+          {
+            path: 'category'
+          },
+          {
+            path: 'category.coding'
+          },
+          {
+            path: 'category.coding.system',
+            fixed_value: 'http://terminology.hl7.org/CodeSystem/observation-category'
+          },
+          {
+            path: 'category.coding.code',
+            fixed_value: 'vital-signs'
+          },
+          {
+            path: 'code'
+          },
+          {
+            path: 'subject'
+          },
+          {
+            path: 'effective'
+          },
+          {
+            path: 'value'
+          },
+          {
+            path: 'value.value'
+          },
+          {
+            path: 'value.unit'
+          },
+          {
+            path: 'value.system',
+            fixed_value: 'http://unitsofmeasure.org'
+          },
+          {
+            path: 'value.code'
+          },
+          {
+            path: 'dataAbsentReason'
+          }
+        ]
+      }.freeze
+
       test :search_by_patient_code do
         metadata do
           id '01'
@@ -522,33 +600,33 @@ module Inferno
             US Core Responders SHALL be capable of populating all data elements as part of the query results as specified by the US Core Server Capability Statement.
             This will look through all Observation resources returned from prior searches to see if any of them provide the following must support elements:
 
-            Observation.status
+            status
 
-            Observation.category
+            category
 
-            Observation.category.coding
+            category.coding
 
-            Observation.category.coding.system
+            category.coding.system
 
-            Observation.category.coding.code
+            category.coding.code
 
-            Observation.code
+            code
 
-            Observation.subject
+            subject
 
-            Observation.effective[x]
+            effective[x]
 
-            Observation.value[x]
+            value[x]
 
-            Observation.value[x].value
+            value[x].value
 
-            Observation.value[x].unit
+            value[x].unit
 
-            Observation.value[x].system
+            value[x].system
 
-            Observation.value[x].code
+            value[x].code
 
-            Observation.dataAbsentReason
+            dataAbsentReason
 
             Observation.category:VSCat
 
@@ -560,62 +638,16 @@ module Inferno
 
         skip_if_not_found(resource_type: 'Observation', delayed: false)
 
-        must_support_slices = [
-          {
-            name: 'Observation.category:VSCat',
-            path: 'Observation.category',
-            discriminator: {
-              type: 'value',
-              values: [
-                {
-                  path: 'coding.code',
-                  value: 'vital-signs'
-                },
-                {
-                  path: 'coding.system',
-                  value: 'http://terminology.hl7.org/CodeSystem/observation-category'
-                }
-              ]
-            }
-          },
-          {
-            name: 'Observation.value[x]:valueQuantity',
-            path: 'Observation.value',
-            discriminator: {
-              type: 'type',
-              code: 'Quantity'
-            }
-          }
-        ]
-        missing_slices = must_support_slices.reject do |slice|
-          truncated_path = slice[:path].gsub('Observation.', '')
+        missing_slices = MUST_SUPPORTS[:slices].reject do |slice|
           @observation_ary&.values&.flatten&.any? do |resource|
-            slice_found = find_slice(resource, truncated_path, slice[:discriminator])
+            slice_found = find_slice(resource, slice[:path], slice[:discriminator])
             slice_found.present?
           end
         end
 
-        must_support_elements = [
-          { path: 'Observation.status' },
-          { path: 'Observation.category' },
-          { path: 'Observation.category.coding' },
-          { path: 'Observation.category.coding.system', fixed_value: 'http://terminology.hl7.org/CodeSystem/observation-category' },
-          { path: 'Observation.category.coding.code', fixed_value: 'vital-signs' },
-          { path: 'Observation.code' },
-          { path: 'Observation.subject' },
-          { path: 'Observation.effective' },
-          { path: 'Observation.value' },
-          { path: 'Observation.value.value' },
-          { path: 'Observation.value.unit' },
-          { path: 'Observation.value.system', fixed_value: 'http://unitsofmeasure.org' },
-          { path: 'Observation.value.code' },
-          { path: 'Observation.dataAbsentReason' }
-        ]
-
-        missing_must_support_elements = must_support_elements.reject do |element|
-          truncated_path = element[:path].gsub('Observation.', '')
+        missing_must_support_elements = MUST_SUPPORTS[:elements].reject do |element|
           @observation_ary&.values&.flatten&.any? do |resource|
-            value_found = resolve_element_from_path(resource, truncated_path) { |value| element[:fixed_value].blank? || value == element[:fixed_value] }
+            value_found = resolve_element_from_path(resource, element[:path]) { |value| element[:fixed_value].blank? || value == element[:fixed_value] }
             value_found.present?
           end
         end

--- a/lib/modules/uscore_v3.1.0/heartrate_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/heartrate_sequence.rb
@@ -88,6 +88,85 @@ module Inferno
 
       @resources_found = false
 
+      MUST_SUPPORTS = {
+        extensions: [],
+        slices: [
+          {
+            name: 'Observation.category:VSCat',
+            path: 'category',
+            discriminator: {
+              type: 'value',
+              values: [
+                {
+                  path: 'coding.code',
+                  value: 'vital-signs'
+                },
+                {
+                  path: 'coding.system',
+                  value: 'http://terminology.hl7.org/CodeSystem/observation-category'
+                }
+              ]
+            }
+          },
+          {
+            name: 'Observation.value[x]:valueQuantity',
+            path: 'value',
+            discriminator: {
+              type: 'type',
+              code: 'Quantity'
+            }
+          }
+        ],
+        elements: [
+          {
+            path: 'status'
+          },
+          {
+            path: 'category'
+          },
+          {
+            path: 'category.coding'
+          },
+          {
+            path: 'category.coding.system',
+            fixed_value: 'http://terminology.hl7.org/CodeSystem/observation-category'
+          },
+          {
+            path: 'category.coding.code',
+            fixed_value: 'vital-signs'
+          },
+          {
+            path: 'code'
+          },
+          {
+            path: 'subject'
+          },
+          {
+            path: 'effective'
+          },
+          {
+            path: 'value'
+          },
+          {
+            path: 'value.value'
+          },
+          {
+            path: 'value.unit'
+          },
+          {
+            path: 'value.system',
+            fixed_value: 'http://unitsofmeasure.org'
+          },
+          {
+            path: 'value.code',
+            fixed_value: '/min'
+          },
+          {
+            path: 'dataAbsentReason'
+          }
+        ]
+      }.freeze
+
       test :search_by_patient_code do
         metadata do
           id '01'
@@ -516,33 +595,33 @@ module Inferno
             US Core Responders SHALL be capable of populating all data elements as part of the query results as specified by the US Core Server Capability Statement.
             This will look through all Observation resources returned from prior searches to see if any of them provide the following must support elements:
 
-            Observation.status
+            status
 
-            Observation.category
+            category
 
-            Observation.category.coding
+            category.coding
 
-            Observation.category.coding.system
+            category.coding.system
 
-            Observation.category.coding.code
+            category.coding.code
 
-            Observation.code
+            code
 
-            Observation.subject
+            subject
 
-            Observation.effective[x]
+            effective[x]
 
-            Observation.value[x]
+            value[x]
 
-            Observation.value[x].value
+            value[x].value
 
-            Observation.value[x].unit
+            value[x].unit
 
-            Observation.value[x].system
+            value[x].system
 
-            Observation.value[x].code
+            value[x].code
 
-            Observation.dataAbsentReason
+            dataAbsentReason
 
             Observation.category:VSCat
 
@@ -554,62 +633,16 @@ module Inferno
 
         skip_if_not_found(resource_type: 'Observation', delayed: false)
 
-        must_support_slices = [
-          {
-            name: 'Observation.category:VSCat',
-            path: 'Observation.category',
-            discriminator: {
-              type: 'value',
-              values: [
-                {
-                  path: 'coding.code',
-                  value: 'vital-signs'
-                },
-                {
-                  path: 'coding.system',
-                  value: 'http://terminology.hl7.org/CodeSystem/observation-category'
-                }
-              ]
-            }
-          },
-          {
-            name: 'Observation.value[x]:valueQuantity',
-            path: 'Observation.value',
-            discriminator: {
-              type: 'type',
-              code: 'Quantity'
-            }
-          }
-        ]
-        missing_slices = must_support_slices.reject do |slice|
-          truncated_path = slice[:path].gsub('Observation.', '')
+        missing_slices = MUST_SUPPORTS[:slices].reject do |slice|
           @observation_ary&.values&.flatten&.any? do |resource|
-            slice_found = find_slice(resource, truncated_path, slice[:discriminator])
+            slice_found = find_slice(resource, slice[:path], slice[:discriminator])
             slice_found.present?
           end
         end
 
-        must_support_elements = [
-          { path: 'Observation.status' },
-          { path: 'Observation.category' },
-          { path: 'Observation.category.coding' },
-          { path: 'Observation.category.coding.system', fixed_value: 'http://terminology.hl7.org/CodeSystem/observation-category' },
-          { path: 'Observation.category.coding.code', fixed_value: 'vital-signs' },
-          { path: 'Observation.code' },
-          { path: 'Observation.subject' },
-          { path: 'Observation.effective' },
-          { path: 'Observation.value' },
-          { path: 'Observation.value.value' },
-          { path: 'Observation.value.unit' },
-          { path: 'Observation.value.system', fixed_value: 'http://unitsofmeasure.org' },
-          { path: 'Observation.value.code', fixed_value: '/min' },
-          { path: 'Observation.dataAbsentReason' }
-        ]
-
-        missing_must_support_elements = must_support_elements.reject do |element|
-          truncated_path = element[:path].gsub('Observation.', '')
+        missing_must_support_elements = MUST_SUPPORTS[:elements].reject do |element|
           @observation_ary&.values&.flatten&.any? do |resource|
-            value_found = resolve_element_from_path(resource, truncated_path) { |value| element[:fixed_value].blank? || value == element[:fixed_value] }
+            value_found = resolve_element_from_path(resource, element[:path]) { |value| element[:fixed_value].blank? || value == element[:fixed_value] }
             value_found.present?
           end
         end

--- a/lib/modules/uscore_v3.1.0/pediatric_bmi_for_age_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/pediatric_bmi_for_age_sequence.rb
@@ -88,6 +88,71 @@ module Inferno
 
       @resources_found = false
 
+      MUST_SUPPORTS = {
+        extensions: [],
+        slices: [
+          {
+            name: 'Observation.category:VSCat',
+            path: 'category',
+            discriminator: {
+              type: 'value',
+              values: [
+                {
+                  path: 'coding.code',
+                  value: 'vital-signs'
+                },
+                {
+                  path: 'coding.system',
+                  value: 'http://terminology.hl7.org/CodeSystem/observation-category'
+                }
+              ]
+            }
+          }
+        ],
+        elements: [
+          {
+            path: 'status'
+          },
+          {
+            path: 'category'
+          },
+          {
+            path: 'category.coding'
+          },
+          {
+            path: 'category.coding.system',
+            fixed_value: 'http://terminology.hl7.org/CodeSystem/observation-category'
+          },
+          {
+            path: 'category.coding.code',
+            fixed_value: 'vital-signs'
+          },
+          {
+            path: 'subject'
+          },
+          {
+            path: 'effective'
+          },
+          {
+            path: 'value'
+          },
+          {
+            path: 'value.value'
+          },
+          {
+            path: 'value.unit'
+          },
+          {
+            path: 'value.system',
+            fixed_value: 'http://unitsofmeasure.org'
+          },
+          {
+            path: 'value.code',
+            fixed_value: '%'
+          }
+        ]
+      }.freeze
+
       test :search_by_patient_code do
         metadata do
           id '01'
@@ -516,29 +581,29 @@ module Inferno
             US Core Responders SHALL be capable of populating all data elements as part of the query results as specified by the US Core Server Capability Statement.
             This will look through all Observation resources returned from prior searches to see if any of them provide the following must support elements:
 
-            Observation.status
+            status
 
-            Observation.category
+            category
 
-            Observation.category.coding
+            category.coding
 
-            Observation.category.coding.system
+            category.coding.system
 
-            Observation.category.coding.code
+            category.coding.code
 
-            Observation.subject
+            subject
 
-            Observation.effective[x]
+            effective[x]
 
-            Observation.value[x]
+            value[x]
 
-            Observation.value[x].value
+            value[x].value
 
-            Observation.value[x].unit
+            value[x].unit
 
-            Observation.value[x].system
+            value[x].system
 
-            Observation.value[x].code
+            value[x].code
 
             Observation.category:VSCat
 
@@ -548,52 +613,16 @@ module Inferno
 
         skip_if_not_found(resource_type: 'Observation', delayed: false)
 
-        must_support_slices = [
-          {
-            name: 'Observation.category:VSCat',
-            path: 'Observation.category',
-            discriminator: {
-              type: 'value',
-              values: [
-                {
-                  path: 'coding.code',
-                  value: 'vital-signs'
-                },
-                {
-                  path: 'coding.system',
-                  value: 'http://terminology.hl7.org/CodeSystem/observation-category'
-                }
-              ]
-            }
-          }
-        ]
-        missing_slices = must_support_slices.reject do |slice|
-          truncated_path = slice[:path].gsub('Observation.', '')
+        missing_slices = MUST_SUPPORTS[:slices].reject do |slice|
           @observation_ary&.values&.flatten&.any? do |resource|
-            slice_found = find_slice(resource, truncated_path, slice[:discriminator])
+            slice_found = find_slice(resource, slice[:path], slice[:discriminator])
             slice_found.present?
           end
         end
 
-        must_support_elements = [
-          { path: 'Observation.status' },
-          { path: 'Observation.category' },
-          { path: 'Observation.category.coding' },
-          { path: 'Observation.category.coding.system', fixed_value: 'http://terminology.hl7.org/CodeSystem/observation-category' },
-          { path: 'Observation.category.coding.code', fixed_value: 'vital-signs' },
-          { path: 'Observation.subject' },
-          { path: 'Observation.effective' },
-          { path: 'Observation.value' },
-          { path: 'Observation.value.value' },
-          { path: 'Observation.value.unit' },
-          { path: 'Observation.value.system', fixed_value: 'http://unitsofmeasure.org' },
-          { path: 'Observation.value.code', fixed_value: '%' }
-        ]
-
-        missing_must_support_elements = must_support_elements.reject do |element|
-          truncated_path = element[:path].gsub('Observation.', '')
+        missing_must_support_elements = MUST_SUPPORTS[:elements].reject do |element|
           @observation_ary&.values&.flatten&.any? do |resource|
-            value_found = resolve_element_from_path(resource, truncated_path) { |value| element[:fixed_value].blank? || value == element[:fixed_value] }
+            value_found = resolve_element_from_path(resource, element[:path]) { |value| element[:fixed_value].blank? || value == element[:fixed_value] }
             value_found.present?
           end
         end

--- a/lib/modules/uscore_v3.1.0/pediatric_weight_for_height_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/pediatric_weight_for_height_sequence.rb
@@ -88,6 +88,71 @@ module Inferno
 
       @resources_found = false
 
+      MUST_SUPPORTS = {
+        extensions: [],
+        slices: [
+          {
+            name: 'Observation.category:VSCat',
+            path: 'category',
+            discriminator: {
+              type: 'value',
+              values: [
+                {
+                  path: 'coding.code',
+                  value: 'vital-signs'
+                },
+                {
+                  path: 'coding.system',
+                  value: 'http://terminology.hl7.org/CodeSystem/observation-category'
+                }
+              ]
+            }
+          }
+        ],
+        elements: [
+          {
+            path: 'status'
+          },
+          {
+            path: 'category'
+          },
+          {
+            path: 'category.coding'
+          },
+          {
+            path: 'category.coding.system',
+            fixed_value: 'http://terminology.hl7.org/CodeSystem/observation-category'
+          },
+          {
+            path: 'category.coding.code',
+            fixed_value: 'vital-signs'
+          },
+          {
+            path: 'subject'
+          },
+          {
+            path: 'effective'
+          },
+          {
+            path: 'value'
+          },
+          {
+            path: 'value.value'
+          },
+          {
+            path: 'value.unit'
+          },
+          {
+            path: 'value.system',
+            fixed_value: 'http://unitsofmeasure.org'
+          },
+          {
+            path: 'value.code',
+            fixed_value: '%'
+          }
+        ]
+      }.freeze
+
       test :search_by_patient_code do
         metadata do
           id '01'
@@ -516,29 +581,29 @@ module Inferno
             US Core Responders SHALL be capable of populating all data elements as part of the query results as specified by the US Core Server Capability Statement.
             This will look through all Observation resources returned from prior searches to see if any of them provide the following must support elements:
 
-            Observation.status
+            status
 
-            Observation.category
+            category
 
-            Observation.category.coding
+            category.coding
 
-            Observation.category.coding.system
+            category.coding.system
 
-            Observation.category.coding.code
+            category.coding.code
 
-            Observation.subject
+            subject
 
-            Observation.effective[x]
+            effective[x]
 
-            Observation.value[x]
+            value[x]
 
-            Observation.value[x].value
+            value[x].value
 
-            Observation.value[x].unit
+            value[x].unit
 
-            Observation.value[x].system
+            value[x].system
 
-            Observation.value[x].code
+            value[x].code
 
             Observation.category:VSCat
 
@@ -548,52 +613,16 @@ module Inferno
 
         skip_if_not_found(resource_type: 'Observation', delayed: false)
 
-        must_support_slices = [
-          {
-            name: 'Observation.category:VSCat',
-            path: 'Observation.category',
-            discriminator: {
-              type: 'value',
-              values: [
-                {
-                  path: 'coding.code',
-                  value: 'vital-signs'
-                },
-                {
-                  path: 'coding.system',
-                  value: 'http://terminology.hl7.org/CodeSystem/observation-category'
-                }
-              ]
-            }
-          }
-        ]
-        missing_slices = must_support_slices.reject do |slice|
-          truncated_path = slice[:path].gsub('Observation.', '')
+        missing_slices = MUST_SUPPORTS[:slices].reject do |slice|
           @observation_ary&.values&.flatten&.any? do |resource|
-            slice_found = find_slice(resource, truncated_path, slice[:discriminator])
+            slice_found = find_slice(resource, slice[:path], slice[:discriminator])
             slice_found.present?
           end
         end
 
-        must_support_elements = [
-          { path: 'Observation.status' },
-          { path: 'Observation.category' },
-          { path: 'Observation.category.coding' },
-          { path: 'Observation.category.coding.system', fixed_value: 'http://terminology.hl7.org/CodeSystem/observation-category' },
-          { path: 'Observation.category.coding.code', fixed_value: 'vital-signs' },
-          { path: 'Observation.subject' },
-          { path: 'Observation.effective' },
-          { path: 'Observation.value' },
-          { path: 'Observation.value.value' },
-          { path: 'Observation.value.unit' },
-          { path: 'Observation.value.system', fixed_value: 'http://unitsofmeasure.org' },
-          { path: 'Observation.value.code', fixed_value: '%' }
-        ]
-
-        missing_must_support_elements = must_support_elements.reject do |element|
-          truncated_path = element[:path].gsub('Observation.', '')
+        missing_must_support_elements = MUST_SUPPORTS[:elements].reject do |element|
           @observation_ary&.values&.flatten&.any? do |resource|
-            value_found = resolve_element_from_path(resource, truncated_path) { |value| element[:fixed_value].blank? || value == element[:fixed_value] }
+            value_found = resolve_element_from_path(resource, element[:path]) { |value| element[:fixed_value].blank? || value == element[:fixed_value] }
             value_found.present?
           end
         end

--- a/lib/modules/uscore_v3.1.0/resprate_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/resprate_sequence.rb
@@ -88,6 +88,85 @@ module Inferno
 
       @resources_found = false
 
+      MUST_SUPPORTS = {
+        extensions: [],
+        slices: [
+          {
+            name: 'Observation.category:VSCat',
+            path: 'category',
+            discriminator: {
+              type: 'value',
+              values: [
+                {
+                  path: 'coding.code',
+                  value: 'vital-signs'
+                },
+                {
+                  path: 'coding.system',
+                  value: 'http://terminology.hl7.org/CodeSystem/observation-category'
+                }
+              ]
+            }
+          },
+          {
+            name: 'Observation.value[x]:valueQuantity',
+            path: 'value',
+            discriminator: {
+              type: 'type',
+              code: 'Quantity'
+            }
+          }
+        ],
+        elements: [
+          {
+            path: 'status'
+          },
+          {
+            path: 'category'
+          },
+          {
+            path: 'category.coding'
+          },
+          {
+            path: 'category.coding.system',
+            fixed_value: 'http://terminology.hl7.org/CodeSystem/observation-category'
+          },
+          {
+            path: 'category.coding.code',
+            fixed_value: 'vital-signs'
+          },
+          {
+            path: 'code'
+          },
+          {
+            path: 'subject'
+          },
+          {
+            path: 'effective'
+          },
+          {
+            path: 'value'
+          },
+          {
+            path: 'value.value'
+          },
+          {
+            path: 'value.unit'
+          },
+          {
+            path: 'value.system',
+            fixed_value: 'http://unitsofmeasure.org'
+          },
+          {
+            path: 'value.code',
+            fixed_value: '/min'
+          },
+          {
+            path: 'dataAbsentReason'
+          }
+        ]
+      }.freeze
+
       test :search_by_patient_code do
         metadata do
           id '01'
@@ -516,33 +595,33 @@ module Inferno
             US Core Responders SHALL be capable of populating all data elements as part of the query results as specified by the US Core Server Capability Statement.
             This will look through all Observation resources returned from prior searches to see if any of them provide the following must support elements:
 
-            Observation.status
+            status
 
-            Observation.category
+            category
 
-            Observation.category.coding
+            category.coding
 
-            Observation.category.coding.system
+            category.coding.system
 
-            Observation.category.coding.code
+            category.coding.code
 
-            Observation.code
+            code
 
-            Observation.subject
+            subject
 
-            Observation.effective[x]
+            effective[x]
 
-            Observation.value[x]
+            value[x]
 
-            Observation.value[x].value
+            value[x].value
 
-            Observation.value[x].unit
+            value[x].unit
 
-            Observation.value[x].system
+            value[x].system
 
-            Observation.value[x].code
+            value[x].code
 
-            Observation.dataAbsentReason
+            dataAbsentReason
 
             Observation.category:VSCat
 
@@ -554,62 +633,16 @@ module Inferno
 
         skip_if_not_found(resource_type: 'Observation', delayed: false)
 
-        must_support_slices = [
-          {
-            name: 'Observation.category:VSCat',
-            path: 'Observation.category',
-            discriminator: {
-              type: 'value',
-              values: [
-                {
-                  path: 'coding.code',
-                  value: 'vital-signs'
-                },
-                {
-                  path: 'coding.system',
-                  value: 'http://terminology.hl7.org/CodeSystem/observation-category'
-                }
-              ]
-            }
-          },
-          {
-            name: 'Observation.value[x]:valueQuantity',
-            path: 'Observation.value',
-            discriminator: {
-              type: 'type',
-              code: 'Quantity'
-            }
-          }
-        ]
-        missing_slices = must_support_slices.reject do |slice|
-          truncated_path = slice[:path].gsub('Observation.', '')
+        missing_slices = MUST_SUPPORTS[:slices].reject do |slice|
           @observation_ary&.values&.flatten&.any? do |resource|
-            slice_found = find_slice(resource, truncated_path, slice[:discriminator])
+            slice_found = find_slice(resource, slice[:path], slice[:discriminator])
             slice_found.present?
           end
         end
 
-        must_support_elements = [
-          { path: 'Observation.status' },
-          { path: 'Observation.category' },
-          { path: 'Observation.category.coding' },
-          { path: 'Observation.category.coding.system', fixed_value: 'http://terminology.hl7.org/CodeSystem/observation-category' },
-          { path: 'Observation.category.coding.code', fixed_value: 'vital-signs' },
-          { path: 'Observation.code' },
-          { path: 'Observation.subject' },
-          { path: 'Observation.effective' },
-          { path: 'Observation.value' },
-          { path: 'Observation.value.value' },
-          { path: 'Observation.value.unit' },
-          { path: 'Observation.value.system', fixed_value: 'http://unitsofmeasure.org' },
-          { path: 'Observation.value.code', fixed_value: '/min' },
-          { path: 'Observation.dataAbsentReason' }
-        ]
-
-        missing_must_support_elements = must_support_elements.reject do |element|
-          truncated_path = element[:path].gsub('Observation.', '')
+        missing_must_support_elements = MUST_SUPPORTS[:elements].reject do |element|
           @observation_ary&.values&.flatten&.any? do |resource|
-            value_found = resolve_element_from_path(resource, truncated_path) { |value| element[:fixed_value].blank? || value == element[:fixed_value] }
+            value_found = resolve_element_from_path(resource, element[:path]) { |value| element[:fixed_value].blank? || value == element[:fixed_value] }
             value_found.present?
           end
         end

--- a/lib/modules/uscore_v3.1.0/us_core_allergyintolerance_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_allergyintolerance_sequence.rb
@@ -74,6 +74,25 @@ module Inferno
 
       @resources_found = false
 
+      MUST_SUPPORTS = {
+        extensions: [],
+        slices: [],
+        elements: [
+          {
+            path: 'clinicalStatus'
+          },
+          {
+            path: 'verificationStatus'
+          },
+          {
+            path: 'code'
+          },
+          {
+            path: 'patient'
+          }
+        ]
+      }.freeze
+
       test :search_by_patient do
         metadata do
           id '01'
@@ -364,13 +383,13 @@ module Inferno
             US Core Responders SHALL be capable of populating all data elements as part of the query results as specified by the US Core Server Capability Statement.
             This will look through all AllergyIntolerance resources returned from prior searches to see if any of them provide the following must support elements:
 
-            AllergyIntolerance.clinicalStatus
+            clinicalStatus
 
-            AllergyIntolerance.verificationStatus
+            verificationStatus
 
-            AllergyIntolerance.code
+            code
 
-            AllergyIntolerance.patient
+            patient
 
           )
           versions :r4
@@ -378,17 +397,9 @@ module Inferno
 
         skip_if_not_found(resource_type: 'AllergyIntolerance', delayed: false)
 
-        must_support_elements = [
-          { path: 'AllergyIntolerance.clinicalStatus' },
-          { path: 'AllergyIntolerance.verificationStatus' },
-          { path: 'AllergyIntolerance.code' },
-          { path: 'AllergyIntolerance.patient' }
-        ]
-
-        missing_must_support_elements = must_support_elements.reject do |element|
-          truncated_path = element[:path].gsub('AllergyIntolerance.', '')
+        missing_must_support_elements = MUST_SUPPORTS[:elements].reject do |element|
           @allergy_intolerance_ary&.values&.flatten&.any? do |resource|
-            value_found = resolve_element_from_path(resource, truncated_path) { |value| element[:fixed_value].blank? || value == element[:fixed_value] }
+            value_found = resolve_element_from_path(resource, element[:path]) { |value| element[:fixed_value].blank? || value == element[:fixed_value] }
             value_found.present?
           end
         end

--- a/lib/modules/uscore_v3.1.0/us_core_careteam_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_careteam_sequence.rb
@@ -74,6 +74,28 @@ module Inferno
 
       @resources_found = false
 
+      MUST_SUPPORTS = {
+        extensions: [],
+        slices: [],
+        elements: [
+          {
+            path: 'status'
+          },
+          {
+            path: 'subject'
+          },
+          {
+            path: 'participant'
+          },
+          {
+            path: 'participant.role'
+          },
+          {
+            path: 'participant.member'
+          }
+        ]
+      }.freeze
+
       test :search_by_patient_status do
         metadata do
           id '01'
@@ -286,15 +308,15 @@ module Inferno
             US Core Responders SHALL be capable of populating all data elements as part of the query results as specified by the US Core Server Capability Statement.
             This will look through all CareTeam resources returned from prior searches to see if any of them provide the following must support elements:
 
-            CareTeam.status
+            status
 
-            CareTeam.subject
+            subject
 
-            CareTeam.participant
+            participant
 
-            CareTeam.participant.role
+            participant.role
 
-            CareTeam.participant.member
+            participant.member
 
           )
           versions :r4
@@ -302,18 +324,9 @@ module Inferno
 
         skip_if_not_found(resource_type: 'CareTeam', delayed: false)
 
-        must_support_elements = [
-          { path: 'CareTeam.status' },
-          { path: 'CareTeam.subject' },
-          { path: 'CareTeam.participant' },
-          { path: 'CareTeam.participant.role' },
-          { path: 'CareTeam.participant.member' }
-        ]
-
-        missing_must_support_elements = must_support_elements.reject do |element|
-          truncated_path = element[:path].gsub('CareTeam.', '')
+        missing_must_support_elements = MUST_SUPPORTS[:elements].reject do |element|
           @care_team_ary&.values&.flatten&.any? do |resource|
-            value_found = resolve_element_from_path(resource, truncated_path) { |value| element[:fixed_value].blank? || value == element[:fixed_value] }
+            value_found = resolve_element_from_path(resource, element[:path]) { |value| element[:fixed_value].blank? || value == element[:fixed_value] }
             value_found.present?
           end
         end

--- a/lib/modules/uscore_v3.1.0/us_core_condition_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_condition_sequence.rb
@@ -88,6 +88,28 @@ module Inferno
 
       @resources_found = false
 
+      MUST_SUPPORTS = {
+        extensions: [],
+        slices: [],
+        elements: [
+          {
+            path: 'clinicalStatus'
+          },
+          {
+            path: 'verificationStatus'
+          },
+          {
+            path: 'category'
+          },
+          {
+            path: 'code'
+          },
+          {
+            path: 'subject'
+          }
+        ]
+      }.freeze
+
       test :search_by_patient do
         metadata do
           id '01'
@@ -485,15 +507,15 @@ module Inferno
             US Core Responders SHALL be capable of populating all data elements as part of the query results as specified by the US Core Server Capability Statement.
             This will look through all Condition resources returned from prior searches to see if any of them provide the following must support elements:
 
-            Condition.clinicalStatus
+            clinicalStatus
 
-            Condition.verificationStatus
+            verificationStatus
 
-            Condition.category
+            category
 
-            Condition.code
+            code
 
-            Condition.subject
+            subject
 
           )
           versions :r4
@@ -501,18 +523,9 @@ module Inferno
 
         skip_if_not_found(resource_type: 'Condition', delayed: false)
 
-        must_support_elements = [
-          { path: 'Condition.clinicalStatus' },
-          { path: 'Condition.verificationStatus' },
-          { path: 'Condition.category' },
-          { path: 'Condition.code' },
-          { path: 'Condition.subject' }
-        ]
-
-        missing_must_support_elements = must_support_elements.reject do |element|
-          truncated_path = element[:path].gsub('Condition.', '')
+        missing_must_support_elements = MUST_SUPPORTS[:elements].reject do |element|
           @condition_ary&.values&.flatten&.any? do |resource|
-            value_found = resolve_element_from_path(resource, truncated_path) { |value| element[:fixed_value].blank? || value == element[:fixed_value] }
+            value_found = resolve_element_from_path(resource, element[:path]) { |value| element[:fixed_value].blank? || value == element[:fixed_value] }
             value_found.present?
           end
         end

--- a/lib/modules/uscore_v3.1.0/us_core_diagnosticreport_lab_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_diagnosticreport_lab_sequence.rb
@@ -88,6 +88,48 @@ module Inferno
 
       @resources_found = false
 
+      MUST_SUPPORTS = {
+        extensions: [],
+        slices: [
+          {
+            name: 'DiagnosticReport.category:LaboratorySlice',
+            path: 'category',
+            discriminator: {
+              type: 'patternCodeableConcept',
+              path: '',
+              code: 'LAB',
+              system: 'http://terminology.hl7.org/CodeSystem/v2-0074'
+            }
+          }
+        ],
+        elements: [
+          {
+            path: 'status'
+          },
+          {
+            path: 'category'
+          },
+          {
+            path: 'code'
+          },
+          {
+            path: 'subject'
+          },
+          {
+            path: 'effective'
+          },
+          {
+            path: 'issued'
+          },
+          {
+            path: 'performer'
+          },
+          {
+            path: 'result'
+          }
+        ]
+      }.freeze
+
       test :search_by_patient_category do
         metadata do
           id '01'
@@ -502,21 +544,21 @@ module Inferno
             US Core Responders SHALL be capable of populating all data elements as part of the query results as specified by the US Core Server Capability Statement.
             This will look through all DiagnosticReport resources returned from prior searches to see if any of them provide the following must support elements:
 
-            DiagnosticReport.status
+            status
 
-            DiagnosticReport.category
+            category
 
-            DiagnosticReport.code
+            code
 
-            DiagnosticReport.subject
+            subject
 
-            DiagnosticReport.effective[x]
+            effective[x]
 
-            DiagnosticReport.issued
+            issued
 
-            DiagnosticReport.performer
+            performer
 
-            DiagnosticReport.result
+            result
 
             DiagnosticReport.category:LaboratorySlice
 
@@ -526,41 +568,16 @@ module Inferno
 
         skip_if_not_found(resource_type: 'DiagnosticReport', delayed: false)
 
-        must_support_slices = [
-          {
-            name: 'DiagnosticReport.category:LaboratorySlice',
-            path: 'DiagnosticReport.category',
-            discriminator: {
-              type: 'patternCodeableConcept',
-              path: '',
-              code: 'LAB',
-              system: 'http://terminology.hl7.org/CodeSystem/v2-0074'
-            }
-          }
-        ]
-        missing_slices = must_support_slices.reject do |slice|
-          truncated_path = slice[:path].gsub('DiagnosticReport.', '')
+        missing_slices = MUST_SUPPORTS[:slices].reject do |slice|
           @diagnostic_report_ary&.values&.flatten&.any? do |resource|
-            slice_found = find_slice(resource, truncated_path, slice[:discriminator])
+            slice_found = find_slice(resource, slice[:path], slice[:discriminator])
             slice_found.present?
           end
         end
 
-        must_support_elements = [
-          { path: 'DiagnosticReport.status' },
-          { path: 'DiagnosticReport.category' },
-          { path: 'DiagnosticReport.code' },
-          { path: 'DiagnosticReport.subject' },
-          { path: 'DiagnosticReport.effective' },
-          { path: 'DiagnosticReport.issued' },
-          { path: 'DiagnosticReport.performer' },
-          { path: 'DiagnosticReport.result' }
-        ]
-
-        missing_must_support_elements = must_support_elements.reject do |element|
-          truncated_path = element[:path].gsub('DiagnosticReport.', '')
+        missing_must_support_elements = MUST_SUPPORTS[:elements].reject do |element|
           @diagnostic_report_ary&.values&.flatten&.any? do |resource|
-            value_found = resolve_element_from_path(resource, truncated_path) { |value| element[:fixed_value].blank? || value == element[:fixed_value] }
+            value_found = resolve_element_from_path(resource, element[:path]) { |value| element[:fixed_value].blank? || value == element[:fixed_value] }
             value_found.present?
           end
         end

--- a/lib/modules/uscore_v3.1.0/us_core_diagnosticreport_note_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_diagnosticreport_note_sequence.rb
@@ -88,6 +88,40 @@ module Inferno
 
       @resources_found = false
 
+      MUST_SUPPORTS = {
+        extensions: [],
+        slices: [],
+        elements: [
+          {
+            path: 'status'
+          },
+          {
+            path: 'category'
+          },
+          {
+            path: 'code'
+          },
+          {
+            path: 'subject'
+          },
+          {
+            path: 'encounter'
+          },
+          {
+            path: 'effective'
+          },
+          {
+            path: 'issued'
+          },
+          {
+            path: 'performer'
+          },
+          {
+            path: 'presentedForm'
+          }
+        ]
+      }.freeze
+
       test :search_by_patient_category do
         metadata do
           id '01'
@@ -508,23 +542,23 @@ module Inferno
             US Core Responders SHALL be capable of populating all data elements as part of the query results as specified by the US Core Server Capability Statement.
             This will look through all DiagnosticReport resources returned from prior searches to see if any of them provide the following must support elements:
 
-            DiagnosticReport.status
+            status
 
-            DiagnosticReport.category
+            category
 
-            DiagnosticReport.code
+            code
 
-            DiagnosticReport.subject
+            subject
 
-            DiagnosticReport.encounter
+            encounter
 
-            DiagnosticReport.effective[x]
+            effective[x]
 
-            DiagnosticReport.issued
+            issued
 
-            DiagnosticReport.performer
+            performer
 
-            DiagnosticReport.presentedForm
+            presentedForm
 
           )
           versions :r4
@@ -532,22 +566,9 @@ module Inferno
 
         skip_if_not_found(resource_type: 'DiagnosticReport', delayed: false)
 
-        must_support_elements = [
-          { path: 'DiagnosticReport.status' },
-          { path: 'DiagnosticReport.category' },
-          { path: 'DiagnosticReport.code' },
-          { path: 'DiagnosticReport.subject' },
-          { path: 'DiagnosticReport.encounter' },
-          { path: 'DiagnosticReport.effective' },
-          { path: 'DiagnosticReport.issued' },
-          { path: 'DiagnosticReport.performer' },
-          { path: 'DiagnosticReport.presentedForm' }
-        ]
-
-        missing_must_support_elements = must_support_elements.reject do |element|
-          truncated_path = element[:path].gsub('DiagnosticReport.', '')
+        missing_must_support_elements = MUST_SUPPORTS[:elements].reject do |element|
           @diagnostic_report_ary&.values&.flatten&.any? do |resource|
-            value_found = resolve_element_from_path(resource, truncated_path) { |value| element[:fixed_value].blank? || value == element[:fixed_value] }
+            value_found = resolve_element_from_path(resource, element[:path]) { |value| element[:fixed_value].blank? || value == element[:fixed_value] }
             value_found.present?
           end
         end

--- a/lib/modules/uscore_v3.1.0/us_core_documentreference_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_documentreference_sequence.rb
@@ -98,6 +98,64 @@ module Inferno
 
       @resources_found = false
 
+      MUST_SUPPORTS = {
+        extensions: [],
+        slices: [],
+        elements: [
+          {
+            path: 'identifier'
+          },
+          {
+            path: 'status'
+          },
+          {
+            path: 'type'
+          },
+          {
+            path: 'category'
+          },
+          {
+            path: 'subject'
+          },
+          {
+            path: 'date'
+          },
+          {
+            path: 'author'
+          },
+          {
+            path: 'custodian'
+          },
+          {
+            path: 'content'
+          },
+          {
+            path: 'content.attachment'
+          },
+          {
+            path: 'content.attachment.contentType'
+          },
+          {
+            path: 'content.attachment.data'
+          },
+          {
+            path: 'content.attachment.url'
+          },
+          {
+            path: 'content.format'
+          },
+          {
+            path: 'context'
+          },
+          {
+            path: 'context.encounter'
+          },
+          {
+            path: 'context.period'
+          }
+        ]
+      }.freeze
+
       test :search_by_patient do
         metadata do
           id '01'
@@ -595,39 +653,39 @@ module Inferno
             US Core Responders SHALL be capable of populating all data elements as part of the query results as specified by the US Core Server Capability Statement.
             This will look through all DocumentReference resources returned from prior searches to see if any of them provide the following must support elements:
 
-            DocumentReference.identifier
+            identifier
 
-            DocumentReference.status
+            status
 
-            DocumentReference.type
+            type
 
-            DocumentReference.category
+            category
 
-            DocumentReference.subject
+            subject
 
-            DocumentReference.date
+            date
 
-            DocumentReference.author
+            author
 
-            DocumentReference.custodian
+            custodian
 
-            DocumentReference.content
+            content
 
-            DocumentReference.content.attachment
+            content.attachment
 
-            DocumentReference.content.attachment.contentType
+            content.attachment.contentType
 
-            DocumentReference.content.attachment.data
+            content.attachment.data
 
-            DocumentReference.content.attachment.url
+            content.attachment.url
 
-            DocumentReference.content.format
+            content.format
 
-            DocumentReference.context
+            context
 
-            DocumentReference.context.encounter
+            context.encounter
 
-            DocumentReference.context.period
+            context.period
 
           )
           versions :r4
@@ -635,30 +693,9 @@ module Inferno
 
         skip_if_not_found(resource_type: 'DocumentReference', delayed: false)
 
-        must_support_elements = [
-          { path: 'DocumentReference.identifier' },
-          { path: 'DocumentReference.status' },
-          { path: 'DocumentReference.type' },
-          { path: 'DocumentReference.category' },
-          { path: 'DocumentReference.subject' },
-          { path: 'DocumentReference.date' },
-          { path: 'DocumentReference.author' },
-          { path: 'DocumentReference.custodian' },
-          { path: 'DocumentReference.content' },
-          { path: 'DocumentReference.content.attachment' },
-          { path: 'DocumentReference.content.attachment.contentType' },
-          { path: 'DocumentReference.content.attachment.data' },
-          { path: 'DocumentReference.content.attachment.url' },
-          { path: 'DocumentReference.content.format' },
-          { path: 'DocumentReference.context' },
-          { path: 'DocumentReference.context.encounter' },
-          { path: 'DocumentReference.context.period' }
-        ]
-
-        missing_must_support_elements = must_support_elements.reject do |element|
-          truncated_path = element[:path].gsub('DocumentReference.', '')
+        missing_must_support_elements = MUST_SUPPORTS[:elements].reject do |element|
           @document_reference_ary&.values&.flatten&.any? do |resource|
-            value_found = resolve_element_from_path(resource, truncated_path) { |value| element[:fixed_value].blank? || value == element[:fixed_value] }
+            value_found = resolve_element_from_path(resource, element[:path]) { |value| element[:fixed_value].blank? || value == element[:fixed_value] }
             value_found.present?
           end
         end

--- a/lib/modules/uscore_v3.1.0/us_core_encounter_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_encounter_sequence.rb
@@ -115,7 +115,7 @@ module Inferno
             path: 'status'
           },
           {
-            path: 'class'
+            path: 'local_class'
           },
           {
             path: 'type'

--- a/lib/modules/uscore_v3.1.0/us_core_encounter_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_encounter_sequence.rb
@@ -98,6 +98,64 @@ module Inferno
 
       @resources_found = false
 
+      MUST_SUPPORTS = {
+        extensions: [],
+        slices: [],
+        elements: [
+          {
+            path: 'identifier'
+          },
+          {
+            path: 'identifier.system'
+          },
+          {
+            path: 'identifier.value'
+          },
+          {
+            path: 'status'
+          },
+          {
+            path: 'class'
+          },
+          {
+            path: 'type'
+          },
+          {
+            path: 'subject'
+          },
+          {
+            path: 'participant'
+          },
+          {
+            path: 'participant.type'
+          },
+          {
+            path: 'participant.period'
+          },
+          {
+            path: 'participant.individual'
+          },
+          {
+            path: 'period'
+          },
+          {
+            path: 'reasonCode'
+          },
+          {
+            path: 'hospitalization'
+          },
+          {
+            path: 'hospitalization.dischargeDisposition'
+          },
+          {
+            path: 'location'
+          },
+          {
+            path: 'location.location'
+          }
+        ]
+      }.freeze
+
       test :search_by_patient do
         metadata do
           id '01'
@@ -583,39 +641,39 @@ module Inferno
             US Core Responders SHALL be capable of populating all data elements as part of the query results as specified by the US Core Server Capability Statement.
             This will look through all Encounter resources returned from prior searches to see if any of them provide the following must support elements:
 
-            Encounter.identifier
+            identifier
 
-            Encounter.identifier.system
+            identifier.system
 
-            Encounter.identifier.value
+            identifier.value
 
-            Encounter.status
+            status
 
-            Encounter.class
+            class
 
-            Encounter.type
+            type
 
-            Encounter.subject
+            subject
 
-            Encounter.participant
+            participant
 
-            Encounter.participant.type
+            participant.type
 
-            Encounter.participant.period
+            participant.period
 
-            Encounter.participant.individual
+            participant.individual
 
-            Encounter.period
+            period
 
-            Encounter.reasonCode
+            reasonCode
 
-            Encounter.hospitalization
+            hospitalization
 
-            Encounter.hospitalization.dischargeDisposition
+            hospitalization.dischargeDisposition
 
-            Encounter.location
+            location
 
-            Encounter.location.location
+            location.location
 
           )
           versions :r4
@@ -623,30 +681,9 @@ module Inferno
 
         skip_if_not_found(resource_type: 'Encounter', delayed: false)
 
-        must_support_elements = [
-          { path: 'Encounter.identifier' },
-          { path: 'Encounter.identifier.system' },
-          { path: 'Encounter.identifier.value' },
-          { path: 'Encounter.status' },
-          { path: 'Encounter.local_class' },
-          { path: 'Encounter.type' },
-          { path: 'Encounter.subject' },
-          { path: 'Encounter.participant' },
-          { path: 'Encounter.participant.type' },
-          { path: 'Encounter.participant.period' },
-          { path: 'Encounter.participant.individual' },
-          { path: 'Encounter.period' },
-          { path: 'Encounter.reasonCode' },
-          { path: 'Encounter.hospitalization' },
-          { path: 'Encounter.hospitalization.dischargeDisposition' },
-          { path: 'Encounter.location' },
-          { path: 'Encounter.location.location' }
-        ]
-
-        missing_must_support_elements = must_support_elements.reject do |element|
-          truncated_path = element[:path].gsub('Encounter.', '')
+        missing_must_support_elements = MUST_SUPPORTS[:elements].reject do |element|
           @encounter_ary&.values&.flatten&.any? do |resource|
-            value_found = resolve_element_from_path(resource, truncated_path) { |value| element[:fixed_value].blank? || value == element[:fixed_value] }
+            value_found = resolve_element_from_path(resource, element[:path]) { |value| element[:fixed_value].blank? || value == element[:fixed_value] }
             value_found.present?
           end
         end

--- a/lib/modules/uscore_v3.1.0/us_core_goal_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_goal_sequence.rb
@@ -78,6 +78,34 @@ module Inferno
 
       @resources_found = false
 
+      MUST_SUPPORTS = {
+        extensions: [],
+        slices: [
+          {
+            name: 'Goal.target.due[x]:dueDate',
+            path: 'target.due',
+            discriminator: {
+              type: 'type',
+              code: 'Date'
+            }
+          }
+        ],
+        elements: [
+          {
+            path: 'lifecycleStatus'
+          },
+          {
+            path: 'description'
+          },
+          {
+            path: 'subject'
+          },
+          {
+            path: 'target'
+          }
+        ]
+      }.freeze
+
       test :search_by_patient do
         metadata do
           id '01'
@@ -363,13 +391,13 @@ module Inferno
             US Core Responders SHALL be capable of populating all data elements as part of the query results as specified by the US Core Server Capability Statement.
             This will look through all Goal resources returned from prior searches to see if any of them provide the following must support elements:
 
-            Goal.lifecycleStatus
+            lifecycleStatus
 
-            Goal.description
+            description
 
-            Goal.subject
+            subject
 
-            Goal.target
+            target
 
             Goal.target.due[x]:dueDate
 
@@ -379,35 +407,16 @@ module Inferno
 
         skip_if_not_found(resource_type: 'Goal', delayed: false)
 
-        must_support_slices = [
-          {
-            name: 'Goal.target.due[x]:dueDate',
-            path: 'Goal.target.due',
-            discriminator: {
-              type: 'type',
-              code: 'Date'
-            }
-          }
-        ]
-        missing_slices = must_support_slices.reject do |slice|
-          truncated_path = slice[:path].gsub('Goal.', '')
+        missing_slices = MUST_SUPPORTS[:slices].reject do |slice|
           @goal_ary&.values&.flatten&.any? do |resource|
-            slice_found = find_slice(resource, truncated_path, slice[:discriminator])
+            slice_found = find_slice(resource, slice[:path], slice[:discriminator])
             slice_found.present?
           end
         end
 
-        must_support_elements = [
-          { path: 'Goal.lifecycleStatus' },
-          { path: 'Goal.description' },
-          { path: 'Goal.subject' },
-          { path: 'Goal.target' }
-        ]
-
-        missing_must_support_elements = must_support_elements.reject do |element|
-          truncated_path = element[:path].gsub('Goal.', '')
+        missing_must_support_elements = MUST_SUPPORTS[:elements].reject do |element|
           @goal_ary&.values&.flatten&.any? do |resource|
-            value_found = resolve_element_from_path(resource, truncated_path) { |value| element[:fixed_value].blank? || value == element[:fixed_value] }
+            value_found = resolve_element_from_path(resource, element[:path]) { |value| element[:fixed_value].blank? || value == element[:fixed_value] }
             value_found.present?
           end
         end

--- a/lib/modules/uscore_v3.1.0/us_core_immunization_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_immunization_sequence.rb
@@ -78,6 +78,31 @@ module Inferno
 
       @resources_found = false
 
+      MUST_SUPPORTS = {
+        extensions: [],
+        slices: [],
+        elements: [
+          {
+            path: 'status'
+          },
+          {
+            path: 'statusReason'
+          },
+          {
+            path: 'vaccineCode'
+          },
+          {
+            path: 'patient'
+          },
+          {
+            path: 'occurrence'
+          },
+          {
+            path: 'primarySource'
+          }
+        ]
+      }.freeze
+
       test :search_by_patient do
         metadata do
           id '01'
@@ -375,17 +400,17 @@ module Inferno
             US Core Responders SHALL be capable of populating all data elements as part of the query results as specified by the US Core Server Capability Statement.
             This will look through all Immunization resources returned from prior searches to see if any of them provide the following must support elements:
 
-            Immunization.status
+            status
 
-            Immunization.statusReason
+            statusReason
 
-            Immunization.vaccineCode
+            vaccineCode
 
-            Immunization.patient
+            patient
 
-            Immunization.occurrence[x]
+            occurrence[x]
 
-            Immunization.primarySource
+            primarySource
 
           )
           versions :r4
@@ -393,19 +418,9 @@ module Inferno
 
         skip_if_not_found(resource_type: 'Immunization', delayed: false)
 
-        must_support_elements = [
-          { path: 'Immunization.status' },
-          { path: 'Immunization.statusReason' },
-          { path: 'Immunization.vaccineCode' },
-          { path: 'Immunization.patient' },
-          { path: 'Immunization.occurrence' },
-          { path: 'Immunization.primarySource' }
-        ]
-
-        missing_must_support_elements = must_support_elements.reject do |element|
-          truncated_path = element[:path].gsub('Immunization.', '')
+        missing_must_support_elements = MUST_SUPPORTS[:elements].reject do |element|
           @immunization_ary&.values&.flatten&.any? do |resource|
-            value_found = resolve_element_from_path(resource, truncated_path) { |value| element[:fixed_value].blank? || value == element[:fixed_value] }
+            value_found = resolve_element_from_path(resource, element[:path]) { |value| element[:fixed_value].blank? || value == element[:fixed_value] }
             value_found.present?
           end
         end

--- a/lib/modules/uscore_v3.1.0/us_core_implantable_device_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_implantable_device_sequence.rb
@@ -41,6 +41,46 @@ module Inferno
 
       @resources_found = false
 
+      MUST_SUPPORTS = {
+        extensions: [],
+        slices: [],
+        elements: [
+          {
+            path: 'udiCarrier'
+          },
+          {
+            path: 'udiCarrier.deviceIdentifier'
+          },
+          {
+            path: 'udiCarrier.carrierAIDC'
+          },
+          {
+            path: 'udiCarrier.carrierHRF'
+          },
+          {
+            path: 'distinctIdentifier'
+          },
+          {
+            path: 'manufactureDate'
+          },
+          {
+            path: 'expirationDate'
+          },
+          {
+            path: 'lotNumber'
+          },
+          {
+            path: 'serialNumber'
+          },
+          {
+            path: 'type'
+          },
+          {
+            path: 'patient'
+          }
+        ]
+      }.freeze
+
       test :search_by_patient do
         metadata do
           id '01'
@@ -308,27 +348,27 @@ module Inferno
             US Core Responders SHALL be capable of populating all data elements as part of the query results as specified by the US Core Server Capability Statement.
             This will look through all Device resources returned from prior searches to see if any of them provide the following must support elements:
 
-            Device.udiCarrier
+            udiCarrier
 
-            Device.udiCarrier.deviceIdentifier
+            udiCarrier.deviceIdentifier
 
-            Device.udiCarrier.carrierAIDC
+            udiCarrier.carrierAIDC
 
-            Device.udiCarrier.carrierHRF
+            udiCarrier.carrierHRF
 
-            Device.distinctIdentifier
+            distinctIdentifier
 
-            Device.manufactureDate
+            manufactureDate
 
-            Device.expirationDate
+            expirationDate
 
-            Device.lotNumber
+            lotNumber
 
-            Device.serialNumber
+            serialNumber
 
-            Device.type
+            type
 
-            Device.patient
+            patient
 
           )
           versions :r4
@@ -336,24 +376,9 @@ module Inferno
 
         skip_if_not_found(resource_type: 'Device', delayed: false)
 
-        must_support_elements = [
-          { path: 'Device.udiCarrier' },
-          { path: 'Device.udiCarrier.deviceIdentifier' },
-          { path: 'Device.udiCarrier.carrierAIDC' },
-          { path: 'Device.udiCarrier.carrierHRF' },
-          { path: 'Device.distinctIdentifier' },
-          { path: 'Device.manufactureDate' },
-          { path: 'Device.expirationDate' },
-          { path: 'Device.lotNumber' },
-          { path: 'Device.serialNumber' },
-          { path: 'Device.type' },
-          { path: 'Device.patient' }
-        ]
-
-        missing_must_support_elements = must_support_elements.reject do |element|
-          truncated_path = element[:path].gsub('Device.', '')
+        missing_must_support_elements = MUST_SUPPORTS[:elements].reject do |element|
           @device_ary&.values&.flatten&.any? do |resource|
-            value_found = resolve_element_from_path(resource, truncated_path) { |value| element[:fixed_value].blank? || value == element[:fixed_value] }
+            value_found = resolve_element_from_path(resource, element[:path]) { |value| element[:fixed_value].blank? || value == element[:fixed_value] }
             value_found.present?
           end
         end

--- a/lib/modules/uscore_v3.1.0/us_core_location_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_location_sequence.rb
@@ -63,6 +63,40 @@ module Inferno
 
       @resources_found = false
 
+      MUST_SUPPORTS = {
+        extensions: [],
+        slices: [],
+        elements: [
+          {
+            path: 'status'
+          },
+          {
+            path: 'name'
+          },
+          {
+            path: 'telecom'
+          },
+          {
+            path: 'address'
+          },
+          {
+            path: 'address.line'
+          },
+          {
+            path: 'address.city'
+          },
+          {
+            path: 'address.state'
+          },
+          {
+            path: 'address.postalCode'
+          },
+          {
+            path: 'managingOrganization'
+          }
+        ]
+      }.freeze
+
       test :resource_read do
         metadata do
           id '01'
@@ -414,23 +448,23 @@ module Inferno
             US Core Responders SHALL be capable of populating all data elements as part of the query results as specified by the US Core Server Capability Statement.
             This will look through all Location resources returned from prior searches to see if any of them provide the following must support elements:
 
-            Location.status
+            status
 
-            Location.name
+            name
 
-            Location.telecom
+            telecom
 
-            Location.address
+            address
 
-            Location.address.line
+            address.line
 
-            Location.address.city
+            address.city
 
-            Location.address.state
+            address.state
 
-            Location.address.postalCode
+            address.postalCode
 
-            Location.managingOrganization
+            managingOrganization
 
           )
           versions :r4
@@ -438,22 +472,9 @@ module Inferno
 
         skip_if_not_found(resource_type: 'Location', delayed: true)
 
-        must_support_elements = [
-          { path: 'Location.status' },
-          { path: 'Location.name' },
-          { path: 'Location.telecom' },
-          { path: 'Location.address' },
-          { path: 'Location.address.line' },
-          { path: 'Location.address.city' },
-          { path: 'Location.address.state' },
-          { path: 'Location.address.postalCode' },
-          { path: 'Location.managingOrganization' }
-        ]
-
-        missing_must_support_elements = must_support_elements.reject do |element|
-          truncated_path = element[:path].gsub('Location.', '')
+        missing_must_support_elements = MUST_SUPPORTS[:elements].reject do |element|
           @location_ary&.any? do |resource|
-            value_found = resolve_element_from_path(resource, truncated_path) { |value| element[:fixed_value].blank? || value == element[:fixed_value] }
+            value_found = resolve_element_from_path(resource, element[:path]) { |value| element[:fixed_value].blank? || value == element[:fixed_value] }
             value_found.present?
           end
         end

--- a/lib/modules/uscore_v3.1.0/us_core_medicationrequest_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_medicationrequest_sequence.rb
@@ -119,6 +119,43 @@ module Inferno
 
       @resources_found = false
 
+      MUST_SUPPORTS = {
+        extensions: [],
+        slices: [],
+        elements: [
+          {
+            path: 'status'
+          },
+          {
+            path: 'intent'
+          },
+          {
+            path: 'reported'
+          },
+          {
+            path: 'medication'
+          },
+          {
+            path: 'subject'
+          },
+          {
+            path: 'encounter'
+          },
+          {
+            path: 'authoredOn'
+          },
+          {
+            path: 'requester'
+          },
+          {
+            path: 'dosageInstruction'
+          },
+          {
+            path: 'dosageInstruction.text'
+          }
+        ]
+      }.freeze
+
       test :search_by_patient_intent do
         metadata do
           id '01'
@@ -538,25 +575,25 @@ module Inferno
             US Core Responders SHALL be capable of populating all data elements as part of the query results as specified by the US Core Server Capability Statement.
             This will look through all MedicationRequest resources returned from prior searches to see if any of them provide the following must support elements:
 
-            MedicationRequest.status
+            status
 
-            MedicationRequest.intent
+            intent
 
-            MedicationRequest.reported[x]
+            reported[x]
 
-            MedicationRequest.medication[x]
+            medication[x]
 
-            MedicationRequest.subject
+            subject
 
-            MedicationRequest.encounter
+            encounter
 
-            MedicationRequest.authoredOn
+            authoredOn
 
-            MedicationRequest.requester
+            requester
 
-            MedicationRequest.dosageInstruction
+            dosageInstruction
 
-            MedicationRequest.dosageInstruction.text
+            dosageInstruction.text
 
           )
           versions :r4
@@ -564,23 +601,9 @@ module Inferno
 
         skip_if_not_found(resource_type: 'MedicationRequest', delayed: false)
 
-        must_support_elements = [
-          { path: 'MedicationRequest.status' },
-          { path: 'MedicationRequest.intent' },
-          { path: 'MedicationRequest.reported' },
-          { path: 'MedicationRequest.medication' },
-          { path: 'MedicationRequest.subject' },
-          { path: 'MedicationRequest.encounter' },
-          { path: 'MedicationRequest.authoredOn' },
-          { path: 'MedicationRequest.requester' },
-          { path: 'MedicationRequest.dosageInstruction' },
-          { path: 'MedicationRequest.dosageInstruction.text' }
-        ]
-
-        missing_must_support_elements = must_support_elements.reject do |element|
-          truncated_path = element[:path].gsub('MedicationRequest.', '')
+        missing_must_support_elements = MUST_SUPPORTS[:elements].reject do |element|
           @medication_request_ary&.values&.flatten&.any? do |resource|
-            value_found = resolve_element_from_path(resource, truncated_path) { |value| element[:fixed_value].blank? || value == element[:fixed_value] }
+            value_found = resolve_element_from_path(resource, element[:path]) { |value| element[:fixed_value].blank? || value == element[:fixed_value] }
             value_found.present?
           end
         end

--- a/lib/modules/uscore_v3.1.0/us_core_observation_lab_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_observation_lab_sequence.rb
@@ -88,6 +88,45 @@ module Inferno
 
       @resources_found = false
 
+      MUST_SUPPORTS = {
+        extensions: [],
+        slices: [
+          {
+            name: 'Observation.category:Laboratory',
+            path: 'category',
+            discriminator: {
+              type: 'patternCodeableConcept',
+              path: '',
+              code: 'laboratory',
+              system: 'http://terminology.hl7.org/CodeSystem/observation-category'
+            }
+          }
+        ],
+        elements: [
+          {
+            path: 'status'
+          },
+          {
+            path: 'category'
+          },
+          {
+            path: 'code'
+          },
+          {
+            path: 'subject'
+          },
+          {
+            path: 'effective'
+          },
+          {
+            path: 'value'
+          },
+          {
+            path: 'dataAbsentReason'
+          }
+        ]
+      }.freeze
+
       test :search_by_patient_category do
         metadata do
           id '01'
@@ -498,19 +537,19 @@ module Inferno
             US Core Responders SHALL be capable of populating all data elements as part of the query results as specified by the US Core Server Capability Statement.
             This will look through all Observation resources returned from prior searches to see if any of them provide the following must support elements:
 
-            Observation.status
+            status
 
-            Observation.category
+            category
 
-            Observation.code
+            code
 
-            Observation.subject
+            subject
 
-            Observation.effective[x]
+            effective[x]
 
-            Observation.value[x]
+            value[x]
 
-            Observation.dataAbsentReason
+            dataAbsentReason
 
             Observation.category:Laboratory
 
@@ -520,40 +559,16 @@ module Inferno
 
         skip_if_not_found(resource_type: 'Observation', delayed: false)
 
-        must_support_slices = [
-          {
-            name: 'Observation.category:Laboratory',
-            path: 'Observation.category',
-            discriminator: {
-              type: 'patternCodeableConcept',
-              path: '',
-              code: 'laboratory',
-              system: 'http://terminology.hl7.org/CodeSystem/observation-category'
-            }
-          }
-        ]
-        missing_slices = must_support_slices.reject do |slice|
-          truncated_path = slice[:path].gsub('Observation.', '')
+        missing_slices = MUST_SUPPORTS[:slices].reject do |slice|
           @observation_ary&.values&.flatten&.any? do |resource|
-            slice_found = find_slice(resource, truncated_path, slice[:discriminator])
+            slice_found = find_slice(resource, slice[:path], slice[:discriminator])
             slice_found.present?
           end
         end
 
-        must_support_elements = [
-          { path: 'Observation.status' },
-          { path: 'Observation.category' },
-          { path: 'Observation.code' },
-          { path: 'Observation.subject' },
-          { path: 'Observation.effective' },
-          { path: 'Observation.value' },
-          { path: 'Observation.dataAbsentReason' }
-        ]
-
-        missing_must_support_elements = must_support_elements.reject do |element|
-          truncated_path = element[:path].gsub('Observation.', '')
+        missing_must_support_elements = MUST_SUPPORTS[:elements].reject do |element|
           @observation_ary&.values&.flatten&.any? do |resource|
-            value_found = resolve_element_from_path(resource, truncated_path) { |value| element[:fixed_value].blank? || value == element[:fixed_value] }
+            value_found = resolve_element_from_path(resource, element[:path]) { |value| element[:fixed_value].blank? || value == element[:fixed_value] }
             value_found.present?
           end
         end

--- a/lib/modules/uscore_v3.1.0/us_core_organization_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_organization_sequence.rb
@@ -48,6 +48,68 @@ module Inferno
 
       @resources_found = false
 
+      MUST_SUPPORTS = {
+        extensions: [],
+        slices: [
+          {
+            name: 'Organization.identifier:NPI',
+            path: 'identifier',
+            discriminator: {
+              type: 'patternIdentifier',
+              path: '',
+              system: 'http://hl7.org/fhir/sid/us-npi'
+            }
+          },
+          {
+            name: 'Organization.identifier:CLIA',
+            path: 'identifier',
+            discriminator: {
+              type: 'patternIdentifier',
+              path: '',
+              system: 'urn:oid:2.16.840.1.113883.4.7'
+            }
+          }
+        ],
+        elements: [
+          {
+            path: 'identifier'
+          },
+          {
+            path: 'identifier.system'
+          },
+          {
+            path: 'identifier.value'
+          },
+          {
+            path: 'active'
+          },
+          {
+            path: 'name'
+          },
+          {
+            path: 'telecom'
+          },
+          {
+            path: 'address'
+          },
+          {
+            path: 'address.line'
+          },
+          {
+            path: 'address.city'
+          },
+          {
+            path: 'address.state'
+          },
+          {
+            path: 'address.postalCode'
+          },
+          {
+            path: 'address.country'
+          }
+        ]
+      }.freeze
+
       test :resource_read do
         metadata do
           id '01'
@@ -309,29 +371,29 @@ module Inferno
             US Core Responders SHALL be capable of populating all data elements as part of the query results as specified by the US Core Server Capability Statement.
             This will look through all Organization resources returned from prior searches to see if any of them provide the following must support elements:
 
-            Organization.identifier
+            identifier
 
-            Organization.identifier.system
+            identifier.system
 
-            Organization.identifier.value
+            identifier.value
 
-            Organization.active
+            active
 
-            Organization.name
+            name
 
-            Organization.telecom
+            telecom
 
-            Organization.address
+            address
 
-            Organization.address.line
+            address.line
 
-            Organization.address.city
+            address.city
 
-            Organization.address.state
+            address.state
 
-            Organization.address.postalCode
+            address.postalCode
 
-            Organization.address.country
+            address.country
 
             Organization.identifier:NPI
 
@@ -343,53 +405,16 @@ module Inferno
 
         skip_if_not_found(resource_type: 'Organization', delayed: true)
 
-        must_support_slices = [
-          {
-            name: 'Organization.identifier:NPI',
-            path: 'Organization.identifier',
-            discriminator: {
-              type: 'patternIdentifier',
-              path: '',
-              system: 'http://hl7.org/fhir/sid/us-npi'
-            }
-          },
-          {
-            name: 'Organization.identifier:CLIA',
-            path: 'Organization.identifier',
-            discriminator: {
-              type: 'patternIdentifier',
-              path: '',
-              system: 'urn:oid:2.16.840.1.113883.4.7'
-            }
-          }
-        ]
-        missing_slices = must_support_slices.reject do |slice|
-          truncated_path = slice[:path].gsub('Organization.', '')
+        missing_slices = MUST_SUPPORTS[:slices].reject do |slice|
           @organization_ary&.any? do |resource|
-            slice_found = find_slice(resource, truncated_path, slice[:discriminator])
+            slice_found = find_slice(resource, slice[:path], slice[:discriminator])
             slice_found.present?
           end
         end
 
-        must_support_elements = [
-          { path: 'Organization.identifier' },
-          { path: 'Organization.identifier.system' },
-          { path: 'Organization.identifier.value' },
-          { path: 'Organization.active' },
-          { path: 'Organization.name' },
-          { path: 'Organization.telecom' },
-          { path: 'Organization.address' },
-          { path: 'Organization.address.line' },
-          { path: 'Organization.address.city' },
-          { path: 'Organization.address.state' },
-          { path: 'Organization.address.postalCode' },
-          { path: 'Organization.address.country' }
-        ]
-
-        missing_must_support_elements = must_support_elements.reject do |element|
-          truncated_path = element[:path].gsub('Organization.', '')
+        missing_must_support_elements = MUST_SUPPORTS[:elements].reject do |element|
           @organization_ary&.any? do |resource|
-            value_found = resolve_element_from_path(resource, truncated_path) { |value| element[:fixed_value].blank? || value == element[:fixed_value] }
+            value_found = resolve_element_from_path(resource, element[:path]) { |value| element[:fixed_value].blank? || value == element[:fixed_value] }
             value_found.present?
           end
         end

--- a/lib/modules/uscore_v3.1.0/us_core_practitionerrole_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_practitionerrole_sequence.rb
@@ -43,6 +43,40 @@ module Inferno
 
       @resources_found = false
 
+      MUST_SUPPORTS = {
+        extensions: [],
+        slices: [],
+        elements: [
+          {
+            path: 'practitioner'
+          },
+          {
+            path: 'organization'
+          },
+          {
+            path: 'code'
+          },
+          {
+            path: 'specialty'
+          },
+          {
+            path: 'location'
+          },
+          {
+            path: 'telecom'
+          },
+          {
+            path: 'telecom.system'
+          },
+          {
+            path: 'telecom.value'
+          },
+          {
+            path: 'endpoint'
+          }
+        ]
+      }.freeze
+
       test :resource_read do
         metadata do
           id '01'
@@ -388,23 +422,23 @@ module Inferno
             US Core Responders SHALL be capable of populating all data elements as part of the query results as specified by the US Core Server Capability Statement.
             This will look through all PractitionerRole resources returned from prior searches to see if any of them provide the following must support elements:
 
-            PractitionerRole.practitioner
+            practitioner
 
-            PractitionerRole.organization
+            organization
 
-            PractitionerRole.code
+            code
 
-            PractitionerRole.specialty
+            specialty
 
-            PractitionerRole.location
+            location
 
-            PractitionerRole.telecom
+            telecom
 
-            PractitionerRole.telecom.system
+            telecom.system
 
-            PractitionerRole.telecom.value
+            telecom.value
 
-            PractitionerRole.endpoint
+            endpoint
 
           )
           versions :r4
@@ -412,22 +446,9 @@ module Inferno
 
         skip_if_not_found(resource_type: 'PractitionerRole', delayed: true)
 
-        must_support_elements = [
-          { path: 'PractitionerRole.practitioner' },
-          { path: 'PractitionerRole.organization' },
-          { path: 'PractitionerRole.code' },
-          { path: 'PractitionerRole.specialty' },
-          { path: 'PractitionerRole.location' },
-          { path: 'PractitionerRole.telecom' },
-          { path: 'PractitionerRole.telecom.system' },
-          { path: 'PractitionerRole.telecom.value' },
-          { path: 'PractitionerRole.endpoint' }
-        ]
-
-        missing_must_support_elements = must_support_elements.reject do |element|
-          truncated_path = element[:path].gsub('PractitionerRole.', '')
+        missing_must_support_elements = MUST_SUPPORTS[:elements].reject do |element|
           @practitioner_role_ary&.any? do |resource|
-            value_found = resolve_element_from_path(resource, truncated_path) { |value| element[:fixed_value].blank? || value == element[:fixed_value] }
+            value_found = resolve_element_from_path(resource, element[:path]) { |value| element[:fixed_value].blank? || value == element[:fixed_value] }
             value_found.present?
           end
         end

--- a/lib/modules/uscore_v3.1.0/us_core_procedure_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_procedure_sequence.rb
@@ -83,6 +83,25 @@ module Inferno
 
       @resources_found = false
 
+      MUST_SUPPORTS = {
+        extensions: [],
+        slices: [],
+        elements: [
+          {
+            path: 'status'
+          },
+          {
+            path: 'code'
+          },
+          {
+            path: 'subject'
+          },
+          {
+            path: 'performed'
+          }
+        ]
+      }.freeze
+
       test :search_by_patient do
         metadata do
           id '01'
@@ -421,13 +440,13 @@ module Inferno
             US Core Responders SHALL be capable of populating all data elements as part of the query results as specified by the US Core Server Capability Statement.
             This will look through all Procedure resources returned from prior searches to see if any of them provide the following must support elements:
 
-            Procedure.status
+            status
 
-            Procedure.code
+            code
 
-            Procedure.subject
+            subject
 
-            Procedure.performed[x]
+            performed[x]
 
           )
           versions :r4
@@ -435,17 +454,9 @@ module Inferno
 
         skip_if_not_found(resource_type: 'Procedure', delayed: false)
 
-        must_support_elements = [
-          { path: 'Procedure.status' },
-          { path: 'Procedure.code' },
-          { path: 'Procedure.subject' },
-          { path: 'Procedure.performed' }
-        ]
-
-        missing_must_support_elements = must_support_elements.reject do |element|
-          truncated_path = element[:path].gsub('Procedure.', '')
+        missing_must_support_elements = MUST_SUPPORTS[:elements].reject do |element|
           @procedure_ary&.values&.flatten&.any? do |resource|
-            value_found = resolve_element_from_path(resource, truncated_path) { |value| element[:fixed_value].blank? || value == element[:fixed_value] }
+            value_found = resolve_element_from_path(resource, element[:path]) { |value| element[:fixed_value].blank? || value == element[:fixed_value] }
             value_found.present?
           end
         end

--- a/lib/modules/uscore_v3.1.0/us_core_pulse_oximetry_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_pulse_oximetry_sequence.rb
@@ -88,6 +88,175 @@ module Inferno
 
       @resources_found = false
 
+      MUST_SUPPORTS = {
+        extensions: [],
+        slices: [
+          {
+            name: 'Observation.category:VSCat',
+            path: 'category',
+            discriminator: {
+              type: 'value',
+              values: [
+                {
+                  path: 'coding.code',
+                  value: 'vital-signs'
+                },
+                {
+                  path: 'coding.system',
+                  value: 'http://terminology.hl7.org/CodeSystem/observation-category'
+                }
+              ]
+            }
+          },
+          {
+            name: 'Observation.code.coding:PulseOx',
+            path: 'code.coding',
+            discriminator: {
+              type: 'value',
+              values: [
+                {
+                  path: 'code',
+                  value: '59408-5'
+                },
+                {
+                  path: 'system',
+                  value: 'http://loinc.org'
+                }
+              ]
+            }
+          },
+          {
+            name: 'Observation.value[x]:valueQuantity',
+            path: 'value',
+            discriminator: {
+              type: 'type',
+              code: 'Quantity'
+            }
+          },
+          {
+            name: 'Observation.component:FlowRate',
+            path: 'component',
+            discriminator: {
+              type: 'patternCodeableConcept',
+              path: 'code',
+              code: '3151-8',
+              system: 'http://loinc.org'
+            }
+          },
+          {
+            name: 'Observation.component:Concentration',
+            path: 'component',
+            discriminator: {
+              type: 'patternCodeableConcept',
+              path: 'code',
+              code: '3150-0',
+              system: 'http://loinc.org'
+            }
+          }
+        ],
+        elements: [
+          {
+            path: 'status'
+          },
+          {
+            path: 'category'
+          },
+          {
+            path: 'category.coding'
+          },
+          {
+            path: 'category.coding.system',
+            fixed_value: 'http://terminology.hl7.org/CodeSystem/observation-category'
+          },
+          {
+            path: 'category.coding.code',
+            fixed_value: 'vital-signs'
+          },
+          {
+            path: 'code'
+          },
+          {
+            path: 'code.coding'
+          },
+          {
+            path: 'code.coding.system',
+            fixed_value: 'http://loinc.org'
+          },
+          {
+            path: 'code.coding.code',
+            fixed_value: '59408-5'
+          },
+          {
+            path: 'subject'
+          },
+          {
+            path: 'effective'
+          },
+          {
+            path: 'value'
+          },
+          {
+            path: 'value.value'
+          },
+          {
+            path: 'value.unit'
+          },
+          {
+            path: 'value.system',
+            fixed_value: 'http://unitsofmeasure.org'
+          },
+          {
+            path: 'value.code',
+            fixed_value: '%'
+          },
+          {
+            path: 'dataAbsentReason'
+          },
+          {
+            path: 'component'
+          },
+          {
+            path: 'component.code'
+          },
+          {
+            path: 'component.code.coding.code',
+            fixed_value: '3151-8'
+          },
+          {
+            path: 'component.value.system',
+            fixed_value: 'http://unitsofmeasure.org'
+          },
+          {
+            path: 'component.value.code',
+            fixed_value: 'l/min'
+          },
+          {
+            path: 'component.code.coding.code',
+            fixed_value: '3150-0'
+          },
+          {
+            path: 'component.value'
+          },
+          {
+            path: 'component.value.value'
+          },
+          {
+            path: 'component.value.unit'
+          },
+          {
+            path: 'component.value.system',
+            fixed_value: 'http://unitsofmeasure.org'
+          },
+          {
+            path: 'component.value.code',
+            fixed_value: '%'
+          },
+          {
+            path: 'component.dataAbsentReason'
+          }
+        ]
+      }.freeze
+
       test :search_by_patient_code do
         metadata do
           id '01'
@@ -558,61 +727,63 @@ module Inferno
             US Core Responders SHALL be capable of populating all data elements as part of the query results as specified by the US Core Server Capability Statement.
             This will look through all Observation resources returned from prior searches to see if any of them provide the following must support elements:
 
-            Observation.status
+            status
 
-            Observation.category
+            category
 
-            Observation.category.coding
+            category.coding
 
-            Observation.category.coding.system
+            category.coding.system
 
-            Observation.category.coding.code
+            category.coding.code
 
-            Observation.code
+            code
 
-            Observation.code.coding
+            code.coding
 
-            Observation.code.coding.system
+            code.coding.system
 
-            Observation.code.coding.code
+            code.coding.code
 
-            Observation.subject
+            subject
 
-            Observation.effective[x]
+            effective[x]
 
-            Observation.value[x]
+            value[x]
 
-            Observation.value[x].value
+            value[x].value
 
-            Observation.value[x].unit
+            value[x].unit
 
-            Observation.value[x].system
+            value[x].system
 
-            Observation.value[x].code
+            value[x].code
 
-            Observation.dataAbsentReason
+            dataAbsentReason
 
-            Observation.component
+            component
 
-            Observation.component.code
+            component.code
 
-            Observation.component.code.coding.code
+            component.code.coding.code
 
-            Observation.component.value[x].system
+            component.value[x].system
 
-            Observation.component.value[x].code
+            component.value[x].code
 
-            Observation.component.code.coding.code
+            component.code.coding.code
 
-            Observation.component.value[x]
+            component.value[x]
 
-            Observation.component.value[x].value
+            component.value[x].value
 
-            Observation.component.value[x].unit
+            component.value[x].unit
 
-            Observation.component.value[x].code
+            component.value[x].system
 
-            Observation.component.dataAbsentReason
+            component.value[x].code
+
+            component.dataAbsentReason
 
             Observation.category:VSCat
 
@@ -630,113 +801,16 @@ module Inferno
 
         skip_if_not_found(resource_type: 'Observation', delayed: false)
 
-        must_support_slices = [
-          {
-            name: 'Observation.category:VSCat',
-            path: 'Observation.category',
-            discriminator: {
-              type: 'value',
-              values: [
-                {
-                  path: 'coding.code',
-                  value: 'vital-signs'
-                },
-                {
-                  path: 'coding.system',
-                  value: 'http://terminology.hl7.org/CodeSystem/observation-category'
-                }
-              ]
-            }
-          },
-          {
-            name: 'Observation.code.coding:PulseOx',
-            path: 'Observation.code.coding',
-            discriminator: {
-              type: 'value',
-              values: [
-                {
-                  path: 'code',
-                  value: '59408-5'
-                },
-                {
-                  path: 'system',
-                  value: 'http://loinc.org'
-                }
-              ]
-            }
-          },
-          {
-            name: 'Observation.value[x]:valueQuantity',
-            path: 'Observation.value',
-            discriminator: {
-              type: 'type',
-              code: 'Quantity'
-            }
-          },
-          {
-            name: 'Observation.component:FlowRate',
-            path: 'Observation.component',
-            discriminator: {
-              type: 'patternCodeableConcept',
-              path: 'code',
-              code: '3151-8',
-              system: 'http://loinc.org'
-            }
-          },
-          {
-            name: 'Observation.component:Concentration',
-            path: 'Observation.component',
-            discriminator: {
-              type: 'patternCodeableConcept',
-              path: 'code',
-              code: '3150-0',
-              system: 'http://loinc.org'
-            }
-          }
-        ]
-        missing_slices = must_support_slices.reject do |slice|
-          truncated_path = slice[:path].gsub('Observation.', '')
+        missing_slices = MUST_SUPPORTS[:slices].reject do |slice|
           @observation_ary&.values&.flatten&.any? do |resource|
-            slice_found = find_slice(resource, truncated_path, slice[:discriminator])
+            slice_found = find_slice(resource, slice[:path], slice[:discriminator])
             slice_found.present?
           end
         end
 
-        must_support_elements = [
-          { path: 'Observation.status' },
-          { path: 'Observation.category' },
-          { path: 'Observation.category.coding' },
-          { path: 'Observation.category.coding.system', fixed_value: 'http://terminology.hl7.org/CodeSystem/observation-category' },
-          { path: 'Observation.category.coding.code', fixed_value: 'vital-signs' },
-          { path: 'Observation.code' },
-          { path: 'Observation.code.coding' },
-          { path: 'Observation.code.coding.system', fixed_value: 'http://loinc.org' },
-          { path: 'Observation.code.coding.code', fixed_value: '59408-5' },
-          { path: 'Observation.subject' },
-          { path: 'Observation.effective' },
-          { path: 'Observation.value' },
-          { path: 'Observation.value.value' },
-          { path: 'Observation.value.unit' },
-          { path: 'Observation.value.system', fixed_value: 'http://unitsofmeasure.org' },
-          { path: 'Observation.value.code', fixed_value: '%' },
-          { path: 'Observation.dataAbsentReason' },
-          { path: 'Observation.component' },
-          { path: 'Observation.component.code' },
-          { path: 'Observation.component.code.coding.code', fixed_value: '3151-8' },
-          { path: 'Observation.component.value.system', fixed_value: 'http://unitsofmeasure.org' },
-          { path: 'Observation.component.value.code', fixed_value: 'l/min' },
-          { path: 'Observation.component.code.coding.code', fixed_value: '3150-0' },
-          { path: 'Observation.component.value' },
-          { path: 'Observation.component.value.value' },
-          { path: 'Observation.component.value.unit' },
-          { path: 'Observation.component.value.code', fixed_value: '%' },
-          { path: 'Observation.component.dataAbsentReason' }
-        ]
-
-        missing_must_support_elements = must_support_elements.reject do |element|
-          truncated_path = element[:path].gsub('Observation.', '')
+        missing_must_support_elements = MUST_SUPPORTS[:elements].reject do |element|
           @observation_ary&.values&.flatten&.any? do |resource|
-            value_found = resolve_element_from_path(resource, truncated_path) { |value| element[:fixed_value].blank? || value == element[:fixed_value] }
+            value_found = resolve_element_from_path(resource, element[:path]) { |value| element[:fixed_value].blank? || value == element[:fixed_value] }
             value_found.present?
           end
         end


### PR DESCRIPTION
This adds must support testing capabilities to the bulk data test. It will loop through all the resources returned for a given resource and look for the associated must support elements. 

**Submitter:**
- [X] This pull request describes why these changes were made
- [X] Internal ticket for this PR: https://oncprojectracking.healthit.gov/support/browse/FI-650
- [X] Internal ticket links to this PR
- [X] Internal ticket is properly labeled (Community/Program)
- [X] Internal ticket has a justification for its Community/Program label
- [X] Code diff has been reviewed for extraneous/missing code
- [X] Tests are included and test edge cases
- [X] Tests/code quality metrics have been run locally and pass


**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
