### PR TITLE
Rename Valueset to ValueSet to comply with naming conventions

### DIFF
--- a/lib/app/utils/bcp47.rb
+++ b/lib/app/utils/bcp47.rb
@@ -66,7 +66,7 @@ module Inferno
         meets_criteria = true
         if filter.op == 'exists'
           filter_value = string_to_boolean(filter.value)
-          throw Terminology::Valueset::FilterOperationException(filter.to_s) if filter_value.nil?
+          throw Terminology::ValueSet::FilterOperationException(filter.to_s) if filter_value.nil?
           if filter.property == 'ext-lang'
             meets_criteria = (language['Type'] == 'extlang') == filter_value
           elsif filter.property == 'script'
@@ -78,10 +78,10 @@ module Inferno
           elsif filter.property == 'private-use'
             meets_criteria = (language['Scope'] == 'private-use') == filter_value
           else
-            throw Terminology::Valueset::FilterOperationException(filter.to_s)
+            throw Terminology::ValueSet::FilterOperationException(filter.to_s)
           end
         else
-          throw Terminology::Valueset::FilterOperationException(filter.op)
+          throw Terminology::ValueSet::FilterOperationException(filter.op)
         end
         meets_criteria
       end

--- a/lib/app/utils/codesystem.rb
+++ b/lib/app/utils/codesystem.rb
@@ -43,7 +43,7 @@ module Inferno
           parent_concept = find_concept(filter.value)
           cs_set = all_codes_in_concept([parent_concept])
         else
-          throw Inferno::Terminology::Valueset::FilterOperationException(filter.to_s)
+          throw Inferno::Terminology::ValueSet::FilterOperationException(filter.to_s)
         end
         cs_set
       end

--- a/lib/app/utils/terminology.rb
+++ b/lib/app/utils/terminology.rb
@@ -64,7 +64,7 @@ module Inferno
     def self.create_validators(type: :bloom, selected_module: :all, minimum_binding_strength: 'example', include_umls: true)
       strengths = ['example', 'preferred', 'extensible', 'required'].drop_while { |s| s != minimum_binding_strength }
       validators = []
-      umls_code_systems = Set.new(Inferno::Terminology::Valueset::SAB.keys)
+      umls_code_systems = Set.new(Inferno::Terminology::ValueSet::SAB.keys)
       root_dir = "resources/terminology/validators/#{type}"
       FileUtils.mkdir_p(root_dir)
 
@@ -77,14 +77,14 @@ module Inferno
         begin
           save_to_file(vs.valueset, filename, type)
           validators << { url: k, file: name_by_type(File.basename(filename), type), count: vs.count, type: type.to_s, code_systems: vs.included_code_systems }
-        rescue Valueset::UnknownCodeSystemException, Valueset::FilterOperationException, UnknownValueSetException, URI::InvalidURIError => e
+        rescue ValueSet::UnknownCodeSystemException, ValueSet::FilterOperationException, UnknownValueSetException, URI::InvalidURIError => e
           Inferno.logger.warn "#{e.message} for ValueSet: #{k}"
           next
         end
       end
 
       code_systems = validators.flat_map { |vs| vs[:code_systems] }.uniq
-      vs = Inferno::Terminology::Valueset.new(@db)
+      vs = Inferno::Terminology::ValueSet.new(@db)
 
       code_systems.each do |cs_name|
         next if SKIP_SYS.include? cs_name
@@ -96,7 +96,7 @@ module Inferno
           filename = "#{root_dir}/#{bloom_file_name(cs_name)}"
           save_to_file(cs, filename, type)
           validators << { url: cs_name, file: name_by_type(File.basename(filename), type), count: cs.length, type: type.to_s, code_systems: cs_name }
-        rescue Valueset::UnknownCodeSystemException, Valueset::FilterOperationException, UnknownValueSetException, URI::InvalidURIError => e
+        rescue ValueSet::UnknownCodeSystemException, ValueSet::FilterOperationException, UnknownValueSetException, URI::InvalidURIError => e
           Inferno.logger.warn "#{e.message} for CodeSystem #{cs_name}"
           next
         end
