### PR TITLE
fi-738 save only us core delayed references

### DIFF
--- a/generator/uscore/metadata_extractor.rb
+++ b/generator/uscore/metadata_extractor.rb
@@ -80,7 +80,7 @@ module Inferno
           operations: [],
           searches: [],
           search_param_descriptions: {},
-          element_descriptions: {},
+          references: [],
           must_supports: {
             extensions: [],
             slices: [],
@@ -113,7 +113,7 @@ module Inferno
             add_must_support_elements(profile_definition, new_sequence)
             add_terminology_bindings(profile_definition, new_sequence)
             add_search_param_descriptions(profile_definition, new_sequence)
-            add_element_definitions(profile_definition, new_sequence)
+            add_references(profile_definition, new_sequence)
 
             metadata[:sequences] << new_sequence
           end
@@ -440,18 +440,13 @@ module Inferno
         param_metadata[:values] = fhir_metadata['valid_codes'].values.flatten if use_valid_codes
       end
 
-      def add_element_definitions(profile_definition, sequence)
-        profile_definition['snapshot']['element'].each do |element|
-          next if element['type'].nil? # base profile
-
-          path = element['id']
-          if path.include? '[x]'
-            element['type'].each do |type|
-              sequence[:element_descriptions][path.gsub('[x]', type['code']).downcase.to_sym] = { type: type['code'], contains_multiple: element['max'] == '*' }
-            end
-          else
-            sequence[:element_descriptions][path.downcase.to_sym] = { type: element['type'].first['code'], contains_multiple: element['max'] == '*' }
-          end
+      def add_references(profile_definition, sequence)
+        references = profile_definition['snapshot']['element'].select { |el| el['type'].present? && el['type'].first['code'] == 'Reference' }
+        sequence[:references] = references.map do |ref_def|
+          {
+            path: ref_def['path'],
+            profiles: ref_def['type'].first['targetProfile']
+          }
         end
       end
 

--- a/generator/uscore/templates/sequence.rb.erb
+++ b/generator/uscore/templates/sequence.rb.erb
@@ -1,11 +1,13 @@
 # frozen_string_literal: true
 
 require_relative './data_absent_reason_checker'
+require_relative './profile_definitions/<%=name.downcase%>_definitions'
 
 module Inferno
   module Sequence
     class <%=class_name%> < SequenceBase
-      include Inferno::DataAbsentReasonChecker
+      include Inferno::DataAbsentReasonChecker  
+      include Inferno::USCore310ProfileDefinitions
 
       title '<%=title%>'
 
@@ -26,7 +28,6 @@ module Inferno
       end
 
       @resources_found = false
-      <%=must_support_constants%>
       <% tests.each do |test|%>
 
 

--- a/generator/uscore/templates/sequence_definition.rb.erb
+++ b/generator/uscore/templates/sequence_definition.rb.erb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+module Inferno
+  module USCore310ProfileDefinitions
+    class <%=class_name%>Definitions
+      <%=must_support_constants%>
+      <%=delayed_references_constant%>
+    end
+  end
+end

--- a/lib/modules/onc_program/bulk_data_group_validation_sequence.rb
+++ b/lib/modules/onc_program/bulk_data_group_validation_sequence.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'http' # for streaming http client
+Dir['lib/modules/uscore_v3.1.0/profile_definitions/*'].sort.each { |file| require './' + file }
 
 module Inferno
   module Sequence
@@ -21,6 +22,7 @@ module Inferno
       MIN_RESOURCE_COUNT = 2
 
       US_CORE_R4_URIS = Inferno::ValidationUtil::US_CORE_R4_URIS
+      include Inferno::USCore310ProfileDefinitions
 
       def initialize(instance, client, disable_tls_tests = false, sequence_result = nil)
         super(instance, client, disable_tls_tests, sequence_result)
@@ -282,7 +284,7 @@ module Inferno
         must_supports = [
           {
             profile: nil,
-            must_support_info: Inferno::Sequence::USCore310PatientSequence::MUST_SUPPORTS.dup
+            must_support_info: USCore310PatientSequenceDefinitions::MUST_SUPPORTS.dup
           }
         ]
         test_output_against_profile('Patient', must_supports)
@@ -334,7 +336,7 @@ module Inferno
         must_supports = [
           {
             profile: nil,
-            must_support_info: Inferno::Sequence::USCore310AllergyintoleranceSequence::MUST_SUPPORTS.dup
+            must_support_info: USCore310AllergyintoleranceSequenceDefinitions::MUST_SUPPORTS.dup
           }
         ]
         test_output_against_profile('AllergyIntolerance', must_supports)
@@ -353,7 +355,7 @@ module Inferno
         must_supports = [
           {
             profile: nil,
-            must_support_info: Inferno::Sequence::USCore310CareplanSequence::MUST_SUPPORTS.dup
+            must_support_info: USCore310CareplanSequenceDefinitions::MUST_SUPPORTS.dup
           }
         ]
         test_output_against_profile('CarePlan', must_supports)
@@ -372,7 +374,7 @@ module Inferno
         must_supports = [
           {
             profile: nil,
-            must_support_info: Inferno::Sequence::USCore310CareteamSequence::MUST_SUPPORTS.dup
+            must_support_info: USCore310CareteamSequenceDefinitions::MUST_SUPPORTS.dup
           }
         ]
         test_output_against_profile('CareTeam', must_supports)
@@ -391,7 +393,7 @@ module Inferno
         must_supports = [
           {
             profile: nil,
-            must_support_info: Inferno::Sequence::USCore310ConditionSequence::MUST_SUPPORTS.dup
+            must_support_info: USCore310ConditionSequenceDefinitions::MUST_SUPPORTS.dup
           }
         ]
         test_output_against_profile('Condition', must_supports)
@@ -426,11 +428,11 @@ module Inferno
         must_supports = [
           {
             profile: US_CORE_R4_URIS[:diagnostic_report_lab],
-            must_support_info: Inferno::Sequence::USCore310DiagnosticreportLabSequence::MUST_SUPPORTS.dup
+            must_support_info: USCore310DiagnosticreportLabSequenceDefinitions::MUST_SUPPORTS.dup
           },
           {
             profile: US_CORE_R4_URIS[:diagnostic_report_note],
-            must_support_info: Inferno::Sequence::USCore310DiagnosticreportNoteSequence::MUST_SUPPORTS.dup
+            must_support_info: USCore310DiagnosticreportNoteSequenceDefinitions::MUST_SUPPORTS.dup
           }
         ]
         test_output_against_profile('DiagnosticReport', must_supports)
@@ -449,7 +451,7 @@ module Inferno
         must_supports = [
           {
             profile: nil,
-            must_support_info: Inferno::Sequence::USCore310DocumentreferenceSequence::MUST_SUPPORTS.dup
+            must_support_info: USCore310DocumentreferenceSequenceDefinitions::MUST_SUPPORTS.dup
           }
         ]
         test_output_against_profile('DocumentReference', must_supports)
@@ -468,7 +470,7 @@ module Inferno
         must_supports = [
           {
             profile: nil,
-            must_support_info: Inferno::Sequence::USCore310EncounterSequence::MUST_SUPPORTS.dup
+            must_support_info: USCore310EncounterSequenceDefinitions::MUST_SUPPORTS.dup
           }
         ]
         test_output_against_profile('Encounter', must_supports)
@@ -487,7 +489,7 @@ module Inferno
         must_supports = [
           {
             profile: nil,
-            must_support_info: Inferno::Sequence::USCore310GoalSequence::MUST_SUPPORTS.dup
+            must_support_info: USCore310GoalSequenceDefinitions::MUST_SUPPORTS.dup
           }
         ]
         test_output_against_profile('Goal', must_supports)
@@ -506,7 +508,7 @@ module Inferno
         must_supports = [
           {
             profile: nil,
-            must_support_info: Inferno::Sequence::USCore310ImmunizationSequence::MUST_SUPPORTS.dup
+            must_support_info: USCore310ImmunizationSequenceDefinitions::MUST_SUPPORTS.dup
           }
         ]
         test_output_against_profile('Immunization', must_supports)
@@ -525,7 +527,7 @@ module Inferno
         must_supports = [
           {
             profile: nil,
-            must_support_info: Inferno::Sequence::USCore310MedicationrequestSequence::MUST_SUPPORTS.dup
+            must_support_info: USCore310MedicationrequestSequenceDefinitions::MUST_SUPPORTS.dup
           }
         ]
         test_output_against_profile('MedicationRequest', must_supports)
@@ -550,23 +552,23 @@ module Inferno
         must_supports = [
           {
             profile: US_CORE_R4_URIS[:pediatric_bmi_age],
-            must_support_info: Inferno::Sequence::USCore310PediatricBmiForAgeSequence::MUST_SUPPORTS.dup
+            must_support_info: USCore310PediatricBmiForAgeSequenceDefinitions::MUST_SUPPORTS.dup
           },
           {
             profile: US_CORE_R4_URIS[:pediatric_weight_height],
-            must_support_info: Inferno::Sequence::USCore310PediatricWeightForHeightSequence::MUST_SUPPORTS.dup
+            must_support_info: USCore310PediatricWeightForHeightSequenceDefinitions::MUST_SUPPORTS.dup
           },
           {
             profile: US_CORE_R4_URIS[:USCore310PulseOximetrySequence],
-            must_support_info: Inferno::Sequence::USCore310PulseOximetrySequence::MUST_SUPPORTS.dup
+            must_support_info: USCore310PulseOximetrySequenceDefinitions::MUST_SUPPORTS.dup
           },
           {
             profile: US_CORE_R4_URIS[:lab_results],
-            must_support_info: Inferno::Sequence::USCore310ObservationLabSequence::MUST_SUPPORTS.dup
+            must_support_info: USCore310ObservationLabSequenceDefinitions::MUST_SUPPORTS.dup
           },
           {
             profile: US_CORE_R4_URIS[:smoking_status],
-            must_support_info: Inferno::Sequence::USCore310SmokingstatusSequence::MUST_SUPPORTS.dup
+            must_support_info: USCore310SmokingstatusSequenceDefinitions::MUST_SUPPORTS.dup
           }
         ]
 
@@ -586,7 +588,7 @@ module Inferno
         must_supports = [
           {
             profile: nil,
-            must_support_info: Inferno::Sequence::USCore310ProcedureSequence::MUST_SUPPORTS.dup
+            must_support_info: USCore310ProcedureSequenceDefinitions::MUST_SUPPORTS.dup
           }
         ]
         test_output_against_profile('Procedure', must_supports)
@@ -602,7 +604,13 @@ module Inferno
           )
         end
 
-        test_output_against_profile('Location')
+        must_supports = [
+          {
+            profile: nil,
+            must_support_info: USCore310LocationSequenceDefinitions::MUST_SUPPORTS.dup
+          }
+        ]
+        test_output_against_profile('Location', must_supports)
       end
 
       test :validate_medication do
@@ -631,7 +639,7 @@ module Inferno
         must_supports = [
           {
             profile: nil,
-            must_support_info: Inferno::Sequence::USCore310OrganizationSequence::MUST_SUPPORTS.dup
+            must_support_info: USCore310OrganizationSequenceDefinitions::MUST_SUPPORTS.dup
           }
         ]
         test_output_against_profile('Organization', must_supports)
@@ -650,7 +658,7 @@ module Inferno
         must_supports = [
           {
             profile: nil,
-            must_support_info: Inferno::Sequence::USCore310PractitionerSequence::MUST_SUPPORTS.dup
+            must_support_info: USCore310PractitionerSequenceDefinitions::MUST_SUPPORTS.dup
           }
         ]
         test_output_against_profile('Practitioner', must_supports)
@@ -666,7 +674,13 @@ module Inferno
           )
         end
 
-        test_output_against_profile('PractitionerRole')
+        must_supports = [
+          {
+            profile: nil,
+            must_support_info: USCore310PractitionerroleSequenceDefinitions::MUST_SUPPORTS.dup
+          }
+        ]
+        test_output_against_profile('PractitionerRole', must_supports)
       end
     end
   end

--- a/lib/modules/uscore_v3.1.0/bodyheight_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/bodyheight_sequence.rb
@@ -1,11 +1,13 @@
 # frozen_string_literal: true
 
 require_relative './data_absent_reason_checker'
+require_relative './profile_definitions/bodyheight_definitions'
 
 module Inferno
   module Sequence
     class USCore310BodyheightSequence < SequenceBase
       include Inferno::DataAbsentReasonChecker
+      include Inferno::USCore310ProfileDefinitions
 
       title 'Observation Body Height'
 
@@ -88,84 +90,6 @@ module Inferno
 
       @resources_found = false
 
-      MUST_SUPPORTS = {
-        extensions: [],
-        slices: [
-          {
-            name: 'Observation.category:VSCat',
-            path: 'category',
-            discriminator: {
-              type: 'value',
-              values: [
-                {
-                  path: 'coding.code',
-                  value: 'vital-signs'
-                },
-                {
-                  path: 'coding.system',
-                  value: 'http://terminology.hl7.org/CodeSystem/observation-category'
-                }
-              ]
-            }
-          },
-          {
-            name: 'Observation.value[x]:valueQuantity',
-            path: 'value',
-            discriminator: {
-              type: 'type',
-              code: 'Quantity'
-            }
-          }
-        ],
-        elements: [
-          {
-            path: 'status'
-          },
-          {
-            path: 'category'
-          },
-          {
-            path: 'category.coding'
-          },
-          {
-            path: 'category.coding.system',
-            fixed_value: 'http://terminology.hl7.org/CodeSystem/observation-category'
-          },
-          {
-            path: 'category.coding.code',
-            fixed_value: 'vital-signs'
-          },
-          {
-            path: 'code'
-          },
-          {
-            path: 'subject'
-          },
-          {
-            path: 'effective'
-          },
-          {
-            path: 'value'
-          },
-          {
-            path: 'value.value'
-          },
-          {
-            path: 'value.unit'
-          },
-          {
-            path: 'value.system',
-            fixed_value: 'http://unitsofmeasure.org'
-          },
-          {
-            path: 'value.code'
-          },
-          {
-            path: 'dataAbsentReason'
-          }
-        ]
-      }.freeze
-
       test :search_by_patient_code do
         metadata do
           id '01'
@@ -203,7 +127,7 @@ module Inferno
             @observation_ary[patient] += resources_returned
 
             save_resource_references(versioned_resource_class('Observation'), @observation_ary[patient], Inferno::ValidationUtil::US_CORE_R4_URIS[:body_height])
-            save_delayed_sequence_references(resources_returned)
+            save_delayed_sequence_references(resources_returned, USCore310BodyheightSequenceDefinitions::DELAYED_REFERENCES)
             validate_reply_entries(resources_returned, search_params)
 
             break
@@ -473,7 +397,7 @@ module Inferno
             .select { |resource| resource.resourceType == 'Provenance' }
         end
         save_resource_references(versioned_resource_class('Provenance'), provenance_results)
-        save_delayed_sequence_references(provenance_results)
+        save_delayed_sequence_references(provenance_results, USCore310BodyheightSequenceDefinitions::DELAYED_REFERENCES)
         skip 'Could not resolve all parameters (patient, code) in any resource.' unless resolved_one
         skip 'No Provenance resources were returned from this search' unless provenance_results.present?
       end
@@ -643,15 +567,16 @@ module Inferno
         end
 
         skip_if_not_found(resource_type: 'Observation', delayed: false)
+        must_supports = USCore310BodyheightSequenceDefinitions::MUST_SUPPORTS
 
