### PR TITLE
FI-747 don't add bearer token to metadata query

### DIFF
--- a/lib/modules/onc_program/onc_smart_discovery_sequence.rb
+++ b/lib/modules/onc_program/onc_smart_discovery_sequence.rb
@@ -107,7 +107,6 @@ module Inferno
         end
 
         @client = FHIR::Client.for_testing_instance(@instance, url_property: url_property)
-        @client.set_bearer_token(@instance.token) unless @client.nil? || @instance.nil? || @instance.token.nil?
         @client&.monitor_requests
 
         well_known_configuration_url = instance_url.chomp('/') + '/.well-known/smart-configuration'


### PR DESCRIPTION
This PR makes it so the bearer token isn't added to the metadata endpoint request. To test this, run the ONC Proram Standalone Patient App tests twice. Check the metadata GET request in SMART On FHIR Discovery sequence after the second run. You shouldn't see a bearer token in the headers. 

**Submitter:**
- [X] This pull request describes why these changes were made
- [X] Internal ticket for this PR: https://oncprojectracking.healthit.gov/support/browse/FI-747
- [X] Internal ticket links to this PR
- [X] Internal ticket is properly labeled (Community/Program)
- [X] Internal ticket has a justification for its Community/Program label
- [X] Code diff has been reviewed for extraneous/missing code
- [] Tests are included and test edge cases
- [X] Tests/code quality metrics have been run locally and pass


**Reviewer 1:**

Name:
- [x] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