@@ -177,7 +177,7 @@ module Inferno
     end
 
     def self.add_valueset_from_file(vs_file)
-      vs = Inferno::Terminology::Valueset.new(@db)
+      vs = Inferno::Terminology::ValueSet.new(@db)
       vs.read_valueset(vs_file)
       vs.vsa = self
       @known_valuesets[vs.url] = vs

--- a/lib/app/utils/valueset.rb
+++ b/lib/app/utils/valueset.rb
@@ -8,9 +8,9 @@ require_relative 'fhir_package_manager'
 
 module Inferno
   class Terminology
-    class Valueset
-      # STU3 Valuesets located at: http://hl7.org/fhir/stu3/terminologies-valuesets.html
-      # STU3 Valueset Resource: http://hl7.org/fhir/stu3/valueset.html
+    class ValueSet
+      # STU3 ValueSets located at: http://hl7.org/fhir/stu3/terminologies-valuesets.html
+      # STU3 ValueSet Resource: http://hl7.org/fhir/stu3/valueset.html
       #
       # snomed in umls: https://www.nlm.nih.gov/research/umls/Snomed/snomed_represented.html
 
@@ -103,7 +103,7 @@ module Inferno
         if @valueset_model&.expansion&.contains
           # This is moved into a nested clause so we can tell in the debug statements which path we're taking
           if valueset_toocostly || valueset_unclosed
-            Inferno.logger.debug("Valueset too costly or unclosed: #{url}")
+            Inferno.logger.debug("ValueSet too costly or unclosed: #{url}")
             process_valueset
           else
             Inferno.logger.debug("Processing expanded valueset: #{url}")
@@ -204,7 +204,7 @@ module Inferno
       #
       # See: http://hl7.org/fhir/stu3/valueset.html#compositions
       #
-      # @param [ValueSet::Compose::Include] vscs the FHIR Valueset include or exclude
+      # @param [ValueSet::Compose::Include] vscs the FHIR ValueSet include or exclude
       def get_code_sets(vscs)
         intersection_set = nil
 

--- a/test/unit/valueset_test.rb
+++ b/test/unit/valueset_test.rb
@@ -59,13 +59,13 @@ class ValueSetTest < Minitest::Test
   end
 
   def test_get_medication_codes_valueset
-    vs = Inferno::Terminology::Valueset.new(@db)
+    vs = Inferno::Terminology::ValueSet.new(@db)
     vs.read_valueset('resources/argonauts/ValueSet-medication-codes.json')
     assert vs.valueset.length == 8, 'Expected 8 concepts'
   end
 
   def test_medication_codes_bloom_filter
-    vs = Inferno::Terminology::Valueset.new(@db)
+    vs = Inferno::Terminology::ValueSet.new(@db)
     vs.read_valueset('resources/argonauts/ValueSet-medication-codes.json')
     bf = vs.generate_bloom
     assert bf.count == 8, 'Expected 8 entries in the filter'


### PR DESCRIPTION
The `Valueset` class was a uniquely-named class in that it didn't follow CamelCase convention. This PR renames it to `ValueSet`

﻿Pull requests into Inferno require the following items to be completed. Submitter and reviewer 
should check the relevant check boxes when the associated item is done. For items that are not 
applicable, note it's not applicable ("N/A") and check the box. For example, external Pull 
Requests do not require ticket links.

**Submitter:**
- [x] This pull request describes why these changes were made
- N/A Internal ticket for this PR:
- N/A Internal ticket links to this PR
- N/A Internal ticket is properly labeled (Community/Program)
- N/A Internal ticket has a justification for its Community/Program label
- [x] Code diff has been reviewed for extraneous/missing code
- N/A Tests are included and test edge cases
- [x] Tests/code quality metrics have been run locally and pass


**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