-        missing_slices = MUST_SUPPORTS[:slices].reject do |slice|
+        missing_slices = must_supports[:slices].reject do |slice|
           @observation_ary&.values&.flatten&.any? do |resource|
             slice_found = find_slice(resource, slice[:path], slice[:discriminator])
             slice_found.present?
           end
         end
 
-        missing_must_support_elements = MUST_SUPPORTS[:elements].reject do |element|
+        missing_must_support_elements = must_supports[:elements].reject do |element|
           @observation_ary&.values&.flatten&.any? do |resource|
             value_found = resolve_element_from_path(resource, element[:path]) { |value| element[:fixed_value].blank? || value == element[:fixed_value] }
             value_found.present?

--- a/lib/modules/uscore_v3.1.0/bodytemp_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/bodytemp_sequence.rb
@@ -1,11 +1,13 @@
 # frozen_string_literal: true
 
 require_relative './data_absent_reason_checker'
+require_relative './profile_definitions/bodytemp_definitions'
 
 module Inferno
   module Sequence
     class USCore310BodytempSequence < SequenceBase
       include Inferno::DataAbsentReasonChecker
+      include Inferno::USCore310ProfileDefinitions
 
       title 'Observation Body Temperature'
 
@@ -88,84 +90,6 @@ module Inferno
 
       @resources_found = false
 
-      MUST_SUPPORTS = {
-        extensions: [],
-        slices: [
-          {
-            name: 'Observation.category:VSCat',
-            path: 'category',
-            discriminator: {
-              type: 'value',
-              values: [
-                {
-                  path: 'coding.code',
-                  value: 'vital-signs'
-                },
-                {
-                  path: 'coding.system',
-                  value: 'http://terminology.hl7.org/CodeSystem/observation-category'
-                }
-              ]
-            }
-          },
-          {
-            name: 'Observation.value[x]:valueQuantity',
-            path: 'value',
-            discriminator: {
-              type: 'type',
-              code: 'Quantity'
-            }
-          }
-        ],
-        elements: [
-          {
-            path: 'status'
-          },
-          {
-            path: 'category'
-          },
-          {
-            path: 'category.coding'
-          },
-          {
-            path: 'category.coding.system',
-            fixed_value: 'http://terminology.hl7.org/CodeSystem/observation-category'
-          },
-          {
-            path: 'category.coding.code',
-            fixed_value: 'vital-signs'
-          },
-          {
-            path: 'code'
-          },
-          {
-            path: 'subject'
-          },
-          {
-            path: 'effective'
-          },
-          {
-            path: 'value'
-          },
-          {
-            path: 'value.value'
-          },
-          {
-            path: 'value.unit'
-          },
-          {
-            path: 'value.system',
-            fixed_value: 'http://unitsofmeasure.org'
-          },
-          {
-            path: 'value.code'
-          },
-          {
-            path: 'dataAbsentReason'
-          }
-        ]
-      }.freeze
-
       test :search_by_patient_code do
         metadata do
           id '01'
@@ -203,7 +127,7 @@ module Inferno
             @observation_ary[patient] += resources_returned
 
             save_resource_references(versioned_resource_class('Observation'), @observation_ary[patient], Inferno::ValidationUtil::US_CORE_R4_URIS[:body_temperature])
-            save_delayed_sequence_references(resources_returned)
+            save_delayed_sequence_references(resources_returned, USCore310BodytempSequenceDefinitions::DELAYED_REFERENCES)
             validate_reply_entries(resources_returned, search_params)
 
             break
@@ -473,7 +397,7 @@ module Inferno
             .select { |resource| resource.resourceType == 'Provenance' }
         end
         save_resource_references(versioned_resource_class('Provenance'), provenance_results)
-        save_delayed_sequence_references(provenance_results)
+        save_delayed_sequence_references(provenance_results, USCore310BodytempSequenceDefinitions::DELAYED_REFERENCES)
         skip 'Could not resolve all parameters (patient, code) in any resource.' unless resolved_one
         skip 'No Provenance resources were returned from this search' unless provenance_results.present?
       end
@@ -643,15 +567,16 @@ module Inferno
         end
 
         skip_if_not_found(resource_type: 'Observation', delayed: false)
+        must_supports = USCore310BodytempSequenceDefinitions::MUST_SUPPORTS
 
-        missing_slices = MUST_SUPPORTS[:slices].reject do |slice|
+        missing_slices = must_supports[:slices].reject do |slice|
           @observation_ary&.values&.flatten&.any? do |resource|
             slice_found = find_slice(resource, slice[:path], slice[:discriminator])
             slice_found.present?
           end
         end
 
-        missing_must_support_elements = MUST_SUPPORTS[:elements].reject do |element|
+        missing_must_support_elements = must_supports[:elements].reject do |element|
           @observation_ary&.values&.flatten&.any? do |resource|
             value_found = resolve_element_from_path(resource, element[:path]) { |value| element[:fixed_value].blank? || value == element[:fixed_value] }
             value_found.present?

--- a/lib/modules/uscore_v3.1.0/bp_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/bp_sequence.rb
@@ -1,11 +1,13 @@
 # frozen_string_literal: true
 
 require_relative './data_absent_reason_checker'
+require_relative './profile_definitions/bp_definitions'
 
 module Inferno
   module Sequence
     class USCore310BpSequence < SequenceBase
       include Inferno::DataAbsentReasonChecker
+      include Inferno::USCore310ProfileDefinitions
 
       title 'Observation Blood Pressure'
 
@@ -88,60 +90,6 @@ module Inferno
 
       @resources_found = false
 
-      MUST_SUPPORTS = {
-        extensions: [],
-        slices: [
-          {
-            name: 'Observation.category:VSCat',
-            path: 'category',
-            discriminator: {
-              type: 'value',
-              values: [
-                {
-                  path: 'coding.code',
-                  value: 'vital-signs'
-                },
-                {
-                  path: 'coding.system',
-                  value: 'http://terminology.hl7.org/CodeSystem/observation-category'
-                }
-              ]
-            }
-          }
-        ],
-        elements: [
-          {
-            path: 'status'
-          },
-          {
-            path: 'category'
-          },
-          {
-            path: 'category.coding'
-          },
-          {
-            path: 'category.coding.system',
-            fixed_value: 'http://terminology.hl7.org/CodeSystem/observation-category'
-          },
-          {
-            path: 'category.coding.code',
-            fixed_value: 'vital-signs'
-          },
-          {
-            path: 'code'
-          },
-          {
-            path: 'subject'
-          },
-          {
-            path: 'effective'
-          },
-          {
-            path: 'dataAbsentReason'
-          }
-        ]
-      }.freeze
-
       test :search_by_patient_code do
         metadata do
           id '01'
@@ -179,7 +127,7 @@ module Inferno
             @observation_ary[patient] += resources_returned
 
             save_resource_references(versioned_resource_class('Observation'), @observation_ary[patient], Inferno::ValidationUtil::US_CORE_R4_URIS[:blood_pressure])
-            save_delayed_sequence_references(resources_returned)
+            save_delayed_sequence_references(resources_returned, USCore310BpSequenceDefinitions::DELAYED_REFERENCES)
             validate_reply_entries(resources_returned, search_params)
 
             break
@@ -449,7 +397,7 @@ module Inferno
             .select { |resource| resource.resourceType == 'Provenance' }
         end
         save_resource_references(versioned_resource_class('Provenance'), provenance_results)
-        save_delayed_sequence_references(provenance_results)
+        save_delayed_sequence_references(provenance_results, USCore310BpSequenceDefinitions::DELAYED_REFERENCES)
         skip 'Could not resolve all parameters (patient, code) in any resource.' unless resolved_one
         skip 'No Provenance resources were returned from this search' unless provenance_results.present?
       end
@@ -637,15 +585,16 @@ module Inferno
         end
 
         skip_if_not_found(resource_type: 'Observation', delayed: false)
+        must_supports = USCore310BpSequenceDefinitions::MUST_SUPPORTS
 
-        missing_slices = MUST_SUPPORTS[:slices].reject do |slice|
+        missing_slices = must_supports[:slices].reject do |slice|
           @observation_ary&.values&.flatten&.any? do |resource|
             slice_found = find_slice(resource, slice[:path], slice[:discriminator])
             slice_found.present?
           end
         end
 
-        missing_must_support_elements = MUST_SUPPORTS[:elements].reject do |element|
+        missing_must_support_elements = must_supports[:elements].reject do |element|
           @observation_ary&.values&.flatten&.any? do |resource|
             value_found = resolve_element_from_path(resource, element[:path]) { |value| element[:fixed_value].blank? || value == element[:fixed_value] }
             value_found.present?

--- a/lib/modules/uscore_v3.1.0/headcircum_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/headcircum_sequence.rb
@@ -1,11 +1,13 @@
 # frozen_string_literal: true
 
 require_relative './data_absent_reason_checker'
+require_relative './profile_definitions/headcircum_definitions'
 
 module Inferno
   module Sequence
     class USCore310HeadcircumSequence < SequenceBase
       include Inferno::DataAbsentReasonChecker
+      include Inferno::USCore310ProfileDefinitions
 
       title 'Observation Head Circumference'
 
@@ -88,84 +90,6 @@ module Inferno
 
       @resources_found = false
 
-      MUST_SUPPORTS = {
-        extensions: [],
-        slices: [
-          {
-            name: 'Observation.category:VSCat',
-            path: 'category',
-            discriminator: {
-              type: 'value',
-              values: [
-                {
-                  path: 'coding.code',
-                  value: 'vital-signs'
-                },
-                {
-                  path: 'coding.system',
-                  value: 'http://terminology.hl7.org/CodeSystem/observation-category'
-                }
-              ]
-            }
-          },
-          {
-            name: 'Observation.value[x]:valueQuantity',
-            path: 'value',
-            discriminator: {
-              type: 'type',
-              code: 'Quantity'
-            }
-          }
-        ],
-        elements: [
-          {
-            path: 'status'
-          },
-          {
-            path: 'category'
-          },
-          {
-            path: 'category.coding'
-          },
-          {
-            path: 'category.coding.system',
-            fixed_value: 'http://terminology.hl7.org/CodeSystem/observation-category'
-          },
-          {
-            path: 'category.coding.code',
-            fixed_value: 'vital-signs'
-          },
-          {
-            path: 'code'
-          },
-          {
-            path: 'subject'
-          },
-          {
-            path: 'effective'
-          },
-          {
-            path: 'value'
-          },
-          {
-            path: 'value.value'
-          },
-          {
-            path: 'value.unit'
-          },
-          {
-            path: 'value.system',
-            fixed_value: 'http://unitsofmeasure.org'
-          },
-          {
-            path: 'value.code'
-          },
-          {
-            path: 'dataAbsentReason'
-          }
-        ]
-      }.freeze
-
       test :search_by_patient_code do
         metadata do
           id '01'
@@ -203,7 +127,7 @@ module Inferno
             @observation_ary[patient] += resources_returned
 
             save_resource_references(versioned_resource_class('Observation'), @observation_ary[patient], Inferno::ValidationUtil::US_CORE_R4_URIS[:head_circumference])
-            save_delayed_sequence_references(resources_returned)
+            save_delayed_sequence_references(resources_returned, USCore310HeadcircumSequenceDefinitions::DELAYED_REFERENCES)
             validate_reply_entries(resources_returned, search_params)
 
             break
@@ -473,7 +397,7 @@ module Inferno
             .select { |resource| resource.resourceType == 'Provenance' }
         end
         save_resource_references(versioned_resource_class('Provenance'), provenance_results)
-        save_delayed_sequence_references(provenance_results)
+        save_delayed_sequence_references(provenance_results, USCore310HeadcircumSequenceDefinitions::DELAYED_REFERENCES)
         skip 'Could not resolve all parameters (patient, code) in any resource.' unless resolved_one
         skip 'No Provenance resources were returned from this search' unless provenance_results.present?
       end
@@ -643,15 +567,16 @@ module Inferno
         end
 
         skip_if_not_found(resource_type: 'Observation', delayed: false)
+        must_supports = USCore310HeadcircumSequenceDefinitions::MUST_SUPPORTS
 
-        missing_slices = MUST_SUPPORTS[:slices].reject do |slice|
+        missing_slices = must_supports[:slices].reject do |slice|
           @observation_ary&.values&.flatten&.any? do |resource|
             slice_found = find_slice(resource, slice[:path], slice[:discriminator])
             slice_found.present?
           end
         end
 
-        missing_must_support_elements = MUST_SUPPORTS[:elements].reject do |element|
+        missing_must_support_elements = must_supports[:elements].reject do |element|
           @observation_ary&.values&.flatten&.any? do |resource|
             value_found = resolve_element_from_path(resource, element[:path]) { |value| element[:fixed_value].blank? || value == element[:fixed_value] }
             value_found.present?

--- a/lib/modules/uscore_v3.1.0/heartrate_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/heartrate_sequence.rb
@@ -1,11 +1,13 @@
 # frozen_string_literal: true
 
 require_relative './data_absent_reason_checker'
+require_relative './profile_definitions/heartrate_definitions'
 
 module Inferno
   module Sequence
     class USCore310HeartrateSequence < SequenceBase
       include Inferno::DataAbsentReasonChecker
+      include Inferno::USCore310ProfileDefinitions
 
       title 'Observation Heart Rate'
 
@@ -88,85 +90,6 @@ module Inferno
 
       @resources_found = false
 
-      MUST_SUPPORTS = {
-        extensions: [],
-        slices: [
-          {
-            name: 'Observation.category:VSCat',
-            path: 'category',
-            discriminator: {
-              type: 'value',
-              values: [
-                {
-                  path: 'coding.code',
-                  value: 'vital-signs'
-                },
-                {
-                  path: 'coding.system',
-                  value: 'http://terminology.hl7.org/CodeSystem/observation-category'
-                }
-              ]
-            }
-          },
-          {
-            name: 'Observation.value[x]:valueQuantity',
-            path: 'value',
-            discriminator: {
-              type: 'type',
-              code: 'Quantity'
-            }
-          }
-        ],
-        elements: [
-          {
-            path: 'status'
-          },
-          {
-            path: 'category'
-          },
-          {
-            path: 'category.coding'
-          },
-          {
-            path: 'category.coding.system',
-            fixed_value: 'http://terminology.hl7.org/CodeSystem/observation-category'
-          },
-          {
-            path: 'category.coding.code',
-            fixed_value: 'vital-signs'
-          },
-          {
-            path: 'code'
-          },
-          {
-            path: 'subject'
-          },
-          {
-            path: 'effective'
-          },
-          {
-            path: 'value'
-          },
-          {
-            path: 'value.value'
-          },
-          {
-            path: 'value.unit'
-          },
-          {
-            path: 'value.system',
-            fixed_value: 'http://unitsofmeasure.org'
-          },
-          {
-            path: 'value.code',
-            fixed_value: '/min'
-          },
-          {
-            path: 'dataAbsentReason'
-          }
-        ]
-      }.freeze
-
       test :search_by_patient_code do
         metadata do
           id '01'
@@ -204,7 +127,7 @@ module Inferno
             @observation_ary[patient] += resources_returned
 
             save_resource_references(versioned_resource_class('Observation'), @observation_ary[patient], Inferno::ValidationUtil::US_CORE_R4_URIS[:heart_rate])
-            save_delayed_sequence_references(resources_returned)
+            save_delayed_sequence_references(resources_returned, USCore310HeartrateSequenceDefinitions::DELAYED_REFERENCES)
             validate_reply_entries(resources_returned, search_params)
 
             break
@@ -474,7 +397,7 @@ module Inferno
             .select { |resource| resource.resourceType == 'Provenance' }
         end
         save_resource_references(versioned_resource_class('Provenance'), provenance_results)
