### PR TITLE
FI-731: Disable TLS on bulk data streaming client if necessary.

### DIFF
--- a/lib/modules/onc_program/bulk_data_group_validation_sequence.rb
+++ b/lib/modules/onc_program/bulk_data_group_validation_sequence.rb
@@ -154,7 +154,9 @@ module Inferno
       end
 
       def streamed_ndjson_get(url, headers)
-        response = HTTP.headers(headers).get(url)
+        ctx = OpenSSL::SSL::SSLContext.new
+        ctx.verify_mode = OpenSSL::SSL::VERIFY_PEER # set globally to VERIFY_NONE if disable_verify_peer set
+        response = HTTP.headers(headers).get(url, ssl_context: ctx)
 
         # We need to log the request, but don't know what will be in the body
         # until later.  These serve as simple summaries to get turned into


### PR DESCRIPTION
Disables TLS peer validation for the bulk streaming client. Please check both inside and outside a protected (e.g. MITRE) network when reviewing, in both true/false configs for disable_verify_peer (4 cases).

**Submitter:**
- [x] This pull request describes why these changes were made
- [x] Internal ticket for this PR: fi-731
- [x] Internal ticket links to this PR
- [x] Internal ticket is properly labeled (Community/Program)
- [x] Internal ticket has a justification for its Community/Program label
- [x] Code diff has been reviewed for extraneous/missing code
- [ ] Tests are included and test edge cases
- [ ] Tests/code quality metrics have been run locally and pass


**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
