### PR TITLE
FI-478 Fix case when server returns 400 without status search on access verify tests.

### DIFF
--- a/generator/uscore/templates/access_verify_sequence.rb.erb
+++ b/generator/uscore/templates/access_verify_sequence.rb.erb
@@ -141,7 +141,7 @@ module Inferno
             <% additional_filters = access_verify_status_codes[sequence[:resource].downcase.to_sym] %>
 
             <% additional_filters.each do |key, value| %>
-            options.merge!({'<%= key %>': '<%= value %>'})
+            options[:search][:parameters].merge!({'<%= key %>': '<%= value %>'})
             <% end %>
             reply = @client.search('<%=sequence[:resource]%>', options)
           end

--- a/generator/uscore/templates/access_verify_sequence.rb.erb
+++ b/generator/uscore/templates/access_verify_sequence.rb.erb
@@ -138,7 +138,11 @@ module Inferno
               assert false, error_message
             end
 
-            options.merge!(access_verify_status_codes[sequence[:resource].downcase])
+            <% additional_filters = access_verify_status_codes[sequence[:resource].downcase.to_sym] %>
+
+            <% additional_filters.each do |key, value| %>
+            options.merge!({'<%= key %>': '<%= value %>'})
+            <% end %>
             reply = @client.search('<%=sequence[:resource]%>', options)
           end
           <% end %>

--- a/lib/modules/uscore_v3.1.0/access_verify_restricted_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/access_verify_restricted_sequence.rb
@@ -158,7 +158,7 @@ module Inferno
               assert false, error_message
             end
 
-            options.merge!({ 'clinical-status': 'active' })
+            options[:search][:parameters].merge!({ 'clinical-status': 'active' })
 
             reply = @client.search('AllergyIntolerance', options)
           end
@@ -209,7 +209,7 @@ module Inferno
               assert false, error_message
             end
 
-            options.merge!({ 'status': 'active' })
+            options[:search][:parameters].merge!({ 'status': 'active' })
 
             reply = @client.search('CarePlan', options)
           end
@@ -260,7 +260,7 @@ module Inferno
               assert false, error_message
             end
 
-            options.merge!({ 'status': 'active' })
+            options[:search][:parameters].merge!({ 'status': 'active' })
 
             reply = @client.search('CareTeam', options)
           end
@@ -310,7 +310,7 @@ module Inferno
               assert false, error_message
             end
 
-            options.merge!({ 'clinical-status': 'active' })
+            options[:search][:parameters].merge!({ 'clinical-status': 'active' })
 
             reply = @client.search('Condition', options)
           end
@@ -397,7 +397,7 @@ module Inferno
               assert false, error_message
             end
 
-            options.merge!({ 'status': 'final' })
+            options[:search][:parameters].merge!({ 'status': 'final' })
 
             reply = @client.search('DiagnosticReport', options)
           end
@@ -447,7 +447,7 @@ module Inferno
               assert false, error_message
             end
 
-            options.merge!({ 'status': 'current' })
+            options[:search][:parameters].merge!({ 'status': 'current' })
 
             reply = @client.search('DocumentReference', options)
           end
@@ -497,7 +497,7 @@ module Inferno
               assert false, error_message
             end
 
-            options.merge!({ 'status': 'finished' })
+            options[:search][:parameters].merge!({ 'status': 'finished' })
 
             reply = @client.search('Encounter', options)
           end
@@ -547,7 +547,7 @@ module Inferno
               assert false, error_message
             end
 
-            options.merge!({ 'status': 'active' })
+            options[:search][:parameters].merge!({ 'status': 'active' })
 
             reply = @client.search('Goal', options)
           end
@@ -597,7 +597,7 @@ module Inferno
               assert false, error_message
             end
 
-            options.merge!({ 'status': 'completed' })
+            options[:search][:parameters].merge!({ 'status': 'completed' })
 
             reply = @client.search('Immunization', options)
           end
@@ -648,7 +648,7 @@ module Inferno
               assert false, error_message
             end
 