-        save_delayed_sequence_references(provenance_results)
+        save_delayed_sequence_references(provenance_results, USCore310HeartrateSequenceDefinitions::DELAYED_REFERENCES)
         skip 'Could not resolve all parameters (patient, code) in any resource.' unless resolved_one
         skip 'No Provenance resources were returned from this search' unless provenance_results.present?
       end
@@ -638,15 +561,16 @@ module Inferno
         end
 
         skip_if_not_found(resource_type: 'Observation', delayed: false)
+        must_supports = USCore310HeartrateSequenceDefinitions::MUST_SUPPORTS
 
-        missing_slices = MUST_SUPPORTS[:slices].reject do |slice|
+        missing_slices = must_supports[:slices].reject do |slice|
           @observation_ary&.values&.flatten&.any? do |resource|
             slice_found = find_slice(resource, slice[:path], slice[:discriminator])
             slice_found.present?
           end
         end
 
-        missing_must_support_elements = MUST_SUPPORTS[:elements].reject do |element|
+        missing_must_support_elements = must_supports[:elements].reject do |element|
           @observation_ary&.values&.flatten&.any? do |resource|
             value_found = resolve_element_from_path(resource, element[:path]) { |value| element[:fixed_value].blank? || value == element[:fixed_value] }
             value_found.present?

--- a/lib/modules/uscore_v3.1.0/pediatric_bmi_for_age_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/pediatric_bmi_for_age_sequence.rb
@@ -1,11 +1,13 @@
 # frozen_string_literal: true
 
 require_relative './data_absent_reason_checker'
+require_relative './profile_definitions/pediatric_bmi_for_age_definitions'
 
 module Inferno
   module Sequence
     class USCore310PediatricBmiForAgeSequence < SequenceBase
       include Inferno::DataAbsentReasonChecker
+      include Inferno::USCore310ProfileDefinitions
 
       title 'Pediatric BMI for Age Observation'
 
@@ -88,71 +90,6 @@ module Inferno
 
       @resources_found = false
 
-      MUST_SUPPORTS = {
-        extensions: [],
-        slices: [
-          {
-            name: 'Observation.category:VSCat',
-            path: 'category',
-            discriminator: {
-              type: 'value',
-              values: [
-                {
-                  path: 'coding.code',
-                  value: 'vital-signs'
-                },
-                {
-                  path: 'coding.system',
-                  value: 'http://terminology.hl7.org/CodeSystem/observation-category'
-                }
-              ]
-            }
-          }
-        ],
-        elements: [
-          {
-            path: 'status'
-          },
-          {
-            path: 'category'
-          },
-          {
-            path: 'category.coding'
-          },
-          {
-            path: 'category.coding.system',
-            fixed_value: 'http://terminology.hl7.org/CodeSystem/observation-category'
-          },
-          {
-            path: 'category.coding.code',
-            fixed_value: 'vital-signs'
-          },
-          {
-            path: 'subject'
-          },
-          {
-            path: 'effective'
-          },
-          {
-            path: 'value'
-          },
-          {
-            path: 'value.value'
-          },
-          {
-            path: 'value.unit'
-          },
-          {
-            path: 'value.system',
-            fixed_value: 'http://unitsofmeasure.org'
-          },
-          {
-            path: 'value.code',
-            fixed_value: '%'
-          }
-        ]
-      }.freeze
-
       test :search_by_patient_code do
         metadata do
           id '01'
@@ -190,7 +127,7 @@ module Inferno
             @observation_ary[patient] += resources_returned
 
             save_resource_references(versioned_resource_class('Observation'), @observation_ary[patient], Inferno::ValidationUtil::US_CORE_R4_URIS[:pediatric_bmi_age])
-            save_delayed_sequence_references(resources_returned)
+            save_delayed_sequence_references(resources_returned, USCore310PediatricBmiForAgeSequenceDefinitions::DELAYED_REFERENCES)
             validate_reply_entries(resources_returned, search_params)
 
             break
@@ -460,7 +397,7 @@ module Inferno
             .select { |resource| resource.resourceType == 'Provenance' }
         end
         save_resource_references(versioned_resource_class('Provenance'), provenance_results)
-        save_delayed_sequence_references(provenance_results)
+        save_delayed_sequence_references(provenance_results, USCore310PediatricBmiForAgeSequenceDefinitions::DELAYED_REFERENCES)
         skip 'Could not resolve all parameters (patient, code) in any resource.' unless resolved_one
         skip 'No Provenance resources were returned from this search' unless provenance_results.present?
       end
@@ -618,15 +555,16 @@ module Inferno
         end
 
         skip_if_not_found(resource_type: 'Observation', delayed: false)
+        must_supports = USCore310PediatricBmiForAgeSequenceDefinitions::MUST_SUPPORTS
 
-        missing_slices = MUST_SUPPORTS[:slices].reject do |slice|
+        missing_slices = must_supports[:slices].reject do |slice|
           @observation_ary&.values&.flatten&.any? do |resource|
             slice_found = find_slice(resource, slice[:path], slice[:discriminator])
             slice_found.present?
           end
         end
 
-        missing_must_support_elements = MUST_SUPPORTS[:elements].reject do |element|
+        missing_must_support_elements = must_supports[:elements].reject do |element|
           @observation_ary&.values&.flatten&.any? do |resource|
             value_found = resolve_element_from_path(resource, element[:path]) { |value| element[:fixed_value].blank? || value == element[:fixed_value] }
             value_found.present?

--- a/lib/modules/uscore_v3.1.0/pediatric_weight_for_height_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/pediatric_weight_for_height_sequence.rb
@@ -1,11 +1,13 @@
 # frozen_string_literal: true
 
 require_relative './data_absent_reason_checker'
+require_relative './profile_definitions/pediatric_weight_for_height_definitions'
 
 module Inferno
   module Sequence
     class USCore310PediatricWeightForHeightSequence < SequenceBase
       include Inferno::DataAbsentReasonChecker
+      include Inferno::USCore310ProfileDefinitions
 
       title 'Pediatric Weight for Height Observation'
 
@@ -88,71 +90,6 @@ module Inferno
 
       @resources_found = false
 
-      MUST_SUPPORTS = {
-        extensions: [],
-        slices: [
-          {
-            name: 'Observation.category:VSCat',
-            path: 'category',
-            discriminator: {
-              type: 'value',
-              values: [
-                {
-                  path: 'coding.code',
-                  value: 'vital-signs'
-                },
-                {
-                  path: 'coding.system',
-                  value: 'http://terminology.hl7.org/CodeSystem/observation-category'
-                }
-              ]
-            }
-          }
-        ],
-        elements: [
-          {
-            path: 'status'
-          },
-          {
-            path: 'category'
-          },
-          {
-            path: 'category.coding'
-          },
-          {
-            path: 'category.coding.system',
-            fixed_value: 'http://terminology.hl7.org/CodeSystem/observation-category'
-          },
-          {
-            path: 'category.coding.code',
-            fixed_value: 'vital-signs'
-          },
-          {
-            path: 'subject'
-          },
-          {
-            path: 'effective'
-          },
-          {
-            path: 'value'
-          },
-          {
-            path: 'value.value'
-          },
-          {
-            path: 'value.unit'
-          },
-          {
-            path: 'value.system',
-            fixed_value: 'http://unitsofmeasure.org'
-          },
-          {
-            path: 'value.code',
-            fixed_value: '%'
-          }
-        ]
-      }.freeze
-
       test :search_by_patient_code do
         metadata do
           id '01'
@@ -190,7 +127,7 @@ module Inferno
             @observation_ary[patient] += resources_returned
 
             save_resource_references(versioned_resource_class('Observation'), @observation_ary[patient], Inferno::ValidationUtil::US_CORE_R4_URIS[:pediatric_weight_height])
-            save_delayed_sequence_references(resources_returned)
+            save_delayed_sequence_references(resources_returned, USCore310PediatricWeightForHeightSequenceDefinitions::DELAYED_REFERENCES)
             validate_reply_entries(resources_returned, search_params)
 
             break
@@ -460,7 +397,7 @@ module Inferno
             .select { |resource| resource.resourceType == 'Provenance' }
         end
         save_resource_references(versioned_resource_class('Provenance'), provenance_results)
-        save_delayed_sequence_references(provenance_results)
+        save_delayed_sequence_references(provenance_results, USCore310PediatricWeightForHeightSequenceDefinitions::DELAYED_REFERENCES)
         skip 'Could not resolve all parameters (patient, code) in any resource.' unless resolved_one
         skip 'No Provenance resources were returned from this search' unless provenance_results.present?
       end
@@ -618,15 +555,16 @@ module Inferno
         end
 
         skip_if_not_found(resource_type: 'Observation', delayed: false)
+        must_supports = USCore310PediatricWeightForHeightSequenceDefinitions::MUST_SUPPORTS
 
-        missing_slices = MUST_SUPPORTS[:slices].reject do |slice|
+        missing_slices = must_supports[:slices].reject do |slice|
           @observation_ary&.values&.flatten&.any? do |resource|
             slice_found = find_slice(resource, slice[:path], slice[:discriminator])
             slice_found.present?
           end
         end
 
-        missing_must_support_elements = MUST_SUPPORTS[:elements].reject do |element|
+        missing_must_support_elements = must_supports[:elements].reject do |element|
           @observation_ary&.values&.flatten&.any? do |resource|
             value_found = resolve_element_from_path(resource, element[:path]) { |value| element[:fixed_value].blank? || value == element[:fixed_value] }
             value_found.present?

--- a/lib/modules/uscore_v3.1.0/profile_definitions/bodyheight_definitions.rb
+++ b/lib/modules/uscore_v3.1.0/profile_definitions/bodyheight_definitions.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+module Inferno
+  module USCore310ProfileDefinitions
+    class USCore310BodyheightSequenceDefinitions
+      MUST_SUPPORTS = {
+        extensions: [],
+        slices: [
+          {
+            name: 'Observation.category:VSCat',
+            path: 'category',
+            discriminator: {
+              type: 'value',
+              values: [
+                {
+                  path: 'coding.code',
+                  value: 'vital-signs'
+                },
+                {
+                  path: 'coding.system',
+                  value: 'http://terminology.hl7.org/CodeSystem/observation-category'
+                }
+              ]
+            }
+          },
+          {
+            name: 'Observation.value[x]:valueQuantity',
+            path: 'value',
+            discriminator: {
+              type: 'type',
+              code: 'Quantity'
+            }
+          }
+        ],
+        elements: [
+          {
+            path: 'status'
+          },
+          {
+            path: 'category'
+          },
+          {
+            path: 'category.coding'
+          },
+          {
+            path: 'category.coding.system',
+            fixed_value: 'http://terminology.hl7.org/CodeSystem/observation-category'
+          },
+          {
+            path: 'category.coding.code',
+            fixed_value: 'vital-signs'
+          },
+          {
+            path: 'code'
+          },
+          {
+            path: 'subject'
+          },
+          {
+            path: 'effective'
+          },
+          {
+            path: 'value'
+          },
+          {
+            path: 'value.value'
+          },
+          {
+            path: 'value.unit'
+          },
+          {
+            path: 'value.system',
+            fixed_value: 'http://unitsofmeasure.org'
+          },
+          {
+            path: 'value.code'
+          },
+          {
+            path: 'dataAbsentReason'
+          }
+        ]
+      }.freeze
+
+      DELAYED_REFERENCES = [].freeze
+    end
+  end
+end

--- a/lib/modules/uscore_v3.1.0/profile_definitions/bodytemp_definitions.rb
+++ b/lib/modules/uscore_v3.1.0/profile_definitions/bodytemp_definitions.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+module Inferno
+  module USCore310ProfileDefinitions
+    class USCore310BodytempSequenceDefinitions
+      MUST_SUPPORTS = {
+        extensions: [],
+        slices: [
+          {
+            name: 'Observation.category:VSCat',
+            path: 'category',
+            discriminator: {
+              type: 'value',
+              values: [
+                {
+                  path: 'coding.code',
+                  value: 'vital-signs'
+                },
+                {
+                  path: 'coding.system',
+                  value: 'http://terminology.hl7.org/CodeSystem/observation-category'
+                }
+              ]
+            }
+          },
+          {
+            name: 'Observation.value[x]:valueQuantity',
+            path: 'value',
+            discriminator: {
+              type: 'type',
+              code: 'Quantity'
+            }
+          }
+        ],
+        elements: [
+          {
+            path: 'status'
+          },
+          {
+            path: 'category'
+          },
+          {
+            path: 'category.coding'
+          },
+          {
+            path: 'category.coding.system',
+            fixed_value: 'http://terminology.hl7.org/CodeSystem/observation-category'
+          },
+          {
+            path: 'category.coding.code',
+            fixed_value: 'vital-signs'
+          },
+          {
+            path: 'code'
+          },
+          {
+            path: 'subject'
+          },
+          {
+            path: 'effective'
+          },
+          {
+            path: 'value'
+          },
+          {
+            path: 'value.value'
+          },
+          {
+            path: 'value.unit'
+          },
+          {
+            path: 'value.system',
+            fixed_value: 'http://unitsofmeasure.org'
+          },
+          {
+            path: 'value.code'
+          },
+          {
+            path: 'dataAbsentReason'
+          }
+        ]
+      }.freeze
+
+      DELAYED_REFERENCES = [].freeze
+    end
+  end
+end

--- a/lib/modules/uscore_v3.1.0/profile_definitions/bodyweight_definitions.rb
+++ b/lib/modules/uscore_v3.1.0/profile_definitions/bodyweight_definitions.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+module Inferno
+  module USCore310ProfileDefinitions
+    class USCore310BodyweightSequenceDefinitions
+      MUST_SUPPORTS = {
+        extensions: [],
+        slices: [
+          {
+            name: 'Observation.category:VSCat',
+            path: 'category',
+            discriminator: {
+              type: 'value',
+              values: [
+                {
+                  path: 'coding.code',
+                  value: 'vital-signs'
+                },
+                {
+                  path: 'coding.system',
+                  value: 'http://terminology.hl7.org/CodeSystem/observation-category'
+                }
+              ]
+            }
+          },
+          {
+            name: 'Observation.value[x]:valueQuantity',
+            path: 'value',
+            discriminator: {
+              type: 'type',
+              code: 'Quantity'
+            }
+          }
+        ],
+        elements: [
+          {
+            path: 'status'
+          },
+          {
+            path: 'category'
+          },
+          {
+            path: 'category.coding'
+          },
+          {
+            path: 'category.coding.system',
+            fixed_value: 'http://terminology.hl7.org/CodeSystem/observation-category'
+          },
+          {
+            path: 'category.coding.code',
+            fixed_value: 'vital-signs'
+          },
+          {
+            path: 'code'
+          },
+          {
+            path: 'subject'
+          },
+          {
+            path: 'effective'
+          },
+          {
+            path: 'value'
+          },
+          {
+            path: 'value.value'
+          },
+          {
+            path: 'value.unit'
+          },
+          {
+            path: 'value.system',
+            fixed_value: 'http://unitsofmeasure.org'
+          },
+          {
+            path: 'value.code'
+          },
+          {
+            path: 'dataAbsentReason'
+          }
+        ]
+      }.freeze
+
+      DELAYED_REFERENCES = [].freeze
+    end
+  end
+end

