### PR TITLE
Add rake task to expand single ValueSet and save it to a file

### DIFF
--- a/lib/app/utils/valueset.rb
+++ b/lib/app/utils/valueset.rb
@@ -84,9 +84,9 @@ module Inferno
 
       def expansion_as_fhir_valueset
         expansion_backbone = FHIR::ValueSet::Expansion.new
-        expansion_backbone.timestamp = DateTime.now.strftime("%Y-%m-%dT%H:%M:%S%:z")
+        expansion_backbone.timestamp = DateTime.now.strftime('%Y-%m-%dT%H:%M:%S%:z')
         expansion_backbone.contains = valueset.map do |code|
-          FHIR::ValueSet::Expansion::Contains.new({system: code[:system], code: code[:code]})
+          FHIR::ValueSet::Expansion::Contains.new({ system: code[:system], code: code[:code] })
         end
         expansion_backbone.total = expansion_backbone.contains.length
         expansion_valueset = @valueset_model.deep_dup # Make a copy so that the original definition is left intact

--- a/lib/app/utils/valueset.rb
+++ b/lib/app/utils/valueset.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'sqlite3'
+require 'date'
 require_relative 'bcp_13'
 require_relative 'bcp47'
 require_relative 'codesystem'
@@ -79,6 +80,18 @@ module Inferno
 
       def code_system_set(code_system)
         filter_code_set(code_system)
+      end
+
+      def expansion_as_fhir_valueset
+        expansion_backbone = FHIR::ValueSet::Expansion.new
+        expansion_backbone.timestamp = DateTime.now.strftime("%Y-%m-%dT%H:%M:%S%:z")
+        expansion_backbone.contains = valueset.map do |code|
+          FHIR::ValueSet::Expansion::Contains.new({system: code[:system], code: code[:code]})
+        end
+        expansion_backbone.total = expansion_backbone.contains.length
+        expansion_valueset = @valueset_model.deep_dup # Make a copy so that the original definition is left intact
+        expansion_valueset.expansion = expansion_backbone
+        expansion_valueset
       end
 
       # Return the url of the valueset

--- a/lib/tasks/tasks.rake
+++ b/lib/tasks/tasks.rake
@@ -843,6 +843,14 @@ namespace :terminology do |_argv|
     puts vs&.valueset&.count
   end
 
+  desc 'Expand and Save ValueSet to a file'
+  task :expand_valueset_to_file, [:vs, :filename, :type] do |_t, args|
+    Inferno::Terminology.register_umls_db File.join(TEMP_DIR, 'umls.db')
+    Inferno::Terminology.load_valuesets_from_directory(Inferno::Terminology::PACKAGE_DIR, true)
+    vs = Inferno::Terminology.known_valuesets[args.vs]
+    Inferno::Terminology.save_to_file(vs.valueset, args.filename, args.type.to_sym)
+  end
+
   desc 'Download FHIR Package'
   task :download_package, [:package, :location] do |_t, args|
     Inferno::FHIRPackageManager.get_package(args.package, args.location)

--- a/lib/tasks/tasks.rake
+++ b/lib/tasks/tasks.rake
@@ -848,7 +848,11 @@ namespace :terminology do |_argv|
     Inferno::Terminology.register_umls_db File.join(TEMP_DIR, 'umls.db')
     Inferno::Terminology.load_valuesets_from_directory(Inferno::Terminology::PACKAGE_DIR, true)
     vs = Inferno::Terminology.known_valuesets[args.vs]
-    Inferno::Terminology.save_to_file(vs.valueset, args.filename, args.type.to_sym)
+    if args.type == 'json'
+      File.open("#{args.filename}.json", 'wb') { |f| f << vs.expansion_as_fhir_valueset.to_json }
+    else
+      Inferno::Terminology.save_to_file(vs.valueset, args.filename, args.type.to_sym)
+    end
   end
 
   desc 'Download FHIR Package'


### PR DESCRIPTION
This PR does not have an internal ticket because it was done to allow another project to expand ValueSets individually to a CSV for another IG.

To test run:

```shell
be rake 'terminology:expand_valueset_to_file[http://hl7.org/fhir/us/core/ValueSet/birthsex, birthsex_expansion, csv]
```
You can also do this with any new ValueSet by putting that ValueSet into `tmp/terminology/fhir` (any file name that ends with `.json` should do the trick).

This also adds the ability to export the codes as a FHIR ValueSet using the expansion field.  This can be observed by setting type type to `json`

e.g.

```shell
be rake 'terminology:expand_valueset_to_file[http://hl7.org/fhir/us/core/ValueSet/birthsex, birthsex_expansion, json]
```

*Note: you'll need to have all the terminology artifacts present to run this (UMLS, etc.).*

I can update the [Terminology Wiki](https://github.com/onc-healthit/inferno/wiki/Installing-Terminology-Validators) with this as well if we decide to keep it.

Pull requests into Inferno require the following items to be completed. Submitter and reviewer 
should check the relevant check boxes when the associated item is done. For items that are not 
applicable, note it's not applicable ("N/A") and check the box. For example, external Pull 
Requests do not require ticket links.

**Submitter:**
- [ ] This pull request describes why these changes were made
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Internal ticket is properly labeled (Community/Program)
- [ ] Internal ticket has a justification for its Community/Program label
- [ ] Code diff has been reviewed for extraneous/missing code
- [ ] Tests are included and test edge cases
- [ ] Tests/code quality metrics have been run locally and pass


**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