-            options.merge!({ 'status': 'active' })
+            options[:search][:parameters].merge!({ 'status': 'active' })
 
             reply = @client.search('MedicationRequest', options)
           end
@@ -699,7 +699,7 @@ module Inferno
               assert false, error_message
             end
 
-            options.merge!({ 'status': 'final' })
+            options[:search][:parameters].merge!({ 'status': 'final' })
 
             reply = @client.search('Observation', options)
           end
@@ -749,7 +749,7 @@ module Inferno
               assert false, error_message
             end
 
-            options.merge!({ 'status': 'completed' })
+            options[:search][:parameters].merge!({ 'status': 'completed' })
 
             reply = @client.search('Procedure', options)
           end

--- a/lib/modules/uscore_v3.1.0/access_verify_restricted_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/access_verify_restricted_sequence.rb
@@ -158,7 +158,8 @@ module Inferno
               assert false, error_message
             end
 
-            options.merge!(access_verify_status_codes[sequence[:resource].downcase])
+            options.merge!({ 'clinical-status': 'active' })
+
             reply = @client.search('AllergyIntolerance', options)
           end
 
@@ -208,7 +209,8 @@ module Inferno
               assert false, error_message
             end
 
-            options.merge!(access_verify_status_codes[sequence[:resource].downcase])
+            options.merge!({ 'status': 'active' })
+
             reply = @client.search('CarePlan', options)
           end
 
@@ -258,7 +260,8 @@ module Inferno
               assert false, error_message
             end
 
-            options.merge!(access_verify_status_codes[sequence[:resource].downcase])
+            options.merge!({ 'status': 'active' })
+
             reply = @client.search('CareTeam', options)
           end
 
@@ -307,7 +310,8 @@ module Inferno
               assert false, error_message
             end
 
-            options.merge!(access_verify_status_codes[sequence[:resource].downcase])
+            options.merge!({ 'clinical-status': 'active' })
+
             reply = @client.search('Condition', options)
           end
 
@@ -393,7 +397,8 @@ module Inferno
               assert false, error_message
             end
 
-            options.merge!(access_verify_status_codes[sequence[:resource].downcase])
+            options.merge!({ 'status': 'final' })
+
             reply = @client.search('DiagnosticReport', options)
           end
 
@@ -442,7 +447,8 @@ module Inferno
               assert false, error_message
             end
 
-            options.merge!(access_verify_status_codes[sequence[:resource].downcase])
+            options.merge!({ 'status': 'current' })
+
             reply = @client.search('DocumentReference', options)
           end
 
@@ -491,7 +497,8 @@ module Inferno
               assert false, error_message
             end
 
-            options.merge!(access_verify_status_codes[sequence[:resource].downcase])
+            options.merge!({ 'status': 'finished' })
+
             reply = @client.search('Encounter', options)
           end
 
@@ -540,7 +547,8 @@ module Inferno
               assert false, error_message
             end
 
-            options.merge!(access_verify_status_codes[sequence[:resource].downcase])
+            options.merge!({ 'status': 'active' })
+
             reply = @client.search('Goal', options)
           end
 
@@ -589,7 +597,8 @@ module Inferno
               assert false, error_message
             end
 
-            options.merge!(access_verify_status_codes[sequence[:resource].downcase])
+            options.merge!({ 'status': 'completed' })
+
             reply = @client.search('Immunization', options)
           end
 
@@ -639,7 +648,8 @@ module Inferno
               assert false, error_message
             end
 
-            options.merge!(access_verify_status_codes[sequence[:resource].downcase])
+            options.merge!({ 'status': 'active' })
+
             reply = @client.search('MedicationRequest', options)
           end
 
@@ -689,7 +699,8 @@ module Inferno
               assert false, error_message
             end
 
-            options.merge!(access_verify_status_codes[sequence[:resource].downcase])
+            options.merge!({ 'status': 'final' })
+
             reply = @client.search('Observation', options)
           end
 