--- a/lib/modules/uscore_v3.1.0/profile_definitions/bp_definitions.rb
+++ b/lib/modules/uscore_v3.1.0/profile_definitions/bp_definitions.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+module Inferno
+  module USCore310ProfileDefinitions
+    class USCore310BpSequenceDefinitions
+      MUST_SUPPORTS = {
+        extensions: [],
+        slices: [
+          {
+            name: 'Observation.category:VSCat',
+            path: 'category',
+            discriminator: {
+              type: 'value',
+              values: [
+                {
+                  path: 'coding.code',
+                  value: 'vital-signs'
+                },
+                {
+                  path: 'coding.system',
+                  value: 'http://terminology.hl7.org/CodeSystem/observation-category'
+                }
+              ]
+            }
+          }
+        ],
+        elements: [
+          {
+            path: 'status'
+          },
+          {
+            path: 'category'
+          },
+          {
+            path: 'category.coding'
+          },
+          {
+            path: 'category.coding.system',
+            fixed_value: 'http://terminology.hl7.org/CodeSystem/observation-category'
+          },
+          {
+            path: 'category.coding.code',
+            fixed_value: 'vital-signs'
+          },
+          {
+            path: 'code'
+          },
+          {
+            path: 'subject'
+          },
+          {
+            path: 'effective'
+          },
+          {
+            path: 'dataAbsentReason'
+          }
+        ]
+      }.freeze
+
+      DELAYED_REFERENCES = [].freeze
+    end
+  end
+end

--- a/lib/modules/uscore_v3.1.0/profile_definitions/headcircum_definitions.rb
+++ b/lib/modules/uscore_v3.1.0/profile_definitions/headcircum_definitions.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+module Inferno
+  module USCore310ProfileDefinitions
+    class USCore310HeadcircumSequenceDefinitions
+      MUST_SUPPORTS = {
+        extensions: [],
+        slices: [
+          {
+            name: 'Observation.category:VSCat',
+            path: 'category',
+            discriminator: {
+              type: 'value',
+              values: [
+                {
+                  path: 'coding.code',
+                  value: 'vital-signs'
+                },
+                {
+                  path: 'coding.system',
+                  value: 'http://terminology.hl7.org/CodeSystem/observation-category'
+                }
+              ]
+            }
+          },
+          {
+            name: 'Observation.value[x]:valueQuantity',
+            path: 'value',
+            discriminator: {
+              type: 'type',
+              code: 'Quantity'
+            }
+          }
+        ],
+        elements: [
+          {
+            path: 'status'
+          },
+          {
+            path: 'category'
+          },
+          {
+            path: 'category.coding'
+          },
+          {
+            path: 'category.coding.system',
+            fixed_value: 'http://terminology.hl7.org/CodeSystem/observation-category'
+          },
+          {
+            path: 'category.coding.code',
+            fixed_value: 'vital-signs'
+          },
+          {
+            path: 'code'
+          },
+          {
+            path: 'subject'
+          },
+          {
+            path: 'effective'
+          },
+          {
+            path: 'value'
+          },
+          {
+            path: 'value.value'
+          },
+          {
+            path: 'value.unit'
+          },
+          {
+            path: 'value.system',
+            fixed_value: 'http://unitsofmeasure.org'
+          },
+          {
+            path: 'value.code'
+          },
+          {
+            path: 'dataAbsentReason'
+          }
+        ]
+      }.freeze
+
+      DELAYED_REFERENCES = [].freeze
+    end
+  end
+end

--- a/lib/modules/uscore_v3.1.0/profile_definitions/heartrate_definitions.rb
+++ b/lib/modules/uscore_v3.1.0/profile_definitions/heartrate_definitions.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+module Inferno
+  module USCore310ProfileDefinitions
+    class USCore310HeartrateSequenceDefinitions
+      MUST_SUPPORTS = {
+        extensions: [],
+        slices: [
+          {
+            name: 'Observation.category:VSCat',
+            path: 'category',
+            discriminator: {
+              type: 'value',
+              values: [
+                {
+                  path: 'coding.code',
+                  value: 'vital-signs'
+                },
+                {
+                  path: 'coding.system',
+                  value: 'http://terminology.hl7.org/CodeSystem/observation-category'
+                }
+              ]
+            }
+          },
+          {
+            name: 'Observation.value[x]:valueQuantity',
+            path: 'value',
+            discriminator: {
+              type: 'type',
+              code: 'Quantity'
+            }
+          }
+        ],
+        elements: [
+          {
+            path: 'status'
+          },
+          {
+            path: 'category'
+          },
+          {
+            path: 'category.coding'
+          },
+          {
+            path: 'category.coding.system',
+            fixed_value: 'http://terminology.hl7.org/CodeSystem/observation-category'
+          },
+          {
+            path: 'category.coding.code',
+            fixed_value: 'vital-signs'
+          },
+          {
+            path: 'code'
+          },
+          {
+            path: 'subject'
+          },
+          {
+            path: 'effective'
+          },
+          {
+            path: 'value'
+          },
+          {
+            path: 'value.value'
+          },
+          {
+            path: 'value.unit'
+          },
+          {
+            path: 'value.system',
+            fixed_value: 'http://unitsofmeasure.org'
+          },
+          {
+            path: 'value.code',
+            fixed_value: '/min'
+          },
+          {
+            path: 'dataAbsentReason'
+          }
+        ]
+      }.freeze
+
+      DELAYED_REFERENCES = [].freeze
+    end
+  end
+end

--- a/lib/modules/uscore_v3.1.0/profile_definitions/pediatric_bmi_for_age_definitions.rb
+++ b/lib/modules/uscore_v3.1.0/profile_definitions/pediatric_bmi_for_age_definitions.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+module Inferno
+  module USCore310ProfileDefinitions
+    class USCore310PediatricBmiForAgeSequenceDefinitions
+      MUST_SUPPORTS = {
+        extensions: [],
+        slices: [
+          {
+            name: 'Observation.category:VSCat',
+            path: 'category',
+            discriminator: {
+              type: 'value',
+              values: [
+                {
+                  path: 'coding.code',
+                  value: 'vital-signs'
+                },
+                {
+                  path: 'coding.system',
+                  value: 'http://terminology.hl7.org/CodeSystem/observation-category'
+                }
+              ]
+            }
+          }
+        ],
+        elements: [
+          {
+            path: 'status'
+          },
+          {
+            path: 'category'
+          },
+          {
+            path: 'category.coding'
+          },
+          {
+            path: 'category.coding.system',
+            fixed_value: 'http://terminology.hl7.org/CodeSystem/observation-category'
+          },
+          {
+            path: 'category.coding.code',
+            fixed_value: 'vital-signs'
+          },
+          {
+            path: 'subject'
+          },
+          {
+            path: 'effective'
+          },
+          {
+            path: 'value'
+          },
+          {
+            path: 'value.value'
+          },
+          {
+            path: 'value.unit'
+          },
+          {
+            path: 'value.system',
+            fixed_value: 'http://unitsofmeasure.org'
+          },
+          {
+            path: 'value.code',
+            fixed_value: '%'
+          }
+        ]
+      }.freeze
+
+      DELAYED_REFERENCES = [].freeze
+    end
+  end
+end

--- a/lib/modules/uscore_v3.1.0/profile_definitions/pediatric_weight_for_height_definitions.rb
+++ b/lib/modules/uscore_v3.1.0/profile_definitions/pediatric_weight_for_height_definitions.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+module Inferno
+  module USCore310ProfileDefinitions
+    class USCore310PediatricWeightForHeightSequenceDefinitions
+      MUST_SUPPORTS = {
+        extensions: [],
+        slices: [
+          {
+            name: 'Observation.category:VSCat',
+            path: 'category',
+            discriminator: {
+              type: 'value',
+              values: [
+                {
+                  path: 'coding.code',
+                  value: 'vital-signs'
+                },
+                {
+                  path: 'coding.system',
+                  value: 'http://terminology.hl7.org/CodeSystem/observation-category'
+                }
+              ]
+            }
+          }
+        ],
+        elements: [
+          {
+            path: 'status'
+          },
+          {
+            path: 'category'
+          },
+          {
+            path: 'category.coding'
+          },
+          {
+            path: 'category.coding.system',
+            fixed_value: 'http://terminology.hl7.org/CodeSystem/observation-category'
+          },
+          {
+            path: 'category.coding.code',
+            fixed_value: 'vital-signs'
+          },
+          {
+            path: 'subject'
+          },
+          {
+            path: 'effective'
+          },
+          {
+            path: 'value'
+          },
+          {
+            path: 'value.value'
+          },
+          {
+            path: 'value.unit'
+          },
+          {
+            path: 'value.system',
+            fixed_value: 'http://unitsofmeasure.org'
+          },
+          {
+            path: 'value.code',
+            fixed_value: '%'
+          }
+        ]
+      }.freeze
+
+      DELAYED_REFERENCES = [].freeze
+    end
+  end
+end

--- a/lib/modules/uscore_v3.1.0/profile_definitions/resprate_definitions.rb
+++ b/lib/modules/uscore_v3.1.0/profile_definitions/resprate_definitions.rb
@@ -1,0 +1,88 @@
+# frozen_string_literal: true
+
+module Inferno
+  module USCore310ProfileDefinitions
+    class USCore310ResprateSequenceDefinitions
+      MUST_SUPPORTS = {
+        extensions: [],
+        slices: [
+          {
+            name: 'Observation.category:VSCat',
+            path: 'category',
+            discriminator: {
+              type: 'value',
+              values: [
+                {
+                  path: 'coding.code',
+                  value: 'vital-signs'
+                },
+                {
+                  path: 'coding.system',
+                  value: 'http://terminology.hl7.org/CodeSystem/observation-category'
+                }
+              ]
+            }
+          },
+          {
+            name: 'Observation.value[x]:valueQuantity',
+            path: 'value',
+            discriminator: {
+              type: 'type',
+              code: 'Quantity'
+            }
+          }
+        ],
+        elements: [
+          {
+            path: 'status'
+          },
+          {
+            path: 'category'
+          },
+          {
+            path: 'category.coding'
+          },
+          {
+            path: 'category.coding.system',
+            fixed_value: 'http://terminology.hl7.org/CodeSystem/observation-category'
+          },
+          {
+            path: 'category.coding.code',
+            fixed_value: 'vital-signs'
+          },
+          {
+            path: 'code'
+          },
+          {
+            path: 'subject'
+          },
+          {
+            path: 'effective'
+          },
+          {
+            path: 'value'
+          },
+          {
+            path: 'value.value'
+          },
+          {
+            path: 'value.unit'
+          },
+          {
+            path: 'value.system',
+            fixed_value: 'http://unitsofmeasure.org'
+          },
+          {
+            path: 'value.code',
+            fixed_value: '/min'
+          },
+          {
+            path: 'dataAbsentReason'
+          }
+        ]
+      }.freeze
+
+      DELAYED_REFERENCES = [].freeze
+    end
+  end
+end

--- a/lib/modules/uscore_v3.1.0/profile_definitions/us_core_allergyintolerance_definitions.rb
+++ b/lib/modules/uscore_v3.1.0/profile_definitions/us_core_allergyintolerance_definitions.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module Inferno
+  module USCore310ProfileDefinitions
+    class USCore310AllergyintoleranceSequenceDefinitions
+      MUST_SUPPORTS = {
+        extensions: [],
+        slices: [],
+        elements: [
+          {
+            path: 'clinicalStatus'
+          },
+          {
+            path: 'verificationStatus'
+          },
+          {
+            path: 'code'
+          },
+          {
+            path: 'patient'
+          }
+        ]
+      }.freeze
+
+      DELAYED_REFERENCES = [].freeze
+    end
+  end
+end

--- a/lib/modules/uscore_v3.1.0/profile_definitions/us_core_careplan_definitions.rb
+++ b/lib/modules/uscore_v3.1.0/profile_definitions/us_core_careplan_definitions.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+module Inferno
+  module USCore310ProfileDefinitions
+    class USCore310CareplanSequenceDefinitions
+      MUST_SUPPORTS = {
+        extensions: [],
+        slices: [
+          {
+            name: 'CarePlan.category:AssessPlan',
+            path: 'category',
+            discriminator: {
+              type: 'patternCodeableConcept',
+              path: '',
+              code: 'assess-plan',
+              system: 'http://hl7.org/fhir/us/core/CodeSystem/careplan-category'
+            }
+          }
+        ],
+        elements: [
+          {
+            path: 'text'
+          },
+          {
+            path: 'text.status'
+          },
+          {
+            path: 'status'
+          },
+          {
+            path: 'intent'
+          },
+          {
+            path: 'category'
+          },
+          {
+            path: 'subject'
+          }
+        ]
+      }.freeze
+
+      DELAYED_REFERENCES = [].freeze
+    end
+  end
+end

--- a/lib/modules/uscore_v3.1.0/profile_definitions/us_core_careteam_definitions.rb
+++ b/lib/modules/uscore_v3.1.0/profile_definitions/us_core_careteam_definitions.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+module Inferno
+  module USCore310ProfileDefinitions
+    class USCore310CareteamSequenceDefinitions
+      MUST_SUPPORTS = {
+        extensions: [],
+        slices: [],
+        elements: [
+          {
+            path: 'status'
+          },
+          {
+            path: 'subject'
+          },
+          {
+            path: 'participant'
+          },
+          {
+            path: 'participant.role'
+          },
+          {
+            path: 'participant.member'
+          }
+        ]
+      }.freeze
+
+      DELAYED_REFERENCES = [
+        {
+          path: 'participant.member',
+          resources: [
+            'Practitioner',
+            'Organization'
+          ]
+        }
+      ].freeze
+    end
+  end
+end

--- a/lib/modules/uscore_v3.1.0/profile_definitions/us_core_condition_definitions.rb
+++ b/lib/modules/uscore_v3.1.0/profile_definitions/us_core_condition_definitions.rb
@@ -1,0 +1,31 @@
+# frozen_string_literal: true
+
+module Inferno
+  module USCore310ProfileDefinitions
+    class USCore310ConditionSequenceDefinitions
+      MUST_SUPPORTS = {
+        extensions: [],
+        slices: [],
+        elements: [
+          {
+            path: 'clinicalStatus'
+          },
+          {
+            path: 'verificationStatus'
+          },
+          {
+            path: 'category'
+          },
+          {
+            path: 'code'
+          },
+          {
+            path: 'subject'
+          }
+        ]
+      }.freeze
+
+      DELAYED_REFERENCES = [].freeze
+    end
+  end
+end

--- a/lib/modules/uscore_v3.1.0/profile_definitions/us_core_diagnosticreport_lab_definitions.rb
+++ b/lib/modules/uscore_v3.1.0/profile_definitions/us_core_diagnosticreport_lab_definitions.rb
@@ -1,0 +1,59 @@
+# frozen_string_literal: true
+
+module Inferno
+  module USCore310ProfileDefinitions
+    class USCore310DiagnosticreportLabSequenceDefinitions
+      MUST_SUPPORTS = {
+        extensions: [],
+        slices: [
+          {
+            name: 'DiagnosticReport.category:LaboratorySlice',
+            path: 'category',
+            discriminator: {
+              type: 'patternCodeableConcept',
+              path: '',
+              code: 'LAB',
+              system: 'http://terminology.hl7.org/CodeSystem/v2-0074'
+            }
+          }
+        ],
+        elements: [
+          {
+            path: 'status'
+          },
+          {
+            path: 'category'
+          },
+          {
+            path: 'code'
+          },
+          {
+            path: 'subject'
+          },
+          {
+            path: 'effective'
+          },
+          {
+            path: 'issued'
+          },
+          {
+            path: 'performer'
+          },
+          {
+            path: 'result'
+          }
+        ]
+      }.freeze
+
+      DELAYED_REFERENCES = [
+        {
+          path: 'performer',
+          resources: [
+            'Practitioner',
+            'Organization'
+          ]
+        }
+      ].freeze
+    end
+  end
+end

