### PR TITLE
FI-508: Unescape unicode in responses

### DIFF
--- a/lib/app/endpoint/home.rb
+++ b/lib/app/endpoint/home.rb
@@ -111,6 +111,7 @@ module Inferno
         get '/:id/test_request/:test_request_id/?' do
           request_response = Inferno::Models::RequestResponse.get(params[:test_request_id])
           halt 404 if request_response.instance_id != params[:id]
+
           erb :request_details, { layout: false }, rr: request_response
         end
       end

--- a/lib/app/models/request_response.rb
+++ b/lib/app/models/request_response.rb
@@ -23,6 +23,8 @@ module Inferno
         request = req.request
         response = req.response
 
+        unescape_unicode(response[:body])
+
         new(
           direction: direction || req&.direction,
           request_method: request[:method],
@@ -35,6 +37,12 @@ module Inferno
           instance_id: instance_id,
           timestamp: response[:timestamp]
         )
+      end
+
+      # This is needed to escape HTML when the html tags are unicode escape sequences
+      # https://stackoverflow.com/questions/7015778/is-this-the-best-way-to-unescape-unicode-escape-sequences-in-ruby
+      def self.unescape_unicode(body)
+        body.gsub!(/\\u(\h{4})/) { |_m| [Regexp.last_match(1)].pack('H*').unpack('n*').pack('U*') }
       end
     end
   end


### PR DESCRIPTION
This prevents html from being rendered in responses.

**Submitter:**
- [x] This pull request describes why these changes were made
- [x] Internal ticket links to this PR
- [x] Internal ticket is properly labeled (Community/Program)
- [x] Internal ticket has a justification for its Community/Program label
- [x] Code diff has been reviewed for extraneous/missing code
- n/a Tests are included and test edge cases
- [x] Tests/code quality metrics have been run locally and pass


**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