@@ -738,7 +749,8 @@ module Inferno
               assert false, error_message
             end
 
-            options.merge!(access_verify_status_codes[sequence[:resource].downcase])
+            options.merge!({ 'status': 'completed' })
+
             reply = @client.search('Procedure', options)
           end
 

--- a/lib/modules/uscore_v3.1.0/access_verify_unrestricted_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/access_verify_unrestricted_sequence.rb
@@ -158,7 +158,7 @@ module Inferno
               assert false, error_message
             end
 
-            options.merge!({ 'clinical-status': 'active' })
+            options[:search][:parameters].merge!({ 'clinical-status': 'active' })
 
             reply = @client.search('AllergyIntolerance', options)
           end
@@ -209,7 +209,7 @@ module Inferno
               assert false, error_message
             end
 
-            options.merge!({ 'status': 'active' })
+            options[:search][:parameters].merge!({ 'status': 'active' })
 
             reply = @client.search('CarePlan', options)
           end
@@ -260,7 +260,7 @@ module Inferno
               assert false, error_message
             end
 
-            options.merge!({ 'status': 'active' })
+            options[:search][:parameters].merge!({ 'status': 'active' })
 
             reply = @client.search('CareTeam', options)
           end
@@ -310,7 +310,7 @@ module Inferno
               assert false, error_message
             end
 
-            options.merge!({ 'clinical-status': 'active' })
+            options[:search][:parameters].merge!({ 'clinical-status': 'active' })
 
             reply = @client.search('Condition', options)
           end
@@ -397,7 +397,7 @@ module Inferno
               assert false, error_message
             end
 
-            options.merge!({ 'status': 'final' })
+            options[:search][:parameters].merge!({ 'status': 'final' })
 
             reply = @client.search('DiagnosticReport', options)
           end
@@ -447,7 +447,7 @@ module Inferno
               assert false, error_message
             end
 
-            options.merge!({ 'status': 'current' })
+            options[:search][:parameters].merge!({ 'status': 'current' })
 
             reply = @client.search('DocumentReference', options)
           end
@@ -497,7 +497,7 @@ module Inferno
               assert false, error_message
             end
 
-            options.merge!({ 'status': 'finished' })
+            options[:search][:parameters].merge!({ 'status': 'finished' })
 
             reply = @client.search('Encounter', options)
           end
@@ -547,7 +547,7 @@ module Inferno
               assert false, error_message
             end
 
-            options.merge!({ 'status': 'active' })
+            options[:search][:parameters].merge!({ 'status': 'active' })
 
             reply = @client.search('Goal', options)
           end
@@ -597,7 +597,7 @@ module Inferno
               assert false, error_message
             end
 
-            options.merge!({ 'status': 'completed' })
+            options[:search][:parameters].merge!({ 'status': 'completed' })
 
             reply = @client.search('Immunization', options)
           end
@@ -648,7 +648,7 @@ module Inferno
               assert false, error_message
             end
 
-            options.merge!({ 'status': 'active' })
+            options[:search][:parameters].merge!({ 'status': 'active' })
 
             reply = @client.search('MedicationRequest', options)
           end
@@ -699,7 +699,7 @@ module Inferno
               assert false, error_message
             end
 
-            options.merge!({ 'status': 'final' })
+            options[:search][:parameters].merge!({ 'status': 'final' })
 
             reply = @client.search('Observation', options)
           end
@@ -749,7 +749,7 @@ module Inferno
               assert false, error_message
             end
 
-            options.merge!({ 'status': 'completed' })
+            options[:search][:parameters].merge!({ 'status': 'completed' })
 
             reply = @client.search('Procedure', options)
           end

--- a/lib/modules/uscore_v3.1.0/access_verify_unrestricted_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/access_verify_unrestricted_sequence.rb
@@ -158,7 +158,8 @@ module Inferno
               assert false, error_message
             end
 
-            options.merge!(access_verify_status_codes[sequence[:resource].downcase])
+            options.merge!({ 'clinical-status': 'active' })
+
             reply = @client.search('AllergyIntolerance', options)
           end
 