--- a/lib/modules/uscore_v3.1.0/profile_definitions/us_core_diagnosticreport_note_definitions.rb
+++ b/lib/modules/uscore_v3.1.0/profile_definitions/us_core_diagnosticreport_note_definitions.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+module Inferno
+  module USCore310ProfileDefinitions
+    class USCore310DiagnosticreportNoteSequenceDefinitions
+      MUST_SUPPORTS = {
+        extensions: [],
+        slices: [],
+        elements: [
+          {
+            path: 'status'
+          },
+          {
+            path: 'category'
+          },
+          {
+            path: 'code'
+          },
+          {
+            path: 'subject'
+          },
+          {
+            path: 'encounter'
+          },
+          {
+            path: 'effective'
+          },
+          {
+            path: 'issued'
+          },
+          {
+            path: 'performer'
+          },
+          {
+            path: 'presentedForm'
+          }
+        ]
+      }.freeze
+
+      DELAYED_REFERENCES = [
+        {
+          path: 'encounter',
+          resources: [
+            'Encounter'
+          ]
+        },
+        {
+          path: 'performer',
+          resources: [
+            'Practitioner',
+            'Organization'
+          ]
+        }
+      ].freeze
+    end
+  end
+end

--- a/lib/modules/uscore_v3.1.0/profile_definitions/us_core_documentreference_definitions.rb
+++ b/lib/modules/uscore_v3.1.0/profile_definitions/us_core_documentreference_definitions.rb
@@ -1,0 +1,87 @@
+# frozen_string_literal: true
+
+module Inferno
+  module USCore310ProfileDefinitions
+    class USCore310DocumentreferenceSequenceDefinitions
+      MUST_SUPPORTS = {
+        extensions: [],
+        slices: [],
+        elements: [
+          {
+            path: 'identifier'
+          },
+          {
+            path: 'status'
+          },
+          {
+            path: 'type'
+          },
+          {
+            path: 'category'
+          },
+          {
+            path: 'subject'
+          },
+          {
+            path: 'date'
+          },
+          {
+            path: 'author'
+          },
+          {
+            path: 'custodian'
+          },
+          {
+            path: 'content'
+          },
+          {
+            path: 'content.attachment'
+          },
+          {
+            path: 'content.attachment.contentType'
+          },
+          {
+            path: 'content.attachment.data'
+          },
+          {
+            path: 'content.attachment.url'
+          },
+          {
+            path: 'content.format'
+          },
+          {
+            path: 'context'
+          },
+          {
+            path: 'context.encounter'
+          },
+          {
+            path: 'context.period'
+          }
+        ]
+      }.freeze
+
+      DELAYED_REFERENCES = [
+        {
+          path: 'author',
+          resources: [
+            'Practitioner',
+            'Organization'
+          ]
+        },
+        {
+          path: 'custodian',
+          resources: [
+            'Organization'
+          ]
+        },
+        {
+          path: 'context.encounter',
+          resources: [
+            'Encounter'
+          ]
+        }
+      ].freeze
+    end
+  end
+end

--- a/lib/modules/uscore_v3.1.0/profile_definitions/us_core_encounter_definitions.rb
+++ b/lib/modules/uscore_v3.1.0/profile_definitions/us_core_encounter_definitions.rb
@@ -1,0 +1,74 @@
+# frozen_string_literal: true
+
+module Inferno
+  module USCore310ProfileDefinitions
+    class USCore310EncounterSequenceDefinitions
+      MUST_SUPPORTS = {
+        extensions: [],
+        slices: [],
+        elements: [
+          {
+            path: 'identifier'
+          },
+          {
+            path: 'identifier.system'
+          },
+          {
+            path: 'identifier.value'
+          },
+          {
+            path: 'status'
+          },
+          {
+            path: 'local_class'
+          },
+          {
+            path: 'type'
+          },
+          {
+            path: 'subject'
+          },
+          {
+            path: 'participant'
+          },
+          {
+            path: 'participant.type'
+          },
+          {
+            path: 'participant.period'
+          },
+          {
+            path: 'participant.individual'
+          },
+          {
+            path: 'period'
+          },
+          {
+            path: 'reasonCode'
+          },
+          {
+            path: 'hospitalization'
+          },
+          {
+            path: 'hospitalization.dischargeDisposition'
+          },
+          {
+            path: 'location'
+          },
+          {
+            path: 'location.location'
+          }
+        ]
+      }.freeze
+
+      DELAYED_REFERENCES = [
+        {
+          path: 'participant.individual',
+          resources: [
+            'Practitioner'
+          ]
+        }
+      ].freeze
+    end
+  end
+end

--- a/lib/modules/uscore_v3.1.0/profile_definitions/us_core_goal_definitions.rb
+++ b/lib/modules/uscore_v3.1.0/profile_definitions/us_core_goal_definitions.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+module Inferno
+  module USCore310ProfileDefinitions
+    class USCore310GoalSequenceDefinitions
+      MUST_SUPPORTS = {
+        extensions: [],
+        slices: [
+          {
+            name: 'Goal.target.due[x]:dueDate',
+            path: 'target.due',
+            discriminator: {
+              type: 'type',
+              code: 'Date'
+            }
+          }
+        ],
+        elements: [
+          {
+            path: 'lifecycleStatus'
+          },
+          {
+            path: 'description'
+          },
+          {
+            path: 'subject'
+          },
+          {
+            path: 'target'
+          }
+        ]
+      }.freeze
+
+      DELAYED_REFERENCES = [].freeze
+    end
+  end
+end

--- a/lib/modules/uscore_v3.1.0/profile_definitions/us_core_immunization_definitions.rb
+++ b/lib/modules/uscore_v3.1.0/profile_definitions/us_core_immunization_definitions.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+module Inferno
+  module USCore310ProfileDefinitions
+    class USCore310ImmunizationSequenceDefinitions
+      MUST_SUPPORTS = {
+        extensions: [],
+        slices: [],
+        elements: [
+          {
+            path: 'status'
+          },
+          {
+            path: 'statusReason'
+          },
+          {
+            path: 'vaccineCode'
+          },
+          {
+            path: 'patient'
+          },
+          {
+            path: 'occurrence'
+          },
+          {
+            path: 'primarySource'
+          }
+        ]
+      }.freeze
+
+      DELAYED_REFERENCES = [].freeze
+    end
+  end
+end

--- a/lib/modules/uscore_v3.1.0/profile_definitions/us_core_implantable_device_definitions.rb
+++ b/lib/modules/uscore_v3.1.0/profile_definitions/us_core_implantable_device_definitions.rb
@@ -1,0 +1,49 @@
+# frozen_string_literal: true
+
+module Inferno
+  module USCore310ProfileDefinitions
+    class USCore310ImplantableDeviceSequenceDefinitions
+      MUST_SUPPORTS = {
+        extensions: [],
+        slices: [],
+        elements: [
+          {
+            path: 'udiCarrier'
+          },
+          {
+            path: 'udiCarrier.deviceIdentifier'
+          },
+          {
+            path: 'udiCarrier.carrierAIDC'
+          },
+          {
+            path: 'udiCarrier.carrierHRF'
+          },
+          {
+            path: 'distinctIdentifier'
+          },
+          {
+            path: 'manufactureDate'
+          },
+          {
+            path: 'expirationDate'
+          },
+          {
+            path: 'lotNumber'
+          },
+          {
+            path: 'serialNumber'
+          },
+          {
+            path: 'type'
+          },
+          {
+            path: 'patient'
+          }
+        ]
+      }.freeze
+
+      DELAYED_REFERENCES = [].freeze
+    end
+  end
+end

--- a/lib/modules/uscore_v3.1.0/profile_definitions/us_core_location_definitions.rb
+++ b/lib/modules/uscore_v3.1.0/profile_definitions/us_core_location_definitions.rb
@@ -1,0 +1,50 @@
+# frozen_string_literal: true
+
+module Inferno
+  module USCore310ProfileDefinitions
+    class USCore310LocationSequenceDefinitions
+      MUST_SUPPORTS = {
+        extensions: [],
+        slices: [],
+        elements: [
+          {
+            path: 'status'
+          },
+          {
+            path: 'name'
+          },
+          {
+            path: 'telecom'
+          },
+          {
+            path: 'address'
+          },
+          {
+            path: 'address.line'
+          },
+          {
+            path: 'address.city'
+          },
+          {
+            path: 'address.state'
+          },
+          {
+            path: 'address.postalCode'
+          },
+          {
+            path: 'managingOrganization'
+          }
+        ]
+      }.freeze
+
+      DELAYED_REFERENCES = [
+        {
+          path: 'managingOrganization',
+          resources: [
+            'Organization'
+          ]
+        }
+      ].freeze
+    end
+  end
+end

--- a/lib/modules/uscore_v3.1.0/profile_definitions/us_core_medicationrequest_definitions.rb
+++ b/lib/modules/uscore_v3.1.0/profile_definitions/us_core_medicationrequest_definitions.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+module Inferno
+  module USCore310ProfileDefinitions
+    class USCore310MedicationrequestSequenceDefinitions
+      MUST_SUPPORTS = {
+        extensions: [],
+        slices: [],
+        elements: [
+          {
+            path: 'status'
+          },
+          {
+            path: 'intent'
+          },
+          {
+            path: 'reported'
+          },
+          {
+            path: 'medication'
+          },
+          {
+            path: 'subject'
+          },
+          {
+            path: 'encounter'
+          },
+          {
+            path: 'authoredOn'
+          },
+          {
+            path: 'requester'
+          },
+          {
+            path: 'dosageInstruction'
+          },
+          {
+            path: 'dosageInstruction.text'
+          }
+        ]
+      }.freeze
+
+      DELAYED_REFERENCES = [
+        {
+          path: 'requester',
+          resources: [
+            'Practitioner',
+            'Organization'
+          ]
+        }
+      ].freeze
+    end
+  end
+end

--- a/lib/modules/uscore_v3.1.0/profile_definitions/us_core_observation_lab_definitions.rb
+++ b/lib/modules/uscore_v3.1.0/profile_definitions/us_core_observation_lab_definitions.rb
@@ -1,0 +1,48 @@
+# frozen_string_literal: true
+
+module Inferno
+  module USCore310ProfileDefinitions
+    class USCore310ObservationLabSequenceDefinitions
+      MUST_SUPPORTS = {
+        extensions: [],
+        slices: [
+          {
+            name: 'Observation.category:Laboratory',
+            path: 'category',
+            discriminator: {
+              type: 'patternCodeableConcept',
+              path: '',
+              code: 'laboratory',
+              system: 'http://terminology.hl7.org/CodeSystem/observation-category'
+            }
+          }
+        ],
+        elements: [
+          {
+            path: 'status'
+          },
+          {
+            path: 'category'
+          },
+          {
+            path: 'code'
+          },
+          {
+            path: 'subject'
+          },
+          {
+            path: 'effective'
+          },
+          {
+            path: 'value'
+          },
+          {
+            path: 'dataAbsentReason'
+          }
+        ]
+      }.freeze
+
+      DELAYED_REFERENCES = [].freeze
+    end
+  end
+end

--- a/lib/modules/uscore_v3.1.0/profile_definitions/us_core_organization_definitions.rb
+++ b/lib/modules/uscore_v3.1.0/profile_definitions/us_core_organization_definitions.rb
@@ -1,0 +1,71 @@
+# frozen_string_literal: true
+
+module Inferno
+  module USCore310ProfileDefinitions
+    class USCore310OrganizationSequenceDefinitions
+      MUST_SUPPORTS = {
+        extensions: [],
+        slices: [
+          {
+            name: 'Organization.identifier:NPI',
+            path: 'identifier',
+            discriminator: {
+              type: 'patternIdentifier',
+              path: '',
+              system: 'http://hl7.org/fhir/sid/us-npi'
+            }
+          },
+          {
+            name: 'Organization.identifier:CLIA',
+            path: 'identifier',
+            discriminator: {
+              type: 'patternIdentifier',
+              path: '',
+              system: 'urn:oid:2.16.840.1.113883.4.7'
+            }
+          }
+        ],
+        elements: [
+          {
+            path: 'identifier'
+          },
+          {
+            path: 'identifier.system'
+          },
+          {
+            path: 'identifier.value'
+          },
+          {
+            path: 'active'
+          },
+          {
+            path: 'name'
+          },
+          {
+            path: 'telecom'
+          },
+          {
+            path: 'address'
+          },
+          {
+            path: 'address.line'
+          },
+          {
+            path: 'address.city'
+          },
+          {
+            path: 'address.state'
+          },
+          {
+            path: 'address.postalCode'
+          },
+          {
+            path: 'address.country'
+          }
+        ]
+      }.freeze
+
+      DELAYED_REFERENCES = [].freeze
+    end
+  end
+end

--- a/lib/modules/uscore_v3.1.0/profile_definitions/us_core_patient_definitions.rb
+++ b/lib/modules/uscore_v3.1.0/profile_definitions/us_core_patient_definitions.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+module Inferno
+  module USCore310ProfileDefinitions
+    class USCore310PatientSequenceDefinitions
+      MUST_SUPPORTS = {
+        extensions: [
+          {
+            id: 'Patient.extension:race',
+            url: 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-race'
+          },
+          {
+            id: 'Patient.extension:ethnicity',
+            url: 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity'
+          },
+          {
+            id: 'Patient.extension:birthsex',
+            url: 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-birthsex'
+          }
+        ],
+        slices: [],
+        elements: [
+          {
+            path: 'identifier'
+          },
+          {
+            path: 'identifier.system'
+          },
+          {
+            path: 'identifier.value'
+          },
+          {
+            path: 'name'
+          },
+          {
+            path: 'name.family'
+          },
+          {
+            path: 'name.given'
+          },
+          {
+            path: 'telecom'
+          },
+          {
+            path: 'telecom.system'
+          },
+          {
+            path: 'telecom.value'
+          },
+          {
+            path: 'telecom.use'
+          },
+          {
+            path: 'gender'
+          },
+          {
+            path: 'birthDate'
+          },
+          {
+            path: 'address'
+          },
+          {
+            path: 'address.line'
+          },
+          {
+            path: 'address.city'
+          },
+          {
+            path: 'address.state'
+          },
+          {
+            path: 'address.postalCode'
+          },
+          {
+            path: 'address.period'
+          },
+          {
+            path: 'communication'
+          },
+          {
+            path: 'communication.language'
+          }
+        ]
+      }.freeze
+
+      DELAYED_REFERENCES = [].freeze
+    end
+  end
+end

--- a/lib/modules/uscore_v3.1.0/profile_definitions/us_core_practitioner_definitions.rb
+++ b/lib/modules/uscore_v3.1.0/profile_definitions/us_core_practitioner_definitions.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+module Inferno
+  module USCore310ProfileDefinitions
+    class USCore310PractitionerSequenceDefinitions
+      MUST_SUPPORTS = {
+        extensions: [],
+        slices: [
+          {
+            name: 'Practitioner.identifier:NPI',
+            path: 'identifier',
+            discriminator: {
+              type: 'patternIdentifier',
+              path: '',
+              system: 'http://hl7.org/fhir/sid/us-npi'
+            }
+          }
+        ],
+        elements: [
+          {
+            path: 'identifier'
+          },
+          {
+            path: 'identifier.system'
+          },
+          {
+            path: 'identifier.value'
+          },
+          {
+            path: 'name'
+          },
+          {
+            path: 'name.family'
+          }
+        ]
+      }.freeze
+
+      DELAYED_REFERENCES = [].freeze
+    end
+  end
+end

