### PR TITLE
fi-721 replace instances of class with local_class in terminology validation

### DIFF
--- a/generator/uscore/uscore_generator.rb
+++ b/generator/uscore/uscore_generator.rb
@@ -538,8 +538,7 @@ module Inferno
           # class is mapped to local_class in fhir_models. Update this after it
           # has been added to the description so that the description contains
           # the original path
-          element[:path] = 'local_class' if element[:path] == 'class'
-          element[:path] = element[:path].gsub('.class', '.local_class')
+          element[:path] = element[:path].gsub(/(?<!\w)class(?!\w)/, 'local_class')
         end
 
         must_support_extensions = sequence[:must_supports][:extensions]
@@ -682,8 +681,7 @@ module Inferno
           .select { |binding_def| ['required', 'extensible'].include? binding_def[:strength] }
 
         bindings.each do |binding|
-          binding[:path].gsub!('.class', '.local_class')
-          binding[:path] = 'local_class' if binding[:path] == 'class'
+          binding[:path].gsub!(/(?<!\w)class(?!\w)/, 'local_class')
         end
         resources_ary_str = sequence[:delayed_sequence] ? "@#{sequence[:resource].underscore}_ary" : "@#{sequence[:resource].underscore}_ary&.values&.flatten"
         if bindings.present?
@@ -841,7 +839,7 @@ module Inferno
       end
 
       def resolve_element_path(search_param_description, delayed_sequence)
-        element_path = search_param_description[:path].gsub('.class', '.local_class') # match fhir_models because class is protected keyword in ruby
+        element_path = search_param_description[:path].gsub(/(?<!\w)class(?!\w)/, 'local_class')
         path_parts = element_path.split('.')
         resource_val = delayed_sequence ? "@#{path_parts.shift.underscore}_ary" : "@#{path_parts.shift.underscore}_ary[patient]"
         "resolve_element_from_path(#{resource_val}, '#{path_parts.join('.')}')"

--- a/generator/uscore/uscore_generator.rb
+++ b/generator/uscore/uscore_generator.rb
@@ -681,6 +681,10 @@ module Inferno
         bindings = sequence[:bindings]
           .select { |binding_def| ['required', 'extensible'].include? binding_def[:strength] }
 
+        bindings.each do |binding|
+          binding[:path].gsub!('.class', '.local_class')
+          binding[:path] = 'local_class' if binding[:path] == 'class'
+        end
         resources_ary_str = sequence[:delayed_sequence] ? "@#{sequence[:resource].underscore}_ary" : "@#{sequence[:resource].underscore}_ary&.values&.flatten"
         if bindings.present?
           test[:test_code] += %(

--- a/lib/modules/uscore_v3.1.0/us_core_encounter_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_encounter_sequence.rb
@@ -570,13 +570,13 @@ module Inferno
             type: 'Coding',
             strength: 'extensible',
             system: 'http://terminology.hl7.org/ValueSet/v3-ActEncounterCode',
-            path: 'class'
+            path: 'local_class'
           },
           {
             type: 'Coding',
             strength: 'extensible',
             system: 'http://terminology.hl7.org/ValueSet/v3-ActEncounterCode',
-            path: 'classHistory.class'
+            path: 'classHistory.local_class'
           },
           {
             type: 'CodeableConcept',


### PR DESCRIPTION
This fixes an error when running the encounter sequence. Now it should pass without any errors.

**Submitter:**
- [X] This pull request describes why these changes were made
- [X] Internal ticket for this PR: https://oncprojectracking.healthit.gov/support/browse/FI-721
- [X] Internal ticket links to this PR
- [X] Internal ticket is properly labeled (Community/Program)
- [X] Internal ticket has a justification for its Community/Program label
- [X] Code diff has been reviewed for extraneous/missing code
- [X] Tests are included and test edge cases
- [X] Tests/code quality metrics have been run locally and pass


**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