@@ -208,7 +209,8 @@ module Inferno
               assert false, error_message
             end
 
-            options.merge!(access_verify_status_codes[sequence[:resource].downcase])
+            options.merge!({ 'status': 'active' })
+
             reply = @client.search('CarePlan', options)
           end
 
@@ -258,7 +260,8 @@ module Inferno
               assert false, error_message
             end
 
-            options.merge!(access_verify_status_codes[sequence[:resource].downcase])
+            options.merge!({ 'status': 'active' })
+
             reply = @client.search('CareTeam', options)
           end
 
@@ -307,7 +310,8 @@ module Inferno
               assert false, error_message
             end
 
-            options.merge!(access_verify_status_codes[sequence[:resource].downcase])
+            options.merge!({ 'clinical-status': 'active' })
+
             reply = @client.search('Condition', options)
           end
 
@@ -393,7 +397,8 @@ module Inferno
               assert false, error_message
             end
 
-            options.merge!(access_verify_status_codes[sequence[:resource].downcase])
+            options.merge!({ 'status': 'final' })
+
             reply = @client.search('DiagnosticReport', options)
           end
 
@@ -442,7 +447,8 @@ module Inferno
               assert false, error_message
             end
 
-            options.merge!(access_verify_status_codes[sequence[:resource].downcase])
+            options.merge!({ 'status': 'current' })
+
             reply = @client.search('DocumentReference', options)
           end
 
@@ -491,7 +497,8 @@ module Inferno
               assert false, error_message
             end
 
-            options.merge!(access_verify_status_codes[sequence[:resource].downcase])
+            options.merge!({ 'status': 'finished' })
+
             reply = @client.search('Encounter', options)
           end
 
@@ -540,7 +547,8 @@ module Inferno
               assert false, error_message
             end
 
-            options.merge!(access_verify_status_codes[sequence[:resource].downcase])
+            options.merge!({ 'status': 'active' })
+
             reply = @client.search('Goal', options)
           end
 
@@ -589,7 +597,8 @@ module Inferno
               assert false, error_message
             end
 
-            options.merge!(access_verify_status_codes[sequence[:resource].downcase])
+            options.merge!({ 'status': 'completed' })
+
             reply = @client.search('Immunization', options)
           end
 
@@ -639,7 +648,8 @@ module Inferno
               assert false, error_message
             end
 
-            options.merge!(access_verify_status_codes[sequence[:resource].downcase])
+            options.merge!({ 'status': 'active' })
+
             reply = @client.search('MedicationRequest', options)
           end
 
@@ -689,7 +699,8 @@ module Inferno
               assert false, error_message
             end
 
-            options.merge!(access_verify_status_codes[sequence[:resource].downcase])
+            options.merge!({ 'status': 'final' })
+
             reply = @client.search('Observation', options)
           end
 
@@ -738,7 +749,8 @@ module Inferno
               assert false, error_message
             end
 
-            options.merge!(access_verify_status_codes[sequence[:resource].downcase])
+            options.merge!({ 'status': 'completed' })
+
             reply = @client.search('Procedure', options)
           end
 


### PR DESCRIPTION
Access verify tests fail if server returns 400 on searches because they deny searches without filters on the access verification tests.

Pull requests into Inferno require the following items to be completed. Submitter and reviewer 
should check the relevant check boxes when the associated item is done. For items that are not 
applicable, note it's not applicable ("N/A") and check the box. For example, external Pull 
Requests do not require ticket links.

**Submitter:**
- [x] This pull request describes why these changes were made
- [x] Internal ticket for this PR:
- [x] Internal ticket links to this PR
- [x] Internal ticket is properly labeled (Community/Program)
- [x] Internal ticket has a justification for its Community/Program label
- [x] Code diff has been reviewed for extraneous/missing code
- n/a Tests are included and test edge cases
- [x] Tests/code quality metrics have been run locally and pass


**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