--- a/lib/modules/uscore_v3.1.0/profile_definitions/us_core_practitionerrole_definitions.rb
+++ b/lib/modules/uscore_v3.1.0/profile_definitions/us_core_practitionerrole_definitions.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+module Inferno
+  module USCore310ProfileDefinitions
+    class USCore310PractitionerroleSequenceDefinitions
+      MUST_SUPPORTS = {
+        extensions: [],
+        slices: [],
+        elements: [
+          {
+            path: 'practitioner'
+          },
+          {
+            path: 'organization'
+          },
+          {
+            path: 'code'
+          },
+          {
+            path: 'specialty'
+          },
+          {
+            path: 'location'
+          },
+          {
+            path: 'telecom'
+          },
+          {
+            path: 'telecom.system'
+          },
+          {
+            path: 'telecom.value'
+          },
+          {
+            path: 'endpoint'
+          }
+        ]
+      }.freeze
+
+      DELAYED_REFERENCES = [
+        {
+          path: 'practitioner',
+          resources: [
+            'Practitioner'
+          ]
+        },
+        {
+          path: 'organization',
+          resources: [
+            'Organization'
+          ]
+        }
+      ].freeze
+    end
+  end
+end

--- a/lib/modules/uscore_v3.1.0/profile_definitions/us_core_procedure_definitions.rb
+++ b/lib/modules/uscore_v3.1.0/profile_definitions/us_core_procedure_definitions.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module Inferno
+  module USCore310ProfileDefinitions
+    class USCore310ProcedureSequenceDefinitions
+      MUST_SUPPORTS = {
+        extensions: [],
+        slices: [],
+        elements: [
+          {
+            path: 'status'
+          },
+          {
+            path: 'code'
+          },
+          {
+            path: 'subject'
+          },
+          {
+            path: 'performed'
+          }
+        ]
+      }.freeze
+
+      DELAYED_REFERENCES = [].freeze
+    end
+  end
+end

--- a/lib/modules/uscore_v3.1.0/profile_definitions/us_core_provenance_definitions.rb
+++ b/lib/modules/uscore_v3.1.0/profile_definitions/us_core_provenance_definitions.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+module Inferno
+  module USCore310ProfileDefinitions
+    class USCore310ProvenanceSequenceDefinitions
+      MUST_SUPPORTS = {
+        extensions: [],
+        slices: [
+          {
+            name: 'Provenance.agent:ProvenanceAuthor',
+            path: 'agent',
+            discriminator: {
+              type: 'patternCodeableConcept',
+              path: 'type',
+              code: 'author',
+              system: 'http://terminology.hl7.org/CodeSystem/provenance-participant-type'
+            }
+          },
+          {
+            name: 'Provenance.agent:ProvenanceTransmitter',
+            path: 'agent',
+            discriminator: {
+              type: 'patternCodeableConcept',
+              path: 'type',
+              code: 'transmitter',
+              system: 'http://hl7.org/fhir/us/core/CodeSystem/us-core-provenance-participant-type'
+            }
+          }
+        ],
+        elements: [
+          {
+            path: 'target'
+          },
+          {
+            path: 'recorded'
+          },
+          {
+            path: 'agent'
+          },
+          {
+            path: 'agent.type'
+          },
+          {
+            path: 'agent.who'
+          },
+          {
+            path: 'agent.onBehalfOf'
+          },
+          {
+            path: 'agent.type.coding.code',
+            fixed_value: 'author'
+          },
+          {
+            path: 'agent.type.coding.code',
+            fixed_value: 'transmitter'
+          }
+        ]
+      }.freeze
+
+      DELAYED_REFERENCES = [
+        {
+          path: 'agent.who',
+          resources: [
+            'Practitioner',
+            'Organization'
+          ]
+        },
+        {
+          path: 'agent.onBehalfOf',
+          resources: [
+            'Organization'
+          ]
+        }
+      ].freeze
+    end
+  end
+end

--- a/lib/modules/uscore_v3.1.0/profile_definitions/us_core_pulse_oximetry_definitions.rb
+++ b/lib/modules/uscore_v3.1.0/profile_definitions/us_core_pulse_oximetry_definitions.rb
@@ -1,0 +1,178 @@
+# frozen_string_literal: true
+
+module Inferno
+  module USCore310ProfileDefinitions
+    class USCore310PulseOximetrySequenceDefinitions
+      MUST_SUPPORTS = {
+        extensions: [],
+        slices: [
+          {
+            name: 'Observation.category:VSCat',
+            path: 'category',
+            discriminator: {
+              type: 'value',
+              values: [
+                {
+                  path: 'coding.code',
+                  value: 'vital-signs'
+                },
+                {
+                  path: 'coding.system',
+                  value: 'http://terminology.hl7.org/CodeSystem/observation-category'
+                }
+              ]
+            }
+          },
+          {
+            name: 'Observation.code.coding:PulseOx',
+            path: 'code.coding',
+            discriminator: {
+              type: 'value',
+              values: [
+                {
+                  path: 'code',
+                  value: '59408-5'
+                },
+                {
+                  path: 'system',
+                  value: 'http://loinc.org'
+                }
+              ]
+            }
+          },
+          {
+            name: 'Observation.value[x]:valueQuantity',
+            path: 'value',
+            discriminator: {
+              type: 'type',
+              code: 'Quantity'
+            }
+          },
+          {
+            name: 'Observation.component:FlowRate',
+            path: 'component',
+            discriminator: {
+              type: 'patternCodeableConcept',
+              path: 'code',
+              code: '3151-8',
+              system: 'http://loinc.org'
+            }
+          },
+          {
+            name: 'Observation.component:Concentration',
+            path: 'component',
+            discriminator: {
+              type: 'patternCodeableConcept',
+              path: 'code',
+              code: '3150-0',
+              system: 'http://loinc.org'
+            }
+          }
+        ],
+        elements: [
+          {
+            path: 'status'
+          },
+          {
+            path: 'category'
+          },
+          {
+            path: 'category.coding'
+          },
+          {
+            path: 'category.coding.system',
+            fixed_value: 'http://terminology.hl7.org/CodeSystem/observation-category'
+          },
+          {
+            path: 'category.coding.code',
+            fixed_value: 'vital-signs'
+          },
+          {
+            path: 'code'
+          },
+          {
+            path: 'code.coding'
+          },
+          {
+            path: 'code.coding.system',
+            fixed_value: 'http://loinc.org'
+          },
+          {
+            path: 'code.coding.code',
+            fixed_value: '59408-5'
+          },
+          {
+            path: 'subject'
+          },
+          {
+            path: 'effective'
+          },
+          {
+            path: 'value'
+          },
+          {
+            path: 'value.value'
+          },
+          {
+            path: 'value.unit'
+          },
+          {
+            path: 'value.system',
+            fixed_value: 'http://unitsofmeasure.org'
+          },
+          {
+            path: 'value.code',
+            fixed_value: '%'
+          },
+          {
+            path: 'dataAbsentReason'
+          },
+          {
+            path: 'component'
+          },
+          {
+            path: 'component.code'
+          },
+          {
+            path: 'component.code.coding.code',
+            fixed_value: '3151-8'
+          },
+          {
+            path: 'component.value.system',
+            fixed_value: 'http://unitsofmeasure.org'
+          },
+          {
+            path: 'component.value.code',
+            fixed_value: 'l/min'
+          },
+          {
+            path: 'component.code.coding.code',
+            fixed_value: '3150-0'
+          },
+          {
+            path: 'component.value'
+          },
+          {
+            path: 'component.value.value'
+          },
+          {
+            path: 'component.value.unit'
+          },
+          {
+            path: 'component.value.system',
+            fixed_value: 'http://unitsofmeasure.org'
+          },
+          {
+            path: 'component.value.code',
+            fixed_value: '%'
+          },
+          {
+            path: 'component.dataAbsentReason'
+          }
+        ]
+      }.freeze
+
+      DELAYED_REFERENCES = [].freeze
+    end
+  end
+end

--- a/lib/modules/uscore_v3.1.0/profile_definitions/us_core_smokingstatus_definitions.rb
+++ b/lib/modules/uscore_v3.1.0/profile_definitions/us_core_smokingstatus_definitions.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+module Inferno
+  module USCore310ProfileDefinitions
+    class USCore310SmokingstatusSequenceDefinitions
+      MUST_SUPPORTS = {
+        extensions: [],
+        slices: [
+          {
+            name: 'Observation.value[x]:valueCodeableConcept',
+            path: 'value',
+            discriminator: {
+              type: 'type',
+              code: 'CodeableConcept'
+            }
+          }
+        ],
+        elements: [
+          {
+            path: 'status'
+          },
+          {
+            path: 'code'
+          },
+          {
+            path: 'subject'
+          },
+          {
+            path: 'issued'
+          }
+        ]
+      }.freeze
+
+      DELAYED_REFERENCES = [].freeze
+    end
+  end
+end

--- a/lib/modules/uscore_v3.1.0/resprate_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/resprate_sequence.rb
@@ -1,11 +1,13 @@
 # frozen_string_literal: true
 
 require_relative './data_absent_reason_checker'
+require_relative './profile_definitions/resprate_definitions'
 
 module Inferno
   module Sequence
     class USCore310ResprateSequence < SequenceBase
       include Inferno::DataAbsentReasonChecker
+      include Inferno::USCore310ProfileDefinitions
 
       title 'Observation Respiratory Rate'
 
@@ -88,85 +90,6 @@ module Inferno
 
       @resources_found = false
 
-      MUST_SUPPORTS = {
-        extensions: [],
-        slices: [
-          {
-            name: 'Observation.category:VSCat',
-            path: 'category',
-            discriminator: {
-              type: 'value',
-              values: [
-                {
-                  path: 'coding.code',
-                  value: 'vital-signs'
-                },
-                {
-                  path: 'coding.system',
-                  value: 'http://terminology.hl7.org/CodeSystem/observation-category'
-                }
-              ]
-            }
-          },
-          {
-            name: 'Observation.value[x]:valueQuantity',
-            path: 'value',
-            discriminator: {
-              type: 'type',
-              code: 'Quantity'
-            }
-          }
-        ],
-        elements: [
-          {
-            path: 'status'
-          },
-          {
-            path: 'category'
-          },
-          {
-            path: 'category.coding'
-          },
-          {
-            path: 'category.coding.system',
-            fixed_value: 'http://terminology.hl7.org/CodeSystem/observation-category'
-          },
-          {
-            path: 'category.coding.code',
-            fixed_value: 'vital-signs'
-          },
-          {
-            path: 'code'
-          },
-          {
-            path: 'subject'
-          },
-          {
-            path: 'effective'
-          },
-          {
-            path: 'value'
-          },
-          {
-            path: 'value.value'
-          },
-          {
-            path: 'value.unit'
-          },
-          {
-            path: 'value.system',
-            fixed_value: 'http://unitsofmeasure.org'
-          },
-          {
-            path: 'value.code',
-            fixed_value: '/min'
-          },
-          {
-            path: 'dataAbsentReason'
-          }
-        ]
-      }.freeze
-
       test :search_by_patient_code do
         metadata do
           id '01'
@@ -204,7 +127,7 @@ module Inferno
             @observation_ary[patient] += resources_returned
 
             save_resource_references(versioned_resource_class('Observation'), @observation_ary[patient], Inferno::ValidationUtil::US_CORE_R4_URIS[:resp_rate])
-            save_delayed_sequence_references(resources_returned)
+            save_delayed_sequence_references(resources_returned, USCore310ResprateSequenceDefinitions::DELAYED_REFERENCES)
             validate_reply_entries(resources_returned, search_params)
 
             break
@@ -474,7 +397,7 @@ module Inferno
             .select { |resource| resource.resourceType == 'Provenance' }
         end
         save_resource_references(versioned_resource_class('Provenance'), provenance_results)
-        save_delayed_sequence_references(provenance_results)
+        save_delayed_sequence_references(provenance_results, USCore310ResprateSequenceDefinitions::DELAYED_REFERENCES)
         skip 'Could not resolve all parameters (patient, code) in any resource.' unless resolved_one
         skip 'No Provenance resources were returned from this search' unless provenance_results.present?
       end
@@ -638,15 +561,16 @@ module Inferno
         end
 
         skip_if_not_found(resource_type: 'Observation', delayed: false)
+        must_supports = USCore310ResprateSequenceDefinitions::MUST_SUPPORTS
 
-        missing_slices = MUST_SUPPORTS[:slices].reject do |slice|
+        missing_slices = must_supports[:slices].reject do |slice|
           @observation_ary&.values&.flatten&.any? do |resource|
             slice_found = find_slice(resource, slice[:path], slice[:discriminator])
             slice_found.present?
           end
         end
 
-        missing_must_support_elements = MUST_SUPPORTS[:elements].reject do |element|
+        missing_must_support_elements = must_supports[:elements].reject do |element|
           @observation_ary&.values&.flatten&.any? do |resource|
             value_found = resolve_element_from_path(resource, element[:path]) { |value| element[:fixed_value].blank? || value == element[:fixed_value] }
             value_found.present?

--- a/lib/modules/uscore_v3.1.0/us_core_allergyintolerance_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_allergyintolerance_sequence.rb
@@ -1,11 +1,13 @@
 # frozen_string_literal: true
 
 require_relative './data_absent_reason_checker'
+require_relative './profile_definitions/us_core_allergyintolerance_definitions'
 
 module Inferno
   module Sequence
     class USCore310AllergyintoleranceSequence < SequenceBase
       include Inferno::DataAbsentReasonChecker
+      include Inferno::USCore310ProfileDefinitions
 
       title 'AllergyIntolerance'
 
@@ -74,25 +76,6 @@ module Inferno
 
       @resources_found = false
 
-      MUST_SUPPORTS = {
-        extensions: [],
-        slices: [],
-        elements: [
-          {
-            path: 'clinicalStatus'
-          },
-          {
-            path: 'verificationStatus'
-          },
-          {
-            path: 'code'
-          },
-          {
-            path: 'patient'
-          }
-        ]
-      }.freeze
-
       test :search_by_patient do
         metadata do
           id '01'
@@ -131,7 +114,7 @@ module Inferno
           @resources_found = @allergy_intolerance.present?
 
           save_resource_references(versioned_resource_class('AllergyIntolerance'), @allergy_intolerance_ary[patient])
-          save_delayed_sequence_references(@allergy_intolerance_ary[patient])
+          save_delayed_sequence_references(@allergy_intolerance_ary[patient], USCore310AllergyintoleranceSequenceDefinitions::DELAYED_REFERENCES)
           validate_reply_entries(@allergy_intolerance_ary[patient], search_params)
         end
 
@@ -258,7 +241,7 @@ module Inferno
             .select { |resource| resource.resourceType == 'Provenance' }
         end
         save_resource_references(versioned_resource_class('Provenance'), provenance_results)
-        save_delayed_sequence_references(provenance_results)
+        save_delayed_sequence_references(provenance_results, USCore310AllergyintoleranceSequenceDefinitions::DELAYED_REFERENCES)
 
         skip 'No Provenance resources were returned from this search' unless provenance_results.present?
       end
@@ -402,8 +385,9 @@ module Inferno
         end
 
         skip_if_not_found(resource_type: 'AllergyIntolerance', delayed: false)
+        must_supports = USCore310AllergyintoleranceSequenceDefinitions::MUST_SUPPORTS
 
-        missing_must_support_elements = MUST_SUPPORTS[:elements].reject do |element|
+        missing_must_support_elements = must_supports[:elements].reject do |element|
           @allergy_intolerance_ary&.values&.flatten&.any? do |resource|
             value_found = resolve_element_from_path(resource, element[:path]) { |value| element[:fixed_value].blank? || value == element[:fixed_value] }
             value_found.present?

--- a/lib/modules/uscore_v3.1.0/us_core_careplan_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_careplan_sequence.rb
@@ -1,11 +1,13 @@
 # frozen_string_literal: true
 
 require_relative './data_absent_reason_checker'
+require_relative './profile_definitions/us_core_careplan_definitions'
 
 module Inferno
   module Sequence
     class USCore310CareplanSequence < SequenceBase
       include Inferno::DataAbsentReasonChecker
+      include Inferno::USCore310ProfileDefinitions
 
       title 'CarePlan'
 
@@ -83,42 +85,6 @@ module Inferno
 
       @resources_found = false
 
-      MUST_SUPPORTS = {
-        extensions: [],
-        slices: [
-          {
-            name: 'CarePlan.category:AssessPlan',
-            path: 'category',
-            discriminator: {
-              type: 'patternCodeableConcept',
-              path: '',
-              code: 'assess-plan',
-              system: 'http://hl7.org/fhir/us/core/CodeSystem/careplan-category'
-            }
-          }
-        ],
-        elements: [
-          {
-            path: 'text'
-          },
-          {
-            path: 'text.status'
-          },
-          {
-            path: 'status'
-          },
-          {
-            path: 'intent'
-          },
-          {
-            path: 'category'
-          },
-          {
-            path: 'subject'
-          }
-        ]
-      }.freeze
-
       test :search_by_patient_category do
         metadata do
           id '01'
@@ -156,7 +122,7 @@ module Inferno
             @care_plan_ary[patient] += resources_returned
 
             save_resource_references(versioned_resource_class('CarePlan'), @care_plan_ary[patient])
-            save_delayed_sequence_references(resources_returned)
+            save_delayed_sequence_references(resources_returned, USCore310CareplanSequenceDefinitions::DELAYED_REFERENCES)
             validate_reply_entries(resources_returned, search_params)
 
             break
@@ -388,7 +354,7 @@ module Inferno
             .select { |resource| resource.resourceType == 'Provenance' }
         end
         save_resource_references(versioned_resource_class('Provenance'), provenance_results)
-        save_delayed_sequence_references(provenance_results)
+        save_delayed_sequence_references(provenance_results, USCore310CareplanSequenceDefinitions::DELAYED_REFERENCES)
         skip 'Could not resolve all parameters (patient, category) in any resource.' unless resolved_one
         skip 'No Provenance resources were returned from this search' unless provenance_results.present?
       end
@@ -510,15 +476,16 @@ module Inferno
         end
 
         skip_if_not_found(resource_type: 'CarePlan', delayed: false)
+        must_supports = USCore310CareplanSequenceDefinitions::MUST_SUPPORTS
 
-        missing_slices = MUST_SUPPORTS[:slices].reject do |slice|
+        missing_slices = must_supports[:slices].reject do |slice|
           @care_plan_ary&.values&.flatten&.any? do |resource|
             slice_found = find_slice(resource, slice[:path], slice[:discriminator])
             slice_found.present?
           end
         end
 
-        missing_must_support_elements = MUST_SUPPORTS[:elements].reject do |element|
+        missing_must_support_elements = must_supports[:elements].reject do |element|
           @care_plan_ary&.values&.flatten&.any? do |resource|
             value_found = resolve_element_from_path(resource, element[:path]) { |value| element[:fixed_value].blank? || value == element[:fixed_value] }
             value_found.present?

--- a/lib/modules/uscore_v3.1.0/us_core_careteam_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_careteam_sequence.rb
@@ -1,11 +1,13 @@
 # frozen_string_literal: true
 
 require_relative './data_absent_reason_checker'
+require_relative './profile_definitions/us_core_careteam_definitions'
 
 module Inferno
   module Sequence
     class USCore310CareteamSequence < SequenceBase
       include Inferno::DataAbsentReasonChecker
+      include Inferno::USCore310ProfileDefinitions
 
       title 'CareTeam'
 
@@ -74,28 +76,6 @@ module Inferno
 
       @resources_found = false
 
-      MUST_SUPPORTS = {
-        extensions: [],
-        slices: [],
-        elements: [
-          {
-            path: 'status'
-          },
-          {
-            path: 'subject'
-          },
-          {
-            path: 'participant'
-          },
-          {
-            path: 'participant.role'
-          },
-          {
-            path: 'participant.member'
-          }
-        ]
-      }.freeze
-
       test :search_by_patient_status do
         metadata do
           id '01'
@@ -132,7 +112,7 @@ module Inferno
             values_found += 1
 
             save_resource_references(versioned_resource_class('CareTeam'), @care_team_ary[patient])
-            save_delayed_sequence_references(resources_returned)
+            save_delayed_sequence_references(resources_returned, USCore310CareteamSequenceDefinitions::DELAYED_REFERENCES)
             validate_reply_entries(resources_returned, search_params)
 
             break if values_found == 2
@@ -229,7 +209,7 @@ module Inferno
             .select { |resource| resource.resourceType == 'Provenance' }
         end
         save_resource_references(versioned_resource_class('Provenance'), provenance_results)
-        save_delayed_sequence_references(provenance_results)
+        save_delayed_sequence_references(provenance_results, USCore310CareteamSequenceDefinitions::DELAYED_REFERENCES)
         skip 'Could not resolve all parameters (patient, status) in any resource.' unless resolved_one
         skip 'No Provenance resources were returned from this search' unless provenance_results.present?
       end
@@ -329,8 +309,9 @@ module Inferno
         end
 
         skip_if_not_found(resource_type: 'CareTeam', delayed: false)
+        must_supports = USCore310CareteamSequenceDefinitions::MUST_SUPPORTS
 
-        missing_must_support_elements = MUST_SUPPORTS[:elements].reject do |element|
+        missing_must_support_elements = must_supports[:elements].reject do |element|
           @care_team_ary&.values&.flatten&.any? do |resource|
             value_found = resolve_element_from_path(resource, element[:path]) { |value| element[:fixed_value].blank? || value == element[:fixed_value] }
             value_found.present?

--- a/lib/modules/uscore_v3.1.0/us_core_documentreference_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_documentreference_sequence.rb
@@ -1,11 +1,13 @@
 # frozen_string_literal: true
 
 require_relative './data_absent_reason_checker'
+require_relative './profile_definitions/us_core_documentreference_definitions'
 
 module Inferno
   module Sequence
     class USCore310DocumentreferenceSequence < SequenceBase
       include Inferno::DataAbsentReasonChecker
+      include Inferno::USCore310ProfileDefinitions
 
       title 'DocumentReference'
 
@@ -98,64 +100,6 @@ module Inferno
 
       @resources_found = false
 
-      MUST_SUPPORTS = {
-        extensions: [],
-        slices: [],
-        elements: [
-          {
-            path: 'identifier'
-          },
-          {
-            path: 'status'
-          },
-          {
-            path: 'type'
-          },
-          {
-            path: 'category'
-          },
-          {
-            path: 'subject'
-          },
-          {
-            path: 'date'
-          },
-          {
-            path: 'author'
-          },
-          {
-            path: 'custodian'
-          },
-          {
-            path: 'content'
-          },
-          {
-            path: 'content.attachment'
-          },
-          {
-            path: 'content.attachment.contentType'
-          },
-          {
-            path: 'content.attachment.data'
-          },
-          {
-            path: 'content.attachment.url'
-          },
-          {
-            path: 'content.format'
-          },
-          {
-            path: 'context'
-          },
-          {
-            path: 'context.encounter'
-          },
-          {
-            path: 'context.period'
-          }
-        ]
-      }.freeze
-
       test :search_by_patient do
         metadata do
           id '01'
@@ -194,7 +138,7 @@ module Inferno
           @resources_found = @document_reference.present?
 
           save_resource_references(versioned_resource_class('DocumentReference'), @document_reference_ary[patient])
-          save_delayed_sequence_references(@document_reference_ary[patient])
+          save_delayed_sequence_references(@document_reference_ary[patient], USCore310DocumentreferenceSequenceDefinitions::DELAYED_REFERENCES)
           validate_reply_entries(@document_reference_ary[patient], search_params)
         end
 
@@ -522,7 +466,7 @@ module Inferno
             .select { |resource| resource.resourceType == 'Provenance' }
         end
         save_resource_references(versioned_resource_class('Provenance'), provenance_results)
-        save_delayed_sequence_references(provenance_results)
+        save_delayed_sequence_references(provenance_results, USCore310DocumentreferenceSequenceDefinitions::DELAYED_REFERENCES)
 
         skip 'No Provenance resources were returned from this search' unless provenance_results.present?
       end
@@ -698,8 +642,9 @@ module Inferno
         end
 
         skip_if_not_found(resource_type: 'DocumentReference', delayed: false)
+        must_supports = USCore310DocumentreferenceSequenceDefinitions::MUST_SUPPORTS
 
-        missing_must_support_elements = MUST_SUPPORTS[:elements].reject do |element|
+        missing_must_support_elements = must_supports[:elements].reject do |element|
           @document_reference_ary&.values&.flatten&.any? do |resource|
             value_found = resolve_element_from_path(resource, element[:path]) { |value| element[:fixed_value].blank? || value == element[:fixed_value] }
             value_found.present?

--- a/lib/modules/uscore_v3.1.0/us_core_encounter_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_encounter_sequence.rb
@@ -1,11 +1,13 @@
 # frozen_string_literal: true
 
 require_relative './data_absent_reason_checker'
+require_relative './profile_definitions/us_core_encounter_definitions'
 
 module Inferno
   module Sequence
     class USCore310EncounterSequence < SequenceBase
       include Inferno::DataAbsentReasonChecker
+      include Inferno::USCore310ProfileDefinitions
 
       title 'Encounter'
 
@@ -98,64 +100,6 @@ module Inferno
       end
 
       @resources_found = false
-
-      MUST_SUPPORTS = {
-        extensions: [],
-        slices: [],
-        elements: [
-          {
-            path: 'identifier'
-          },
-          {
-            path: 'identifier.system'
-          },
-          {
-            path: 'identifier.value'
-          },
-          {
-            path: 'status'
-          },
-          {
-            path: 'local_class'
-          },
-          {
-            path: 'type'
-          },
-          {
-            path: 'subject'
-          },
-          {
-            path: 'participant'
-          },
-          {
-            path: 'participant.type'
-          },
-          {
-            path: 'participant.period'
-          },
-          {
-            path: 'participant.individual'
-          },
-          {
-            path: 'period'
-          },
-          {
-            path: 'reasonCode'
-          },
-          {
-            path: 'hospitalization'
-          },
-          {
-            path: 'hospitalization.dischargeDisposition'
-          },
-          {
-            path: 'location'
-          },
-          {
-            path: 'location.location'
-          }
-        ]
-      }.freeze
 
       test :resource_read do
         metadata do
@@ -345,8 +289,9 @@ module Inferno
         end
 
         skip_if_not_found(resource_type: 'Encounter', delayed: true)
+        must_supports = USCore310EncounterSequenceDefinitions::MUST_SUPPORTS
 
-        missing_must_support_elements = MUST_SUPPORTS[:elements].reject do |element|
+        missing_must_support_elements = must_supports[:elements].reject do |element|
           @encounter_ary&.any? do |resource|
             value_found = resolve_element_from_path(resource, element[:path]) { |value| element[:fixed_value].blank? || value == element[:fixed_value] }
             value_found.present?

--- a/lib/modules/uscore_v3.1.0/us_core_immunization_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_immunization_sequence.rb
@@ -1,11 +1,13 @@
 # frozen_string_literal: true
 
 require_relative './data_absent_reason_checker'
+require_relative './profile_definitions/us_core_immunization_definitions'
 
 module Inferno
   module Sequence
     class USCore310ImmunizationSequence < SequenceBase
       include Inferno::DataAbsentReasonChecker
+      include Inferno::USCore310ProfileDefinitions
 
       title 'Immunization'
 
@@ -78,31 +80,6 @@ module Inferno
 
       @resources_found = false
 
-      MUST_SUPPORTS = {
-        extensions: [],
-        slices: [],
-        elements: [
-          {
-            path: 'status'
-          },
-          {
-            path: 'statusReason'
-          },
-          {
-            path: 'vaccineCode'
-          },
-          {
-            path: 'patient'
-          },
-          {
-            path: 'occurrence'
-          },
-          {
-            path: 'primarySource'
-          }
-        ]
-      }.freeze
-
       test :search_by_patient do
         metadata do
           id '01'
@@ -141,7 +118,7 @@ module Inferno
           @resources_found = @immunization.present?
 
           save_resource_references(versioned_resource_class('Immunization'), @immunization_ary[patient])
-          save_delayed_sequence_references(@immunization_ary[patient])
+          save_delayed_sequence_references(@immunization_ary[patient], USCore310ImmunizationSequenceDefinitions::DELAYED_REFERENCES)
           validate_reply_entries(@immunization_ary[patient], search_params)
         end
 
@@ -315,7 +292,7 @@ module Inferno
             .select { |resource| resource.resourceType == 'Provenance' }
         end
         save_resource_references(versioned_resource_class('Provenance'), provenance_results)
-        save_delayed_sequence_references(provenance_results)
+        save_delayed_sequence_references(provenance_results, USCore310ImmunizationSequenceDefinitions::DELAYED_REFERENCES)
 
         skip 'No Provenance resources were returned from this search' unless provenance_results.present?
       end
@@ -423,8 +400,9 @@ module Inferno
         end
 
         skip_if_not_found(resource_type: 'Immunization', delayed: false)
+        must_supports = USCore310ImmunizationSequenceDefinitions::MUST_SUPPORTS
 
-        missing_must_support_elements = MUST_SUPPORTS[:elements].reject do |element|
+        missing_must_support_elements = must_supports[:elements].reject do |element|
           @immunization_ary&.values&.flatten&.any? do |resource|
             value_found = resolve_element_from_path(resource, element[:path]) { |value| element[:fixed_value].blank? || value == element[:fixed_value] }
             value_found.present?

--- a/lib/modules/uscore_v3.1.0/us_core_implantable_device_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_implantable_device_sequence.rb
@@ -1,11 +1,13 @@
 # frozen_string_literal: true
 
 require_relative './data_absent_reason_checker'
+require_relative './profile_definitions/us_core_implantable_device_definitions'
 
 module Inferno
   module Sequence
     class USCore310ImplantableDeviceSequence < SequenceBase
       include Inferno::DataAbsentReasonChecker
+      include Inferno::USCore310ProfileDefinitions
 
       title 'Implantable Device'
 
@@ -40,46 +42,6 @@ module Inferno
       end
 
       @resources_found = false
-
-      MUST_SUPPORTS = {
-        extensions: [],
-        slices: [],
-        elements: [
-          {
-            path: 'udiCarrier'
-          },
-          {
-            path: 'udiCarrier.deviceIdentifier'
-          },
-          {
-            path: 'udiCarrier.carrierAIDC'
-          },
-          {
-            path: 'udiCarrier.carrierHRF'
-          },
-          {
-            path: 'distinctIdentifier'
-          },
-          {
-            path: 'manufactureDate'
-          },
-          {
-            path: 'expirationDate'
-          },
-          {
-            path: 'lotNumber'
-          },
-          {
-            path: 'serialNumber'
-          },
-          {
-            path: 'type'
-          },
-          {
-            path: 'patient'
-          }
-        ]
-      }.freeze
 
       test :search_by_patient do
         metadata do
@@ -126,7 +88,7 @@ module Inferno
           @resources_found = @device.present?
 
           save_resource_references(versioned_resource_class('Device'), @device_ary[patient])
-          save_delayed_sequence_references(@device_ary[patient])
+          save_delayed_sequence_references(@device_ary[patient], USCore310ImplantableDeviceSequenceDefinitions::DELAYED_REFERENCES)
           validate_reply_entries(@device_ary[patient], search_params)
         end
 
@@ -251,7 +213,7 @@ module Inferno
             .select { |resource| resource.resourceType == 'Provenance' }
         end
         save_resource_references(versioned_resource_class('Provenance'), provenance_results)
-        save_delayed_sequence_references(provenance_results)
+        save_delayed_sequence_references(provenance_results, USCore310ImplantableDeviceSequenceDefinitions::DELAYED_REFERENCES)
 
         skip 'No Provenance resources were returned from this search' unless provenance_results.present?
       end
@@ -381,8 +343,9 @@ module Inferno
         end
 
         skip_if_not_found(resource_type: 'Device', delayed: false)
+        must_supports = USCore310ImplantableDeviceSequenceDefinitions::MUST_SUPPORTS
 
-        missing_must_support_elements = MUST_SUPPORTS[:elements].reject do |element|
+        missing_must_support_elements = must_supports[:elements].reject do |element|
           @device_ary&.values&.flatten&.any? do |resource|
             value_found = resolve_element_from_path(resource, element[:path]) { |value| element[:fixed_value].blank? || value == element[:fixed_value] }
             value_found.present?

--- a/lib/modules/uscore_v3.1.0/us_core_location_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_location_sequence.rb
@@ -1,11 +1,13 @@
 # frozen_string_literal: true
 
 require_relative './data_absent_reason_checker'
+require_relative './profile_definitions/us_core_location_definitions'
 
 module Inferno
   module Sequence
     class USCore310LocationSequence < SequenceBase
       include Inferno::DataAbsentReasonChecker
+      include Inferno::USCore310ProfileDefinitions
 
       title 'Location'
 
@@ -62,40 +64,6 @@ module Inferno
       end
 
       @resources_found = false
-
-      MUST_SUPPORTS = {
-        extensions: [],
-        slices: [],
-        elements: [
-          {
-            path: 'status'
-          },
-          {
-            path: 'name'
-          },
-          {
-            path: 'telecom'
-          },
-          {
-            path: 'address'
-          },
-          {
-            path: 'address.line'
-          },
-          {
-            path: 'address.city'
-          },
-          {
-            path: 'address.state'
-          },
-          {
-            path: 'address.postalCode'
-          },
-          {
-            path: 'managingOrganization'
-          }
-        ]
-      }.freeze
 
       test :resource_read do
         metadata do
@@ -257,8 +225,9 @@ module Inferno
         end
 
         skip_if_not_found(resource_type: 'Location', delayed: true)
+        must_supports = USCore310LocationSequenceDefinitions::MUST_SUPPORTS
 
-        missing_must_support_elements = MUST_SUPPORTS[:elements].reject do |element|
+        missing_must_support_elements = must_supports[:elements].reject do |element|
           @location_ary&.any? do |resource|
             value_found = resolve_element_from_path(resource, element[:path]) { |value| element[:fixed_value].blank? || value == element[:fixed_value] }
             value_found.present?

--- a/lib/modules/uscore_v3.1.0/us_core_medicationrequest_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_medicationrequest_sequence.rb
@@ -1,11 +1,13 @@
 # frozen_string_literal: true
 
 require_relative './data_absent_reason_checker'
+require_relative './profile_definitions/us_core_medicationrequest_definitions'
 
 module Inferno
   module Sequence
     class USCore310MedicationrequestSequence < SequenceBase
       include Inferno::DataAbsentReasonChecker
+      include Inferno::USCore310ProfileDefinitions
 
       title 'MedicationRequest'
 
@@ -119,43 +121,6 @@ module Inferno
 
       @resources_found = false
 
-      MUST_SUPPORTS = {
-        extensions: [],
-        slices: [],
-        elements: [
-          {
-            path: 'status'
-          },
-          {
-            path: 'intent'
-          },
-          {
-            path: 'reported'
-          },
-          {
-            path: 'medication'
-          },
-          {
-            path: 'subject'
-          },
-          {
-            path: 'encounter'
-          },
-          {
-            path: 'authoredOn'
-          },
-          {
-            path: 'requester'
-          },
-          {
-            path: 'dosageInstruction'
-          },
-          {
-            path: 'dosageInstruction.text'
-          }
-        ]
-      }.freeze
-
       test :search_by_patient_intent do
         metadata do
           id '01'
@@ -197,7 +162,7 @@ module Inferno
             @medication_request_ary[patient] += resources_returned
 
             save_resource_references(versioned_resource_class('MedicationRequest'), @medication_request_ary[patient])
-            save_delayed_sequence_references(resources_returned)
+            save_delayed_sequence_references(resources_returned, USCore310MedicationrequestSequenceDefinitions::DELAYED_REFERENCES)
             validate_reply_entries(resources_returned, search_params)
             test_medication_inclusion(@medication_request_ary[patient], search_params)
             break
@@ -463,7 +428,7 @@ module Inferno
             .select { |resource| resource.resourceType == 'Provenance' }
         end
         save_resource_references(versioned_resource_class('Provenance'), provenance_results)
-        save_delayed_sequence_references(provenance_results)
+        save_delayed_sequence_references(provenance_results, USCore310MedicationrequestSequenceDefinitions::DELAYED_REFERENCES)
         skip 'Could not resolve all parameters (patient, intent) in any resource.' unless resolved_one
         skip 'No Provenance resources were returned from this search' unless provenance_results.present?
       end
@@ -606,8 +571,9 @@ module Inferno
         end
 
         skip_if_not_found(resource_type: 'MedicationRequest', delayed: false)
+        must_supports = USCore310MedicationrequestSequenceDefinitions::MUST_SUPPORTS
 
-        missing_must_support_elements = MUST_SUPPORTS[:elements].reject do |element|
+        missing_must_support_elements = must_supports[:elements].reject do |element|
           @medication_request_ary&.values&.flatten&.any? do |resource|
             value_found = resolve_element_from_path(resource, element[:path]) { |value| element[:fixed_value].blank? || value == element[:fixed_value] }
             value_found.present?

--- a/lib/modules/uscore_v3.1.0/us_core_observation_lab_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_observation_lab_sequence.rb
@@ -1,11 +1,13 @@
 # frozen_string_literal: true
 
 require_relative './data_absent_reason_checker'
+require_relative './profile_definitions/us_core_observation_lab_definitions'
 
 module Inferno
   module Sequence
     class USCore310ObservationLabSequence < SequenceBase
       include Inferno::DataAbsentReasonChecker
+      include Inferno::USCore310ProfileDefinitions
 
       title 'Laboratory Result Observation'
 
@@ -88,45 +90,6 @@ module Inferno
 
       @resources_found = false
 
-      MUST_SUPPORTS = {
-        extensions: [],
-        slices: [
-          {
-            name: 'Observation.category:Laboratory',
-            path: 'category',
-            discriminator: {
-              type: 'patternCodeableConcept',
-              path: '',
-              code: 'laboratory',
-              system: 'http://terminology.hl7.org/CodeSystem/observation-category'
-            }
-          }
-        ],
-        elements: [
-          {
-            path: 'status'
-          },
-          {
-            path: 'category'
-          },
-          {
-            path: 'code'
-          },
-          {
-            path: 'subject'
-          },
-          {
-            path: 'effective'
-          },
-          {
-            path: 'value'
-          },
-          {
-            path: 'dataAbsentReason'
-          }
-        ]
-      }.freeze
-
       test :search_by_patient_category do
         metadata do
           id '01'
@@ -164,7 +127,7 @@ module Inferno
             @observation_ary[patient] += resources_returned
 
             save_resource_references(versioned_resource_class('Observation'), @observation_ary[patient], Inferno::ValidationUtil::US_CORE_R4_URIS[:lab_results])
-            save_delayed_sequence_references(resources_returned)
+            save_delayed_sequence_references(resources_returned, USCore310ObservationLabSequenceDefinitions::DELAYED_REFERENCES)
             validate_reply_entries(resources_returned, search_params)
 
             break
@@ -434,7 +397,7 @@ module Inferno
             .select { |resource| resource.resourceType == 'Provenance' }
         end
         save_resource_references(versioned_resource_class('Provenance'), provenance_results)
-        save_delayed_sequence_references(provenance_results)
+        save_delayed_sequence_references(provenance_results, USCore310ObservationLabSequenceDefinitions::DELAYED_REFERENCES)
         skip 'Could not resolve all parameters (patient, category) in any resource.' unless resolved_one
         skip 'No Provenance resources were returned from this search' unless provenance_results.present?
       end
@@ -564,15 +527,16 @@ module Inferno
         end
 
         skip_if_not_found(resource_type: 'Observation', delayed: false)
+        must_supports = USCore310ObservationLabSequenceDefinitions::MUST_SUPPORTS
 
-        missing_slices = MUST_SUPPORTS[:slices].reject do |slice|
+        missing_slices = must_supports[:slices].reject do |slice|
           @observation_ary&.values&.flatten&.any? do |resource|
             slice_found = find_slice(resource, slice[:path], slice[:discriminator])
             slice_found.present?
           end
         end
 
-        missing_must_support_elements = MUST_SUPPORTS[:elements].reject do |element|
+        missing_must_support_elements = must_supports[:elements].reject do |element|
           @observation_ary&.values&.flatten&.any? do |resource|
             value_found = resolve_element_from_path(resource, element[:path]) { |value| element[:fixed_value].blank? || value == element[:fixed_value] }
             value_found.present?

--- a/lib/modules/uscore_v3.1.0/us_core_practitionerrole_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_practitionerrole_sequence.rb
@@ -1,11 +1,13 @@
 # frozen_string_literal: true
 
 require_relative './data_absent_reason_checker'
+require_relative './profile_definitions/us_core_practitionerrole_definitions'
 
 module Inferno
   module Sequence
     class USCore310PractitionerroleSequence < SequenceBase
       include Inferno::DataAbsentReasonChecker
+      include Inferno::USCore310ProfileDefinitions
 
       title 'PractitionerRole'
 
@@ -42,40 +44,6 @@ module Inferno
       end
 
       @resources_found = false
-
-      MUST_SUPPORTS = {
-        extensions: [],
-        slices: [],
-        elements: [
-          {
-            path: 'practitioner'
-          },
-          {
-            path: 'organization'
-          },
-          {
-            path: 'code'
-          },
-          {
-            path: 'specialty'
-          },
-          {
-            path: 'location'
-          },
-          {
-            path: 'telecom'
-          },
-          {
-            path: 'telecom.system'
-          },
-          {
-            path: 'telecom.value'
-          },
-          {
-            path: 'endpoint'
-          }
-        ]
-      }.freeze
 
       test :resource_read do
         metadata do
@@ -225,8 +193,9 @@ module Inferno
         end
 
         skip_if_not_found(resource_type: 'PractitionerRole', delayed: true)
+        must_supports = USCore310PractitionerroleSequenceDefinitions::MUST_SUPPORTS
 
-        missing_must_support_elements = MUST_SUPPORTS[:elements].reject do |element|
+        missing_must_support_elements = must_supports[:elements].reject do |element|
           @practitioner_role_ary&.any? do |resource|
             value_found = resolve_element_from_path(resource, element[:path]) { |value| element[:fixed_value].blank? || value == element[:fixed_value] }
             value_found.present?

--- a/test/unit/sequence_base_test.rb
+++ b/test/unit/sequence_base_test.rb
@@ -27,26 +27,35 @@ class SequenceBaseTest < MiniTest::Test
     @sequence = Inferno::Sequence::SequenceBase.new(@instance, client, true)
   end
 
-  def test_save_delayed_resource_references
-    delayed_resources = ['Location', 'Organization', 'Practitioner', 'PractitionerRole']
-    some_non_delayed_resources = ['AllergyIntolerance', 'CarePlan', 'Careteam', 'Condition', 'Device', 'Observation', 'Goal']
-
-    delayed_resources.each do |res|
-      set_resource_reference(@allergy_intolerance_resource, res)
-      @sequence.save_delayed_sequence_references(Array.wrap(@allergy_intolerance_resource))
-      assert @instance.resource_references.any? { |ref| ref.resource_type == res }, "#{res} reference should be saved"
+  describe '#save_delayed_sequence_references' do
+    before do
+      @instance = Inferno::Models::TestingInstance.create(selected_module: 'uscore_v3.0.0')
+      client = FHIR::Client.new('')
+      @sequence = Inferno::Sequence::SequenceBase.new(@instance, client, true)
+      @diagnostic_report_resource = FHIR.from_contents(load_fixture(:us_core_r4_diagnostic_report_note))
+      @delayed_references = Inferno::USCore310ProfileDefinitions::USCore310DiagnosticreportNoteSequenceDefinitions::DELAYED_REFERENCES
     end
-    some_non_delayed_resources.each do |res|
-      set_resource_reference(@allergy_intolerance_resource, res)
-      @sequence.save_delayed_sequence_references(Array.wrap(@allergy_intolerance_resource))
-      assert @instance.resource_references.none? { |ref| ref.resource_type == res }, "#{res} reference should not be saved"
-    end
-  end
 
-  def set_resource_reference(resource, type)
-    new_reference = FHIR::Reference.new
-    new_reference.reference = "#{type}/1234"
-    resource.recorder = new_reference
+    it 'saves reference to delayed US core resources' do
+      reference = FHIR::Reference.new
+      reference.reference = 'Practitioner/1234'
+      @diagnostic_report_resource.performer = reference
+      @sequence.save_delayed_sequence_references(Array.wrap(@diagnostic_report_resource), @delayed_references)
+      assert @instance.resource_references.any? { |ref| ref.resource_type == 'Practitioner' }, 'Practitioner references should be saved in DiagnosticReport.perfomer'
+
+      reference.reference = 'Organization/1234'
+      @diagnostic_report_resource.performer = reference
+      @sequence.save_delayed_sequence_references(Array.wrap(@diagnostic_report_resource), @delayed_references)
+      assert @instance.resource_references.any? { |ref| ref.resource_type == 'Organization' }, 'Organization references should be saved in DiagnosticReport.perfomer'
+    end
+
+    it 'does not save delayed reference when not us core resource' do
+      reference = FHIR::Reference.new
+      reference.reference = 'Location/1234'
+      @diagnostic_report_resource.performer = reference
+      @sequence.save_delayed_sequence_references(Array.wrap(@diagnostic_report_resource), @delayed_references)
+      assert @instance.resource_references.none? { |ref| ref.resource_type == 'Location' }, 'Location references should be saved in DiagnosticReport.perfomer'
+    end
   end
 
   describe '#get_value_for_search_param' do


### PR DESCRIPTION
This PR makes it so only references to us core resources will be saved when saving delayed resource references. I made a list of all the references to us core resources for each profile and put into a "definitions" file along with the must support info. Then this file is pulled in by the sequences and the bulk data sequence. 

**Submitter:**
- [X] This pull request describes why these changes were made
- [X] Internal ticket for this PR: https://oncprojectracking.healthit.gov/support/browse/FI-738
- [X] Internal ticket links to this PR
- [X] Internal ticket is properly labeled (Community/Program)
- [X] Internal ticket has a justification for its Community/Program label
- [X] Code diff has been reviewed for extraneous/missing code
- [X] Tests are included and test edge cases
- [X] Tests/code quality metrics have been run locally and pass


**Reviewer 1:**

Name:
- [x] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
