### PR TITLE
fi-749 better error messages when search params don't match

### DIFF
--- a/generator/uscore/uscore_generator.rb
+++ b/generator/uscore/uscore_generator.rb
@@ -1176,67 +1176,19 @@ module Inferno
       def create_search_validation(sequence)
         search_validators = ''
         sequence[:search_param_descriptions].each do |element, definition|
-          search_validators += %(
-              when '#{element}')
           type = definition[:type]
-          path_parts = definition[:path].split('.')
-          path_parts = path_parts.map { |part| part == 'class' ? 'local_class' : part }
-          path_parts.shift
-          case type
-          when 'Period', 'date'
-            search_validators += %(
-                values_found = resolve_path(resource, '#{path_parts.join('.')}')
-                match_found = values_found.any? { |date| validate_date_search(value, date) }
-                assert match_found, "#{element} in #{sequence[:resource]}/\#{resource.id} (\#{values_found}) does not match #{element} requested (\#{value})"
-      )
-          when 'HumanName'
-            # When a string search parameter refers to the types HumanName and Address,
-            # the search covers the elements of type string, and does not cover elements such as use and period
-            # https://www.hl7.org/fhir/search.html#string
-            search_validators += %(
-                value_downcase = value.downcase
-                values_found = resolve_path(resource, '#{path_parts.join('.')}')
-                match_found = values_found.any? do |name|
-                  name&.text&.downcase&.start_with?(value_downcase) ||
-                    name&.family&.downcase&.include?(value_downcase) ||
-                    name&.given&.any? { |given| given.downcase.start_with?(value_downcase) } ||
-                    name&.prefix&.any? { |prefix| prefix.downcase.start_with?(value_downcase) } ||
-                    name&.suffix&.any? { |suffix| suffix.downcase.start_with?(value_downcase) }
-                end
-                assert match_found, "#{element} in #{sequence[:resource]}/\#{resource.id} (\#{values_found}) does not match #{element} requested (\#{value})"
-      )
-          when 'Address'
-            search_validators += %(
-                values_found = resolve_path(resource, '#{path_parts.join('.')}')
-                match_found = values_found.any? do |address|
-                  address&.text&.start_with?(value) ||
-                  address&.city&.start_with?(value) ||
-                  address&.state&.start_with?(value) ||
-                  address&.postalCode&.start_with?(value) ||
-                  address&.country&.start_with?(value)
-                end
-                assert match_found, "#{element} in #{sequence[:resource]}/\#{resource.id} (\#{values_found}) does not match #{element} requested (\#{value})"
+          path = definition[:path]
+            .gsub(/(?<!\w)class(?!\w)/, 'local_class')
+            .split('.')
+            .drop(1)
+            .join('.')
+          path += get_value_path_by_type(type) unless ['Period', 'date', 'HumanName', 'Address'].include? type
+          search_validators += %(
+              when '#{element}'
+              values_found = resolve_path(resource, '#{path}')
+              #{search_param_match_found_code(type, element)}
+              assert match_found, "#{element} in #{sequence[:resource]}/\#{resource.id} (\#{values_found}) does not match #{element} requested (\#{value})"
             )
-          else
-            # searching by patient requires special case because we are searching by a resource identifier
-            # references can also be URL's, so we made need to resolve those url's
-            path = path_parts.join('.') + get_value_path_by_type(type)
-            search_validators +=
-              if ['subject', 'patient'].include? element.to_s
-                %(
-                  references_found = resolve_path(resource, '#{path}')
-                  match_found = references_found.any? { |reference| [value, 'Patient/' + value].include? reference }
-                  assert match_found, "#{element} in  #{sequence[:resource]}/\#{resource.id} (\#{references_found}) does not match #{element} requested (\#{value})"
-                )
-              else
-                %(
-                  values = value.split(/(?<!\\\\),/).each { |str| str.gsub!('\\,', ',') }
-                  values_found = resolve_path(resource, '#{path}')
-                  match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
-                  assert match_found.present?, "#{element} in  #{sequence[:resource]}/\#{resource.id} (\#{values_found}) does not match #{element} requested (\#{values})"
-                )
-              end
-          end
         end
 
         validate_functions =
@@ -1256,6 +1208,42 @@ module Inferno
         validate_functions += perform_search_with_status_code(sequence) if sequence_has_status_search?(sequence)
 
         validate_functions
+      end
+
+      def search_param_match_found_code(type, element)
+        case type
+        when 'Period', 'date'
+          %(match_found = values_found.any? { |date| validate_date_search(value, date) })
+        when 'HumanName'
+          # When a string search parameter refers to the types HumanName and Address,
+          # the search covers the elements of type string, and does not cover elements such as use and period
+          # https://www.hl7.org/fhir/search.html#string
+          %(value_downcase = value.downcase
+            match_found = values_found.any? do |name|
+              name&.text&.downcase&.start_with?(value_downcase) ||
+                name&.family&.downcase&.include?(value_downcase) ||
+                name&.given&.any? { |given| given.downcase.start_with?(value_downcase) } ||
+                name&.prefix&.any? { |prefix| prefix.downcase.start_with?(value_downcase) } ||
+                name&.suffix&.any? { |suffix| suffix.downcase.start_with?(value_downcase) }
+            end)
+        when 'Address'
+          %(match_found = values_found.any? do |address|
+              address&.text&.start_with?(value) ||
+              address&.city&.start_with?(value) ||
+              address&.state&.start_with?(value) ||
+              address&.postalCode&.start_with?(value) ||
+              address&.country&.start_with?(value)
+            end)
+        else
+          # searching by patient requires special case because we are searching by a resource identifier
+          # references can also be URL's, so we made need to resolve those url's
+          if ['subject', 'patient'].include? element.to_s
+            %(match_found = values_found.any? { |reference| [value, 'Patient/' + value].include? reference })
+          else
+            %(values = value.split(/(?<!\\\\),/).each { |str| str.gsub!('\\,', ',') }
+              match_found = values_found.any? { |value_in_resource| values.include? value_in_resource })
+          end
+        end
       end
 
       def test_medication_inclusion_code

--- a/generator/uscore/uscore_generator.rb
+++ b/generator/uscore/uscore_generator.rb
@@ -1185,34 +1185,37 @@ module Inferno
           case type
           when 'Period', 'date'
             search_validators += %(
-                value_found = resolve_element_from_path(resource, '#{path_parts.join('.')}') { |date| validate_date_search(value, date) }
-                assert value_found.present?, '#{element} on resource does not match #{element} requested'
+                values_found = resolve_path(resource, '#{path_parts.join('.')}')
+                match_found = values_found.any? { |date| validate_date_search(value, date) }
+                assert match_found, "#{element} in #{sequence[:resource]}/\#{resource.id} (\#{values_found}) does not match #{element} requested (\#{value})"
       )
           when 'HumanName'
             # When a string search parameter refers to the types HumanName and Address,
             # the search covers the elements of type string, and does not cover elements such as use and period
             # https://www.hl7.org/fhir/search.html#string
             search_validators += %(
-                value = value.downcase
-                value_found = resolve_element_from_path(resource, '#{path_parts.join('.')}') do |name|
-                  name&.text&.start_with?(value) ||
-                    name&.family&.downcase&.include?(value) ||
-                    name&.given&.any? { |given| given.downcase.start_with?(value) } ||
-                    name&.prefix&.any? { |prefix| prefix.downcase.start_with?(value) } ||
-                    name&.suffix&.any? { |suffix| suffix.downcase.start_with?(value) }
+                value_downcase = value.downcase
+                values_found = resolve_path(resource, '#{path_parts.join('.')}')
+                match_found = values_found.any? do |name|
+                  name&.text&.downcase&.start_with?(value_downcase) ||
+                    name&.family&.downcase&.include?(value_downcase) ||
+                    name&.given&.any? { |given| given.downcase.start_with?(value_downcase) } ||
+                    name&.prefix&.any? { |prefix| prefix.downcase.start_with?(value_downcase) } ||
+                    name&.suffix&.any? { |suffix| suffix.downcase.start_with?(value_downcase) }
                 end
-                assert value_found.present?, '#{element} on resource does not match #{element} requested'
+                assert match_found, "#{element} in #{sequence[:resource]}/\#{resource.id} (\#{values_found}) does not match #{element} requested (\#{value})"
       )
           when 'Address'
             search_validators += %(
-                value_found = resolve_element_from_path(resource, '#{path_parts.join('.')}') do |address|
+                values_found = resolve_path(resource, '#{path_parts.join('.')}')
+                match_found = values_found.any? do |address|
                   address&.text&.start_with?(value) ||
-                    address&.city&.start_with?(value) ||
-                    address&.state&.start_with?(value) ||
-                    address&.postalCode&.start_with?(value) ||
-                    address&.country&.start_with?(value)
+                  address&.city&.start_with?(value) ||
+                  address&.state&.start_with?(value) ||
+                  address&.postalCode&.start_with?(value) ||
+                  address&.country&.start_with?(value)
                 end
-                assert value_found.present?, '#{element} on resource does not match #{element} requested'
+                assert match_found, "#{element} in #{sequence[:resource]}/\#{resource.id} (\#{values_found}) does not match #{element} requested (\#{value})"
             )
           else
             # searching by patient requires special case because we are searching by a resource identifier
@@ -1221,14 +1224,16 @@ module Inferno
             search_validators +=
               if ['subject', 'patient'].include? element.to_s
                 %(
-                value_found = resolve_element_from_path(resource, '#{path}') { |reference| [value, 'Patient/' + value].include? reference }
-                assert value_found.present?, '#{element} on resource does not match #{element} requested'
-      )
+                  references_found = resolve_path(resource, '#{path}')
+                  match_found = references_found.any? { |reference| [value, 'Patient/' + value].include? reference }
+                  assert match_found, "#{element} in  #{sequence[:resource]}/\#{resource.id} (\#{references_found}) does not match #{element} requested (\#{value})"
+                )
               else
                 %(
                   values = value.split(/(?<!\\\\),/).each { |str| str.gsub!('\\,', ',') }
-                  value_found = resolve_element_from_path(resource, '#{path}') { |value_in_resource| values.include? value_in_resource }
-                  assert value_found.present?, '#{element} on resource does not match #{element} requested'
+                  values_found = resolve_path(resource, '#{path}')
+                  match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
+                  assert match_found.present?, "#{element} in  #{sequence[:resource]}/\#{resource.id} (\#{values_found}) does not match #{element} requested (\#{values})"
                 )
               end
           end

--- a/lib/modules/uscore_v3.1.0/bodyheight_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/bodyheight_sequence.rb
@@ -70,22 +70,22 @@ module Inferno
         case property
 
         when 'status'
-          values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           values_found = resolve_path(resource, 'status')
+          values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
-          assert match_found.present?, "status in  Observation/#{resource.id} (#{values_found}) does not match status requested (#{values})"
+          assert match_found, "status in Observation/#{resource.id} (#{values_found}) does not match status requested (#{value})"
 
         when 'category'
-          values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           values_found = resolve_path(resource, 'category.coding.code')
+          values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
-          assert match_found.present?, "category in  Observation/#{resource.id} (#{values_found}) does not match category requested (#{values})"
+          assert match_found, "category in Observation/#{resource.id} (#{values_found}) does not match category requested (#{value})"
 
         when 'code'
-          values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           values_found = resolve_path(resource, 'code.coding.code')
+          values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
-          assert match_found.present?, "code in  Observation/#{resource.id} (#{values_found}) does not match code requested (#{values})"
+          assert match_found, "code in Observation/#{resource.id} (#{values_found}) does not match code requested (#{value})"
 
         when 'date'
           values_found = resolve_path(resource, 'effective')
@@ -93,9 +93,9 @@ module Inferno
           assert match_found, "date in Observation/#{resource.id} (#{values_found}) does not match date requested (#{value})"
 
         when 'patient'
-          references_found = resolve_path(resource, 'subject.reference')
-          match_found = references_found.any? { |reference| [value, 'Patient/' + value].include? reference }
-          assert match_found, "patient in  Observation/#{resource.id} (#{references_found}) does not match patient requested (#{value})"
+          values_found = resolve_path(resource, 'subject.reference')
+          match_found = values_found.any? { |reference| [value, 'Patient/' + value].include? reference }
+          assert match_found, "patient in Observation/#{resource.id} (#{values_found}) does not match patient requested (#{value})"
 
         end
       end

--- a/lib/modules/uscore_v3.1.0/bodyheight_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/bodyheight_sequence.rb
@@ -71,26 +71,31 @@ module Inferno
 
         when 'status'
           values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
-          value_found = resolve_element_from_path(resource, 'status') { |value_in_resource| values.include? value_in_resource }
-          assert value_found.present?, 'status on resource does not match status requested'
+          values_found = resolve_path(resource, 'status')
+          match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
+          assert match_found.present?, "status in  Observation/#{resource.id} (#{values_found}) does not match status requested (#{values})"
 
         when 'category'
           values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
-          value_found = resolve_element_from_path(resource, 'category.coding.code') { |value_in_resource| values.include? value_in_resource }
-          assert value_found.present?, 'category on resource does not match category requested'
+          values_found = resolve_path(resource, 'category.coding.code')
+          match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
+          assert match_found.present?, "category in  Observation/#{resource.id} (#{values_found}) does not match category requested (#{values})"
 
         when 'code'
           values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
-          value_found = resolve_element_from_path(resource, 'code.coding.code') { |value_in_resource| values.include? value_in_resource }
-          assert value_found.present?, 'code on resource does not match code requested'
+          values_found = resolve_path(resource, 'code.coding.code')
+          match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
+          assert match_found.present?, "code in  Observation/#{resource.id} (#{values_found}) does not match code requested (#{values})"
 
         when 'date'
-          value_found = resolve_element_from_path(resource, 'effective') { |date| validate_date_search(value, date) }
-          assert value_found.present?, 'date on resource does not match date requested'
+          values_found = resolve_path(resource, 'effective')
+          match_found = values_found.any? { |date| validate_date_search(value, date) }
+          assert match_found, "date in Observation/#{resource.id} (#{values_found}) does not match date requested (#{value})"
 
         when 'patient'
-          value_found = resolve_element_from_path(resource, 'subject.reference') { |reference| [value, 'Patient/' + value].include? reference }
-          assert value_found.present?, 'patient on resource does not match patient requested'
+          references_found = resolve_path(resource, 'subject.reference')
+          match_found = references_found.any? { |reference| [value, 'Patient/' + value].include? reference }
+          assert match_found, "patient in  Observation/#{resource.id} (#{references_found}) does not match patient requested (#{value})"
 
         end
       end

--- a/lib/modules/uscore_v3.1.0/bodytemp_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/bodytemp_sequence.rb
@@ -70,22 +70,22 @@ module Inferno
         case property
 
         when 'status'
-          values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           values_found = resolve_path(resource, 'status')
+          values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
-          assert match_found.present?, "status in  Observation/#{resource.id} (#{values_found}) does not match status requested (#{values})"
+          assert match_found, "status in Observation/#{resource.id} (#{values_found}) does not match status requested (#{value})"
 
         when 'category'
-          values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           values_found = resolve_path(resource, 'category.coding.code')
+          values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
-          assert match_found.present?, "category in  Observation/#{resource.id} (#{values_found}) does not match category requested (#{values})"
+          assert match_found, "category in Observation/#{resource.id} (#{values_found}) does not match category requested (#{value})"
 
         when 'code'
-          values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           values_found = resolve_path(resource, 'code.coding.code')
+          values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
-          assert match_found.present?, "code in  Observation/#{resource.id} (#{values_found}) does not match code requested (#{values})"
+          assert match_found, "code in Observation/#{resource.id} (#{values_found}) does not match code requested (#{value})"
 
         when 'date'
           values_found = resolve_path(resource, 'effective')
@@ -93,9 +93,9 @@ module Inferno
           assert match_found, "date in Observation/#{resource.id} (#{values_found}) does not match date requested (#{value})"
 
         when 'patient'
-          references_found = resolve_path(resource, 'subject.reference')
-          match_found = references_found.any? { |reference| [value, 'Patient/' + value].include? reference }
-          assert match_found, "patient in  Observation/#{resource.id} (#{references_found}) does not match patient requested (#{value})"
+          values_found = resolve_path(resource, 'subject.reference')
+          match_found = values_found.any? { |reference| [value, 'Patient/' + value].include? reference }
+          assert match_found, "patient in Observation/#{resource.id} (#{values_found}) does not match patient requested (#{value})"
 
         end
       end

--- a/lib/modules/uscore_v3.1.0/bodytemp_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/bodytemp_sequence.rb
@@ -71,26 +71,31 @@ module Inferno
 
         when 'status'
           values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
-          value_found = resolve_element_from_path(resource, 'status') { |value_in_resource| values.include? value_in_resource }
-          assert value_found.present?, 'status on resource does not match status requested'
+          values_found = resolve_path(resource, 'status')
+          match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
+          assert match_found.present?, "status in  Observation/#{resource.id} (#{values_found}) does not match status requested (#{values})"
 
         when 'category'
           values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
-          value_found = resolve_element_from_path(resource, 'category.coding.code') { |value_in_resource| values.include? value_in_resource }
-          assert value_found.present?, 'category on resource does not match category requested'
+          values_found = resolve_path(resource, 'category.coding.code')
+          match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
+          assert match_found.present?, "category in  Observation/#{resource.id} (#{values_found}) does not match category requested (#{values})"
 
         when 'code'
           values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
-          value_found = resolve_element_from_path(resource, 'code.coding.code') { |value_in_resource| values.include? value_in_resource }
-          assert value_found.present?, 'code on resource does not match code requested'
+          values_found = resolve_path(resource, 'code.coding.code')
+          match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
+          assert match_found.present?, "code in  Observation/#{resource.id} (#{values_found}) does not match code requested (#{values})"
 
         when 'date'
-          value_found = resolve_element_from_path(resource, 'effective') { |date| validate_date_search(value, date) }
-          assert value_found.present?, 'date on resource does not match date requested'
+          values_found = resolve_path(resource, 'effective')
+          match_found = values_found.any? { |date| validate_date_search(value, date) }
+          assert match_found, "date in Observation/#{resource.id} (#{values_found}) does not match date requested (#{value})"
 
         when 'patient'
-          value_found = resolve_element_from_path(resource, 'subject.reference') { |reference| [value, 'Patient/' + value].include? reference }
-          assert value_found.present?, 'patient on resource does not match patient requested'
+          references_found = resolve_path(resource, 'subject.reference')
+          match_found = references_found.any? { |reference| [value, 'Patient/' + value].include? reference }
+          assert match_found, "patient in  Observation/#{resource.id} (#{references_found}) does not match patient requested (#{value})"
 
         end
       end

--- a/lib/modules/uscore_v3.1.0/bodyweight_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/bodyweight_sequence.rb
@@ -70,22 +70,22 @@ module Inferno
         case property
 
         when 'status'
-          values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           values_found = resolve_path(resource, 'status')
+          values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
-          assert match_found.present?, "status in  Observation/#{resource.id} (#{values_found}) does not match status requested (#{values})"
+          assert match_found, "status in Observation/#{resource.id} (#{values_found}) does not match status requested (#{value})"
 
         when 'category'
-          values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           values_found = resolve_path(resource, 'category.coding.code')
+          values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
-          assert match_found.present?, "category in  Observation/#{resource.id} (#{values_found}) does not match category requested (#{values})"
+          assert match_found, "category in Observation/#{resource.id} (#{values_found}) does not match category requested (#{value})"
 
         when 'code'
-          values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           values_found = resolve_path(resource, 'code.coding.code')
+          values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
-          assert match_found.present?, "code in  Observation/#{resource.id} (#{values_found}) does not match code requested (#{values})"
+          assert match_found, "code in Observation/#{resource.id} (#{values_found}) does not match code requested (#{value})"
 
         when 'date'
           values_found = resolve_path(resource, 'effective')
@@ -93,9 +93,9 @@ module Inferno
           assert match_found, "date in Observation/#{resource.id} (#{values_found}) does not match date requested (#{value})"
 
         when 'patient'
-          references_found = resolve_path(resource, 'subject.reference')
-          match_found = references_found.any? { |reference| [value, 'Patient/' + value].include? reference }
-          assert match_found, "patient in  Observation/#{resource.id} (#{references_found}) does not match patient requested (#{value})"
+          values_found = resolve_path(resource, 'subject.reference')
+          match_found = values_found.any? { |reference| [value, 'Patient/' + value].include? reference }
+          assert match_found, "patient in Observation/#{resource.id} (#{values_found}) does not match patient requested (#{value})"
 
         end
       end

--- a/lib/modules/uscore_v3.1.0/bodyweight_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/bodyweight_sequence.rb
@@ -71,26 +71,31 @@ module Inferno
 
         when 'status'
           values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
-          value_found = resolve_element_from_path(resource, 'status') { |value_in_resource| values.include? value_in_resource }
-          assert value_found.present?, 'status on resource does not match status requested'
+          values_found = resolve_path(resource, 'status')
+          match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
+          assert match_found.present?, "status in  Observation/#{resource.id} (#{values_found}) does not match status requested (#{values})"
 
         when 'category'
           values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
-          value_found = resolve_element_from_path(resource, 'category.coding.code') { |value_in_resource| values.include? value_in_resource }
-          assert value_found.present?, 'category on resource does not match category requested'
+          values_found = resolve_path(resource, 'category.coding.code')
+          match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
+          assert match_found.present?, "category in  Observation/#{resource.id} (#{values_found}) does not match category requested (#{values})"
 
         when 'code'
           values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
-          value_found = resolve_element_from_path(resource, 'code.coding.code') { |value_in_resource| values.include? value_in_resource }
-          assert value_found.present?, 'code on resource does not match code requested'
+          values_found = resolve_path(resource, 'code.coding.code')
+          match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
+          assert match_found.present?, "code in  Observation/#{resource.id} (#{values_found}) does not match code requested (#{values})"
 
         when 'date'
-          value_found = resolve_element_from_path(resource, 'effective') { |date| validate_date_search(value, date) }
-          assert value_found.present?, 'date on resource does not match date requested'
+          values_found = resolve_path(resource, 'effective')
+          match_found = values_found.any? { |date| validate_date_search(value, date) }
+          assert match_found, "date in Observation/#{resource.id} (#{values_found}) does not match date requested (#{value})"
 
         when 'patient'
-          value_found = resolve_element_from_path(resource, 'subject.reference') { |reference| [value, 'Patient/' + value].include? reference }
-          assert value_found.present?, 'patient on resource does not match patient requested'
+          references_found = resolve_path(resource, 'subject.reference')
+          match_found = references_found.any? { |reference| [value, 'Patient/' + value].include? reference }
+          assert match_found, "patient in  Observation/#{resource.id} (#{references_found}) does not match patient requested (#{value})"
 
         end
       end

--- a/lib/modules/uscore_v3.1.0/bp_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/bp_sequence.rb
@@ -70,22 +70,22 @@ module Inferno
         case property
 
         when 'status'
-          values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           values_found = resolve_path(resource, 'status')
+          values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
-          assert match_found.present?, "status in  Observation/#{resource.id} (#{values_found}) does not match status requested (#{values})"
+          assert match_found, "status in Observation/#{resource.id} (#{values_found}) does not match status requested (#{value})"
 
         when 'category'
-          values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           values_found = resolve_path(resource, 'category.coding.code')
+          values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
-          assert match_found.present?, "category in  Observation/#{resource.id} (#{values_found}) does not match category requested (#{values})"
+          assert match_found, "category in Observation/#{resource.id} (#{values_found}) does not match category requested (#{value})"
 
         when 'code'
-          values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           values_found = resolve_path(resource, 'code.coding.code')
+          values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
-          assert match_found.present?, "code in  Observation/#{resource.id} (#{values_found}) does not match code requested (#{values})"
+          assert match_found, "code in Observation/#{resource.id} (#{values_found}) does not match code requested (#{value})"
 
         when 'date'
           values_found = resolve_path(resource, 'effective')
@@ -93,9 +93,9 @@ module Inferno
           assert match_found, "date in Observation/#{resource.id} (#{values_found}) does not match date requested (#{value})"
 
         when 'patient'
-          references_found = resolve_path(resource, 'subject.reference')
-          match_found = references_found.any? { |reference| [value, 'Patient/' + value].include? reference }
-          assert match_found, "patient in  Observation/#{resource.id} (#{references_found}) does not match patient requested (#{value})"
+          values_found = resolve_path(resource, 'subject.reference')
+          match_found = values_found.any? { |reference| [value, 'Patient/' + value].include? reference }
+          assert match_found, "patient in Observation/#{resource.id} (#{values_found}) does not match patient requested (#{value})"
 
         end
       end

--- a/lib/modules/uscore_v3.1.0/bp_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/bp_sequence.rb
@@ -71,26 +71,31 @@ module Inferno
 
         when 'status'
           values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
-          value_found = resolve_element_from_path(resource, 'status') { |value_in_resource| values.include? value_in_resource }
-          assert value_found.present?, 'status on resource does not match status requested'
+          values_found = resolve_path(resource, 'status')
+          match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
+          assert match_found.present?, "status in  Observation/#{resource.id} (#{values_found}) does not match status requested (#{values})"
 
         when 'category'
           values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
-          value_found = resolve_element_from_path(resource, 'category.coding.code') { |value_in_resource| values.include? value_in_resource }
-          assert value_found.present?, 'category on resource does not match category requested'
+          values_found = resolve_path(resource, 'category.coding.code')
+          match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
+          assert match_found.present?, "category in  Observation/#{resource.id} (#{values_found}) does not match category requested (#{values})"
 
         when 'code'
           values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
-          value_found = resolve_element_from_path(resource, 'code.coding.code') { |value_in_resource| values.include? value_in_resource }
-          assert value_found.present?, 'code on resource does not match code requested'
+          values_found = resolve_path(resource, 'code.coding.code')
+          match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
+          assert match_found.present?, "code in  Observation/#{resource.id} (#{values_found}) does not match code requested (#{values})"
 
         when 'date'
-          value_found = resolve_element_from_path(resource, 'effective') { |date| validate_date_search(value, date) }
-          assert value_found.present?, 'date on resource does not match date requested'
+          values_found = resolve_path(resource, 'effective')
+          match_found = values_found.any? { |date| validate_date_search(value, date) }
+          assert match_found, "date in Observation/#{resource.id} (#{values_found}) does not match date requested (#{value})"
 
         when 'patient'
-          value_found = resolve_element_from_path(resource, 'subject.reference') { |reference| [value, 'Patient/' + value].include? reference }
-          assert value_found.present?, 'patient on resource does not match patient requested'
+          references_found = resolve_path(resource, 'subject.reference')
+          match_found = references_found.any? { |reference| [value, 'Patient/' + value].include? reference }
+          assert match_found, "patient in  Observation/#{resource.id} (#{references_found}) does not match patient requested (#{value})"
 
         end
       end

--- a/lib/modules/uscore_v3.1.0/headcircum_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/headcircum_sequence.rb
@@ -70,22 +70,22 @@ module Inferno
         case property
 
         when 'status'
-          values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           values_found = resolve_path(resource, 'status')
+          values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
-          assert match_found.present?, "status in  Observation/#{resource.id} (#{values_found}) does not match status requested (#{values})"
+          assert match_found, "status in Observation/#{resource.id} (#{values_found}) does not match status requested (#{value})"
 
         when 'category'
-          values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           values_found = resolve_path(resource, 'category.coding.code')
+          values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
-          assert match_found.present?, "category in  Observation/#{resource.id} (#{values_found}) does not match category requested (#{values})"
+          assert match_found, "category in Observation/#{resource.id} (#{values_found}) does not match category requested (#{value})"
 
         when 'code'
-          values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           values_found = resolve_path(resource, 'code.coding.code')
+          values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
-          assert match_found.present?, "code in  Observation/#{resource.id} (#{values_found}) does not match code requested (#{values})"
+          assert match_found, "code in Observation/#{resource.id} (#{values_found}) does not match code requested (#{value})"
 
         when 'date'
           values_found = resolve_path(resource, 'effective')
@@ -93,9 +93,9 @@ module Inferno
           assert match_found, "date in Observation/#{resource.id} (#{values_found}) does not match date requested (#{value})"
 
         when 'patient'
-          references_found = resolve_path(resource, 'subject.reference')
-          match_found = references_found.any? { |reference| [value, 'Patient/' + value].include? reference }
-          assert match_found, "patient in  Observation/#{resource.id} (#{references_found}) does not match patient requested (#{value})"
+          values_found = resolve_path(resource, 'subject.reference')
+          match_found = values_found.any? { |reference| [value, 'Patient/' + value].include? reference }
+          assert match_found, "patient in Observation/#{resource.id} (#{values_found}) does not match patient requested (#{value})"
 
         end
       end

--- a/lib/modules/uscore_v3.1.0/headcircum_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/headcircum_sequence.rb
@@ -71,26 +71,31 @@ module Inferno
 
         when 'status'
           values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
-          value_found = resolve_element_from_path(resource, 'status') { |value_in_resource| values.include? value_in_resource }
-          assert value_found.present?, 'status on resource does not match status requested'
+          values_found = resolve_path(resource, 'status')
+          match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
+          assert match_found.present?, "status in  Observation/#{resource.id} (#{values_found}) does not match status requested (#{values})"
 
         when 'category'
           values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
-          value_found = resolve_element_from_path(resource, 'category.coding.code') { |value_in_resource| values.include? value_in_resource }
-          assert value_found.present?, 'category on resource does not match category requested'
+          values_found = resolve_path(resource, 'category.coding.code')
+          match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
+          assert match_found.present?, "category in  Observation/#{resource.id} (#{values_found}) does not match category requested (#{values})"
 
         when 'code'
           values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
-          value_found = resolve_element_from_path(resource, 'code.coding.code') { |value_in_resource| values.include? value_in_resource }
-          assert value_found.present?, 'code on resource does not match code requested'
+          values_found = resolve_path(resource, 'code.coding.code')
+          match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
+          assert match_found.present?, "code in  Observation/#{resource.id} (#{values_found}) does not match code requested (#{values})"
 
         when 'date'
-          value_found = resolve_element_from_path(resource, 'effective') { |date| validate_date_search(value, date) }
-          assert value_found.present?, 'date on resource does not match date requested'
+          values_found = resolve_path(resource, 'effective')
+          match_found = values_found.any? { |date| validate_date_search(value, date) }
+          assert match_found, "date in Observation/#{resource.id} (#{values_found}) does not match date requested (#{value})"
 
         when 'patient'
-          value_found = resolve_element_from_path(resource, 'subject.reference') { |reference| [value, 'Patient/' + value].include? reference }
-          assert value_found.present?, 'patient on resource does not match patient requested'
+          references_found = resolve_path(resource, 'subject.reference')
+          match_found = references_found.any? { |reference| [value, 'Patient/' + value].include? reference }
+          assert match_found, "patient in  Observation/#{resource.id} (#{references_found}) does not match patient requested (#{value})"
 
         end
       end

--- a/lib/modules/uscore_v3.1.0/heartrate_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/heartrate_sequence.rb
@@ -70,22 +70,22 @@ module Inferno
         case property
 
         when 'status'
-          values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           values_found = resolve_path(resource, 'status')
+          values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
-          assert match_found.present?, "status in  Observation/#{resource.id} (#{values_found}) does not match status requested (#{values})"
+          assert match_found, "status in Observation/#{resource.id} (#{values_found}) does not match status requested (#{value})"
 
         when 'category'
-          values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           values_found = resolve_path(resource, 'category.coding.code')
+          values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
-          assert match_found.present?, "category in  Observation/#{resource.id} (#{values_found}) does not match category requested (#{values})"
+          assert match_found, "category in Observation/#{resource.id} (#{values_found}) does not match category requested (#{value})"
 
         when 'code'
-          values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           values_found = resolve_path(resource, 'code.coding.code')
+          values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
-          assert match_found.present?, "code in  Observation/#{resource.id} (#{values_found}) does not match code requested (#{values})"
+          assert match_found, "code in Observation/#{resource.id} (#{values_found}) does not match code requested (#{value})"
 
         when 'date'
           values_found = resolve_path(resource, 'effective')
@@ -93,9 +93,9 @@ module Inferno
           assert match_found, "date in Observation/#{resource.id} (#{values_found}) does not match date requested (#{value})"
 
         when 'patient'
-          references_found = resolve_path(resource, 'subject.reference')
-          match_found = references_found.any? { |reference| [value, 'Patient/' + value].include? reference }
-          assert match_found, "patient in  Observation/#{resource.id} (#{references_found}) does not match patient requested (#{value})"
+          values_found = resolve_path(resource, 'subject.reference')
+          match_found = values_found.any? { |reference| [value, 'Patient/' + value].include? reference }
+          assert match_found, "patient in Observation/#{resource.id} (#{values_found}) does not match patient requested (#{value})"
 
         end
       end

--- a/lib/modules/uscore_v3.1.0/heartrate_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/heartrate_sequence.rb
@@ -71,26 +71,31 @@ module Inferno
 
         when 'status'
           values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
-          value_found = resolve_element_from_path(resource, 'status') { |value_in_resource| values.include? value_in_resource }
-          assert value_found.present?, 'status on resource does not match status requested'
+          values_found = resolve_path(resource, 'status')
+          match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
+          assert match_found.present?, "status in  Observation/#{resource.id} (#{values_found}) does not match status requested (#{values})"
 
         when 'category'
           values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
-          value_found = resolve_element_from_path(resource, 'category.coding.code') { |value_in_resource| values.include? value_in_resource }
-          assert value_found.present?, 'category on resource does not match category requested'
+          values_found = resolve_path(resource, 'category.coding.code')
+          match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
+          assert match_found.present?, "category in  Observation/#{resource.id} (#{values_found}) does not match category requested (#{values})"
 
         when 'code'
           values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
-          value_found = resolve_element_from_path(resource, 'code.coding.code') { |value_in_resource| values.include? value_in_resource }
-          assert value_found.present?, 'code on resource does not match code requested'
+          values_found = resolve_path(resource, 'code.coding.code')
+          match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
+          assert match_found.present?, "code in  Observation/#{resource.id} (#{values_found}) does not match code requested (#{values})"
 
         when 'date'
-          value_found = resolve_element_from_path(resource, 'effective') { |date| validate_date_search(value, date) }
-          assert value_found.present?, 'date on resource does not match date requested'
+          values_found = resolve_path(resource, 'effective')
+          match_found = values_found.any? { |date| validate_date_search(value, date) }
+          assert match_found, "date in Observation/#{resource.id} (#{values_found}) does not match date requested (#{value})"
 
         when 'patient'
-          value_found = resolve_element_from_path(resource, 'subject.reference') { |reference| [value, 'Patient/' + value].include? reference }
-          assert value_found.present?, 'patient on resource does not match patient requested'
+          references_found = resolve_path(resource, 'subject.reference')
+          match_found = references_found.any? { |reference| [value, 'Patient/' + value].include? reference }
+          assert match_found, "patient in  Observation/#{resource.id} (#{references_found}) does not match patient requested (#{value})"
 
         end
       end

--- a/lib/modules/uscore_v3.1.0/pediatric_bmi_for_age_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/pediatric_bmi_for_age_sequence.rb
@@ -70,22 +70,22 @@ module Inferno
         case property
 
         when 'status'
-          values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           values_found = resolve_path(resource, 'status')
+          values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
-          assert match_found.present?, "status in  Observation/#{resource.id} (#{values_found}) does not match status requested (#{values})"
+          assert match_found, "status in Observation/#{resource.id} (#{values_found}) does not match status requested (#{value})"
 
         when 'category'
-          values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           values_found = resolve_path(resource, 'category.coding.code')
+          values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
-          assert match_found.present?, "category in  Observation/#{resource.id} (#{values_found}) does not match category requested (#{values})"
+          assert match_found, "category in Observation/#{resource.id} (#{values_found}) does not match category requested (#{value})"
 
         when 'code'
-          values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           values_found = resolve_path(resource, 'code.coding.code')
+          values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
-          assert match_found.present?, "code in  Observation/#{resource.id} (#{values_found}) does not match code requested (#{values})"
+          assert match_found, "code in Observation/#{resource.id} (#{values_found}) does not match code requested (#{value})"
 
         when 'date'
           values_found = resolve_path(resource, 'effective')
@@ -93,9 +93,9 @@ module Inferno
           assert match_found, "date in Observation/#{resource.id} (#{values_found}) does not match date requested (#{value})"
 
         when 'patient'
-          references_found = resolve_path(resource, 'subject.reference')
-          match_found = references_found.any? { |reference| [value, 'Patient/' + value].include? reference }
-          assert match_found, "patient in  Observation/#{resource.id} (#{references_found}) does not match patient requested (#{value})"
+          values_found = resolve_path(resource, 'subject.reference')
+          match_found = values_found.any? { |reference| [value, 'Patient/' + value].include? reference }
+          assert match_found, "patient in Observation/#{resource.id} (#{values_found}) does not match patient requested (#{value})"
 
         end
       end

--- a/lib/modules/uscore_v3.1.0/pediatric_bmi_for_age_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/pediatric_bmi_for_age_sequence.rb
@@ -71,26 +71,31 @@ module Inferno
 
         when 'status'
           values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
-          value_found = resolve_element_from_path(resource, 'status') { |value_in_resource| values.include? value_in_resource }
-          assert value_found.present?, 'status on resource does not match status requested'
+          values_found = resolve_path(resource, 'status')
+          match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
+          assert match_found.present?, "status in  Observation/#{resource.id} (#{values_found}) does not match status requested (#{values})"
 
         when 'category'
           values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
-          value_found = resolve_element_from_path(resource, 'category.coding.code') { |value_in_resource| values.include? value_in_resource }
-          assert value_found.present?, 'category on resource does not match category requested'
+          values_found = resolve_path(resource, 'category.coding.code')
+          match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
+          assert match_found.present?, "category in  Observation/#{resource.id} (#{values_found}) does not match category requested (#{values})"
 
         when 'code'
           values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
-          value_found = resolve_element_from_path(resource, 'code.coding.code') { |value_in_resource| values.include? value_in_resource }
-          assert value_found.present?, 'code on resource does not match code requested'
+          values_found = resolve_path(resource, 'code.coding.code')
+          match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
+          assert match_found.present?, "code in  Observation/#{resource.id} (#{values_found}) does not match code requested (#{values})"
 
         when 'date'
-          value_found = resolve_element_from_path(resource, 'effective') { |date| validate_date_search(value, date) }
-          assert value_found.present?, 'date on resource does not match date requested'
+          values_found = resolve_path(resource, 'effective')
+          match_found = values_found.any? { |date| validate_date_search(value, date) }
+          assert match_found, "date in Observation/#{resource.id} (#{values_found}) does not match date requested (#{value})"
 
         when 'patient'
-          value_found = resolve_element_from_path(resource, 'subject.reference') { |reference| [value, 'Patient/' + value].include? reference }
-          assert value_found.present?, 'patient on resource does not match patient requested'
+          references_found = resolve_path(resource, 'subject.reference')
+          match_found = references_found.any? { |reference| [value, 'Patient/' + value].include? reference }
+          assert match_found, "patient in  Observation/#{resource.id} (#{references_found}) does not match patient requested (#{value})"
 
         end
       end

--- a/lib/modules/uscore_v3.1.0/pediatric_weight_for_height_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/pediatric_weight_for_height_sequence.rb
@@ -70,22 +70,22 @@ module Inferno
         case property
 
         when 'status'
-          values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           values_found = resolve_path(resource, 'status')
+          values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
-          assert match_found.present?, "status in  Observation/#{resource.id} (#{values_found}) does not match status requested (#{values})"
+          assert match_found, "status in Observation/#{resource.id} (#{values_found}) does not match status requested (#{value})"
 
         when 'category'
-          values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           values_found = resolve_path(resource, 'category.coding.code')
+          values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
-          assert match_found.present?, "category in  Observation/#{resource.id} (#{values_found}) does not match category requested (#{values})"
+          assert match_found, "category in Observation/#{resource.id} (#{values_found}) does not match category requested (#{value})"
 
         when 'code'
-          values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           values_found = resolve_path(resource, 'code.coding.code')
+          values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
-          assert match_found.present?, "code in  Observation/#{resource.id} (#{values_found}) does not match code requested (#{values})"
+          assert match_found, "code in Observation/#{resource.id} (#{values_found}) does not match code requested (#{value})"
 
         when 'date'
           values_found = resolve_path(resource, 'effective')
@@ -93,9 +93,9 @@ module Inferno
           assert match_found, "date in Observation/#{resource.id} (#{values_found}) does not match date requested (#{value})"
 
         when 'patient'
-          references_found = resolve_path(resource, 'subject.reference')
-          match_found = references_found.any? { |reference| [value, 'Patient/' + value].include? reference }
-          assert match_found, "patient in  Observation/#{resource.id} (#{references_found}) does not match patient requested (#{value})"
+          values_found = resolve_path(resource, 'subject.reference')
+          match_found = values_found.any? { |reference| [value, 'Patient/' + value].include? reference }
+          assert match_found, "patient in Observation/#{resource.id} (#{values_found}) does not match patient requested (#{value})"
 
         end
       end

--- a/lib/modules/uscore_v3.1.0/pediatric_weight_for_height_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/pediatric_weight_for_height_sequence.rb
@@ -71,26 +71,31 @@ module Inferno
 
         when 'status'
           values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
-          value_found = resolve_element_from_path(resource, 'status') { |value_in_resource| values.include? value_in_resource }
-          assert value_found.present?, 'status on resource does not match status requested'
+          values_found = resolve_path(resource, 'status')
+          match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
+          assert match_found.present?, "status in  Observation/#{resource.id} (#{values_found}) does not match status requested (#{values})"
 
         when 'category'
           values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
-          value_found = resolve_element_from_path(resource, 'category.coding.code') { |value_in_resource| values.include? value_in_resource }
-          assert value_found.present?, 'category on resource does not match category requested'
+          values_found = resolve_path(resource, 'category.coding.code')
+          match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
+          assert match_found.present?, "category in  Observation/#{resource.id} (#{values_found}) does not match category requested (#{values})"
 
         when 'code'
           values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
-          value_found = resolve_element_from_path(resource, 'code.coding.code') { |value_in_resource| values.include? value_in_resource }
-          assert value_found.present?, 'code on resource does not match code requested'
+          values_found = resolve_path(resource, 'code.coding.code')
+          match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
+          assert match_found.present?, "code in  Observation/#{resource.id} (#{values_found}) does not match code requested (#{values})"
 
         when 'date'
-          value_found = resolve_element_from_path(resource, 'effective') { |date| validate_date_search(value, date) }
-          assert value_found.present?, 'date on resource does not match date requested'
+          values_found = resolve_path(resource, 'effective')
+          match_found = values_found.any? { |date| validate_date_search(value, date) }
+          assert match_found, "date in Observation/#{resource.id} (#{values_found}) does not match date requested (#{value})"
 
         when 'patient'
-          value_found = resolve_element_from_path(resource, 'subject.reference') { |reference| [value, 'Patient/' + value].include? reference }
-          assert value_found.present?, 'patient on resource does not match patient requested'
+          references_found = resolve_path(resource, 'subject.reference')
+          match_found = references_found.any? { |reference| [value, 'Patient/' + value].include? reference }
+          assert match_found, "patient in  Observation/#{resource.id} (#{references_found}) does not match patient requested (#{value})"
 
         end
       end

--- a/lib/modules/uscore_v3.1.0/resprate_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/resprate_sequence.rb
@@ -70,22 +70,22 @@ module Inferno
         case property
 
         when 'status'
-          values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           values_found = resolve_path(resource, 'status')
+          values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
-          assert match_found.present?, "status in  Observation/#{resource.id} (#{values_found}) does not match status requested (#{values})"
+          assert match_found, "status in Observation/#{resource.id} (#{values_found}) does not match status requested (#{value})"
 
         when 'category'
-          values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           values_found = resolve_path(resource, 'category.coding.code')
+          values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
-          assert match_found.present?, "category in  Observation/#{resource.id} (#{values_found}) does not match category requested (#{values})"
+          assert match_found, "category in Observation/#{resource.id} (#{values_found}) does not match category requested (#{value})"
 
         when 'code'
-          values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           values_found = resolve_path(resource, 'code.coding.code')
+          values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
-          assert match_found.present?, "code in  Observation/#{resource.id} (#{values_found}) does not match code requested (#{values})"
+          assert match_found, "code in Observation/#{resource.id} (#{values_found}) does not match code requested (#{value})"
 
         when 'date'
           values_found = resolve_path(resource, 'effective')
@@ -93,9 +93,9 @@ module Inferno
           assert match_found, "date in Observation/#{resource.id} (#{values_found}) does not match date requested (#{value})"
 
         when 'patient'
-          references_found = resolve_path(resource, 'subject.reference')
-          match_found = references_found.any? { |reference| [value, 'Patient/' + value].include? reference }
-          assert match_found, "patient in  Observation/#{resource.id} (#{references_found}) does not match patient requested (#{value})"
+          values_found = resolve_path(resource, 'subject.reference')
+          match_found = values_found.any? { |reference| [value, 'Patient/' + value].include? reference }
+          assert match_found, "patient in Observation/#{resource.id} (#{values_found}) does not match patient requested (#{value})"
 
         end
       end

--- a/lib/modules/uscore_v3.1.0/resprate_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/resprate_sequence.rb
@@ -71,26 +71,31 @@ module Inferno
 
         when 'status'
           values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
-          value_found = resolve_element_from_path(resource, 'status') { |value_in_resource| values.include? value_in_resource }
-          assert value_found.present?, 'status on resource does not match status requested'
+          values_found = resolve_path(resource, 'status')
+          match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
+          assert match_found.present?, "status in  Observation/#{resource.id} (#{values_found}) does not match status requested (#{values})"
 
         when 'category'
           values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
-          value_found = resolve_element_from_path(resource, 'category.coding.code') { |value_in_resource| values.include? value_in_resource }
-          assert value_found.present?, 'category on resource does not match category requested'
+          values_found = resolve_path(resource, 'category.coding.code')
+          match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
+          assert match_found.present?, "category in  Observation/#{resource.id} (#{values_found}) does not match category requested (#{values})"
 
         when 'code'
           values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
-          value_found = resolve_element_from_path(resource, 'code.coding.code') { |value_in_resource| values.include? value_in_resource }
-          assert value_found.present?, 'code on resource does not match code requested'
+          values_found = resolve_path(resource, 'code.coding.code')
+          match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
+          assert match_found.present?, "code in  Observation/#{resource.id} (#{values_found}) does not match code requested (#{values})"
 
         when 'date'
-          value_found = resolve_element_from_path(resource, 'effective') { |date| validate_date_search(value, date) }
-          assert value_found.present?, 'date on resource does not match date requested'
+          values_found = resolve_path(resource, 'effective')
+          match_found = values_found.any? { |date| validate_date_search(value, date) }
+          assert match_found, "date in Observation/#{resource.id} (#{values_found}) does not match date requested (#{value})"
 
         when 'patient'
-          value_found = resolve_element_from_path(resource, 'subject.reference') { |reference| [value, 'Patient/' + value].include? reference }
-          assert value_found.present?, 'patient on resource does not match patient requested'
+          references_found = resolve_path(resource, 'subject.reference')
+          match_found = references_found.any? { |reference| [value, 'Patient/' + value].include? reference }
+          assert match_found, "patient in  Observation/#{resource.id} (#{references_found}) does not match patient requested (#{value})"
 
         end
       end

--- a/lib/modules/uscore_v3.1.0/us_core_allergyintolerance_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_allergyintolerance_sequence.rb
@@ -69,12 +69,14 @@ module Inferno
 
         when 'clinical-status'
           values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
-          value_found = resolve_element_from_path(resource, 'clinicalStatus.coding.code') { |value_in_resource| values.include? value_in_resource }
-          assert value_found.present?, 'clinical-status on resource does not match clinical-status requested'
+          values_found = resolve_path(resource, 'clinicalStatus.coding.code')
+          match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
+          assert match_found.present?, "clinical-status in  AllergyIntolerance/#{resource.id} (#{values_found}) does not match clinical-status requested (#{values})"
 
         when 'patient'
-          value_found = resolve_element_from_path(resource, 'patient.reference') { |reference| [value, 'Patient/' + value].include? reference }
-          assert value_found.present?, 'patient on resource does not match patient requested'
+          references_found = resolve_path(resource, 'patient.reference')
+          match_found = references_found.any? { |reference| [value, 'Patient/' + value].include? reference }
+          assert match_found, "patient in  AllergyIntolerance/#{resource.id} (#{references_found}) does not match patient requested (#{value})"
 
         end
       end

--- a/lib/modules/uscore_v3.1.0/us_core_allergyintolerance_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_allergyintolerance_sequence.rb
@@ -68,15 +68,15 @@ module Inferno
         case property
 
         when 'clinical-status'
-          values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           values_found = resolve_path(resource, 'clinicalStatus.coding.code')
+          values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
-          assert match_found.present?, "clinical-status in  AllergyIntolerance/#{resource.id} (#{values_found}) does not match clinical-status requested (#{values})"
+          assert match_found, "clinical-status in AllergyIntolerance/#{resource.id} (#{values_found}) does not match clinical-status requested (#{value})"
 
         when 'patient'
-          references_found = resolve_path(resource, 'patient.reference')
-          match_found = references_found.any? { |reference| [value, 'Patient/' + value].include? reference }
-          assert match_found, "patient in  AllergyIntolerance/#{resource.id} (#{references_found}) does not match patient requested (#{value})"
+          values_found = resolve_path(resource, 'patient.reference')
+          match_found = values_found.any? { |reference| [value, 'Patient/' + value].include? reference }
+          assert match_found, "patient in AllergyIntolerance/#{resource.id} (#{values_found}) does not match patient requested (#{value})"
 
         end
       end

--- a/lib/modules/uscore_v3.1.0/us_core_careplan_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_careplan_sequence.rb
@@ -69,21 +69,25 @@ module Inferno
 
         when 'category'
           values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
-          value_found = resolve_element_from_path(resource, 'category.coding.code') { |value_in_resource| values.include? value_in_resource }
-          assert value_found.present?, 'category on resource does not match category requested'
+          values_found = resolve_path(resource, 'category.coding.code')
+          match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
+          assert match_found.present?, "category in  CarePlan/#{resource.id} (#{values_found}) does not match category requested (#{values})"
 
         when 'date'
-          value_found = resolve_element_from_path(resource, 'period') { |date| validate_date_search(value, date) }
-          assert value_found.present?, 'date on resource does not match date requested'
+          values_found = resolve_path(resource, 'period')
+          match_found = values_found.any? { |date| validate_date_search(value, date) }
+          assert match_found, "date in CarePlan/#{resource.id} (#{values_found}) does not match date requested (#{value})"
 
         when 'patient'
-          value_found = resolve_element_from_path(resource, 'subject.reference') { |reference| [value, 'Patient/' + value].include? reference }
-          assert value_found.present?, 'patient on resource does not match patient requested'
+          references_found = resolve_path(resource, 'subject.reference')
+          match_found = references_found.any? { |reference| [value, 'Patient/' + value].include? reference }
+          assert match_found, "patient in  CarePlan/#{resource.id} (#{references_found}) does not match patient requested (#{value})"
 
         when 'status'
           values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
-          value_found = resolve_element_from_path(resource, 'status') { |value_in_resource| values.include? value_in_resource }
-          assert value_found.present?, 'status on resource does not match status requested'
+          values_found = resolve_path(resource, 'status')
+          match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
+          assert match_found.present?, "status in  CarePlan/#{resource.id} (#{values_found}) does not match status requested (#{values})"
 
         end
       end

--- a/lib/modules/uscore_v3.1.0/us_core_careplan_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_careplan_sequence.rb
@@ -68,10 +68,10 @@ module Inferno
         case property
 
         when 'category'
-          values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           values_found = resolve_path(resource, 'category.coding.code')
+          values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
-          assert match_found.present?, "category in  CarePlan/#{resource.id} (#{values_found}) does not match category requested (#{values})"
+          assert match_found, "category in CarePlan/#{resource.id} (#{values_found}) does not match category requested (#{value})"
 
         when 'date'
           values_found = resolve_path(resource, 'period')
@@ -79,15 +79,15 @@ module Inferno
           assert match_found, "date in CarePlan/#{resource.id} (#{values_found}) does not match date requested (#{value})"
 
         when 'patient'
-          references_found = resolve_path(resource, 'subject.reference')
-          match_found = references_found.any? { |reference| [value, 'Patient/' + value].include? reference }
-          assert match_found, "patient in  CarePlan/#{resource.id} (#{references_found}) does not match patient requested (#{value})"
+          values_found = resolve_path(resource, 'subject.reference')
+          match_found = values_found.any? { |reference| [value, 'Patient/' + value].include? reference }
+          assert match_found, "patient in CarePlan/#{resource.id} (#{values_found}) does not match patient requested (#{value})"
 
         when 'status'
-          values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           values_found = resolve_path(resource, 'status')
+          values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
-          assert match_found.present?, "status in  CarePlan/#{resource.id} (#{values_found}) does not match status requested (#{values})"
+          assert match_found, "status in CarePlan/#{resource.id} (#{values_found}) does not match status requested (#{value})"
 
         end
       end

--- a/lib/modules/uscore_v3.1.0/us_core_careteam_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_careteam_sequence.rb
@@ -68,13 +68,15 @@ module Inferno
         case property
 
         when 'patient'
-          value_found = resolve_element_from_path(resource, 'subject.reference') { |reference| [value, 'Patient/' + value].include? reference }
-          assert value_found.present?, 'patient on resource does not match patient requested'
+          references_found = resolve_path(resource, 'subject.reference')
+          match_found = references_found.any? { |reference| [value, 'Patient/' + value].include? reference }
+          assert match_found, "patient in  CareTeam/#{resource.id} (#{references_found}) does not match patient requested (#{value})"
 
         when 'status'
           values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
-          value_found = resolve_element_from_path(resource, 'status') { |value_in_resource| values.include? value_in_resource }
-          assert value_found.present?, 'status on resource does not match status requested'
+          values_found = resolve_path(resource, 'status')
+          match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
+          assert match_found.present?, "status in  CareTeam/#{resource.id} (#{values_found}) does not match status requested (#{values})"
 
         end
       end

--- a/lib/modules/uscore_v3.1.0/us_core_careteam_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_careteam_sequence.rb
@@ -68,15 +68,15 @@ module Inferno
         case property
 
         when 'patient'
-          references_found = resolve_path(resource, 'subject.reference')
-          match_found = references_found.any? { |reference| [value, 'Patient/' + value].include? reference }
-          assert match_found, "patient in  CareTeam/#{resource.id} (#{references_found}) does not match patient requested (#{value})"
+          values_found = resolve_path(resource, 'subject.reference')
+          match_found = values_found.any? { |reference| [value, 'Patient/' + value].include? reference }
+          assert match_found, "patient in CareTeam/#{resource.id} (#{values_found}) does not match patient requested (#{value})"
 
         when 'status'
-          values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           values_found = resolve_path(resource, 'status')
+          values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
-          assert match_found.present?, "status in  CareTeam/#{resource.id} (#{values_found}) does not match status requested (#{values})"
+          assert match_found, "status in CareTeam/#{resource.id} (#{values_found}) does not match status requested (#{value})"
 
         end
       end

--- a/lib/modules/uscore_v3.1.0/us_core_condition_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_condition_sequence.rb
@@ -68,21 +68,21 @@ module Inferno
         case property
 
         when 'category'
-          values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           values_found = resolve_path(resource, 'category.coding.code')
+          values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
-          assert match_found.present?, "category in  Condition/#{resource.id} (#{values_found}) does not match category requested (#{values})"
+          assert match_found, "category in Condition/#{resource.id} (#{values_found}) does not match category requested (#{value})"
 
         when 'clinical-status'
-          values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           values_found = resolve_path(resource, 'clinicalStatus.coding.code')
+          values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
-          assert match_found.present?, "clinical-status in  Condition/#{resource.id} (#{values_found}) does not match clinical-status requested (#{values})"
+          assert match_found, "clinical-status in Condition/#{resource.id} (#{values_found}) does not match clinical-status requested (#{value})"
 
         when 'patient'
-          references_found = resolve_path(resource, 'subject.reference')
-          match_found = references_found.any? { |reference| [value, 'Patient/' + value].include? reference }
-          assert match_found, "patient in  Condition/#{resource.id} (#{references_found}) does not match patient requested (#{value})"
+          values_found = resolve_path(resource, 'subject.reference')
+          match_found = values_found.any? { |reference| [value, 'Patient/' + value].include? reference }
+          assert match_found, "patient in Condition/#{resource.id} (#{values_found}) does not match patient requested (#{value})"
 
         when 'onset-date'
           values_found = resolve_path(resource, 'onsetDateTime')
@@ -90,10 +90,10 @@ module Inferno
           assert match_found, "onset-date in Condition/#{resource.id} (#{values_found}) does not match onset-date requested (#{value})"
 
         when 'code'
-          values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           values_found = resolve_path(resource, 'code.coding.code')
+          values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
-          assert match_found.present?, "code in  Condition/#{resource.id} (#{values_found}) does not match code requested (#{values})"
+          assert match_found, "code in Condition/#{resource.id} (#{values_found}) does not match code requested (#{value})"
 
         end
       end

--- a/lib/modules/uscore_v3.1.0/us_core_condition_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_condition_sequence.rb
@@ -69,26 +69,31 @@ module Inferno
 
         when 'category'
           values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
-          value_found = resolve_element_from_path(resource, 'category.coding.code') { |value_in_resource| values.include? value_in_resource }
-          assert value_found.present?, 'category on resource does not match category requested'
+          values_found = resolve_path(resource, 'category.coding.code')
+          match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
+          assert match_found.present?, "category in  Condition/#{resource.id} (#{values_found}) does not match category requested (#{values})"
 
         when 'clinical-status'
           values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
-          value_found = resolve_element_from_path(resource, 'clinicalStatus.coding.code') { |value_in_resource| values.include? value_in_resource }
-          assert value_found.present?, 'clinical-status on resource does not match clinical-status requested'
+          values_found = resolve_path(resource, 'clinicalStatus.coding.code')
+          match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
+          assert match_found.present?, "clinical-status in  Condition/#{resource.id} (#{values_found}) does not match clinical-status requested (#{values})"
 
         when 'patient'
-          value_found = resolve_element_from_path(resource, 'subject.reference') { |reference| [value, 'Patient/' + value].include? reference }
-          assert value_found.present?, 'patient on resource does not match patient requested'
+          references_found = resolve_path(resource, 'subject.reference')
+          match_found = references_found.any? { |reference| [value, 'Patient/' + value].include? reference }
+          assert match_found, "patient in  Condition/#{resource.id} (#{references_found}) does not match patient requested (#{value})"
 
         when 'onset-date'
-          value_found = resolve_element_from_path(resource, 'onsetDateTime') { |date| validate_date_search(value, date) }
-          assert value_found.present?, 'onset-date on resource does not match onset-date requested'
+          values_found = resolve_path(resource, 'onsetDateTime')
+          match_found = values_found.any? { |date| validate_date_search(value, date) }
+          assert match_found, "onset-date in Condition/#{resource.id} (#{values_found}) does not match onset-date requested (#{value})"
 
         when 'code'
           values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
-          value_found = resolve_element_from_path(resource, 'code.coding.code') { |value_in_resource| values.include? value_in_resource }
-          assert value_found.present?, 'code on resource does not match code requested'
+          values_found = resolve_path(resource, 'code.coding.code')
+          match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
+          assert match_found.present?, "code in  Condition/#{resource.id} (#{values_found}) does not match code requested (#{values})"
 
         end
       end

--- a/lib/modules/uscore_v3.1.0/us_core_diagnosticreport_lab_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_diagnosticreport_lab_sequence.rb
@@ -71,27 +71,27 @@ module Inferno
         case property
 
         when 'status'
-          values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           values_found = resolve_path(resource, 'status')
+          values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
-          assert match_found.present?, "status in  DiagnosticReport/#{resource.id} (#{values_found}) does not match status requested (#{values})"
+          assert match_found, "status in DiagnosticReport/#{resource.id} (#{values_found}) does not match status requested (#{value})"
 
         when 'patient'
-          references_found = resolve_path(resource, 'subject.reference')
-          match_found = references_found.any? { |reference| [value, 'Patient/' + value].include? reference }
-          assert match_found, "patient in  DiagnosticReport/#{resource.id} (#{references_found}) does not match patient requested (#{value})"
+          values_found = resolve_path(resource, 'subject.reference')
+          match_found = values_found.any? { |reference| [value, 'Patient/' + value].include? reference }
+          assert match_found, "patient in DiagnosticReport/#{resource.id} (#{values_found}) does not match patient requested (#{value})"
 
         when 'category'
-          values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           values_found = resolve_path(resource, 'category.coding.code')
+          values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
-          assert match_found.present?, "category in  DiagnosticReport/#{resource.id} (#{values_found}) does not match category requested (#{values})"
+          assert match_found, "category in DiagnosticReport/#{resource.id} (#{values_found}) does not match category requested (#{value})"
 
         when 'code'
-          values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           values_found = resolve_path(resource, 'code.coding.code')
+          values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
-          assert match_found.present?, "code in  DiagnosticReport/#{resource.id} (#{values_found}) does not match code requested (#{values})"
+          assert match_found, "code in DiagnosticReport/#{resource.id} (#{values_found}) does not match code requested (#{value})"
 
         when 'date'
           values_found = resolve_path(resource, 'effective')

--- a/lib/modules/uscore_v3.1.0/us_core_diagnosticreport_lab_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_diagnosticreport_lab_sequence.rb
@@ -72,26 +72,31 @@ module Inferno
 
         when 'status'
           values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
-          value_found = resolve_element_from_path(resource, 'status') { |value_in_resource| values.include? value_in_resource }
-          assert value_found.present?, 'status on resource does not match status requested'
+          values_found = resolve_path(resource, 'status')
+          match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
+          assert match_found.present?, "status in  DiagnosticReport/#{resource.id} (#{values_found}) does not match status requested (#{values})"
 
         when 'patient'
-          value_found = resolve_element_from_path(resource, 'subject.reference') { |reference| [value, 'Patient/' + value].include? reference }
-          assert value_found.present?, 'patient on resource does not match patient requested'
+          references_found = resolve_path(resource, 'subject.reference')
+          match_found = references_found.any? { |reference| [value, 'Patient/' + value].include? reference }
+          assert match_found, "patient in  DiagnosticReport/#{resource.id} (#{references_found}) does not match patient requested (#{value})"
 
         when 'category'
           values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
-          value_found = resolve_element_from_path(resource, 'category.coding.code') { |value_in_resource| values.include? value_in_resource }
-          assert value_found.present?, 'category on resource does not match category requested'
+          values_found = resolve_path(resource, 'category.coding.code')
+          match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
+          assert match_found.present?, "category in  DiagnosticReport/#{resource.id} (#{values_found}) does not match category requested (#{values})"
 
         when 'code'
           values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
-          value_found = resolve_element_from_path(resource, 'code.coding.code') { |value_in_resource| values.include? value_in_resource }
-          assert value_found.present?, 'code on resource does not match code requested'
+          values_found = resolve_path(resource, 'code.coding.code')
+          match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
+          assert match_found.present?, "code in  DiagnosticReport/#{resource.id} (#{values_found}) does not match code requested (#{values})"
 
         when 'date'
-          value_found = resolve_element_from_path(resource, 'effective') { |date| validate_date_search(value, date) }
-          assert value_found.present?, 'date on resource does not match date requested'
+          values_found = resolve_path(resource, 'effective')
+          match_found = values_found.any? { |date| validate_date_search(value, date) }
+          assert match_found, "date in DiagnosticReport/#{resource.id} (#{values_found}) does not match date requested (#{value})"
 
         end
       end

--- a/lib/modules/uscore_v3.1.0/us_core_diagnosticreport_note_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_diagnosticreport_note_sequence.rb
@@ -71,27 +71,27 @@ module Inferno
         case property
 
         when 'status'
-          values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           values_found = resolve_path(resource, 'status')
+          values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
-          assert match_found.present?, "status in  DiagnosticReport/#{resource.id} (#{values_found}) does not match status requested (#{values})"
+          assert match_found, "status in DiagnosticReport/#{resource.id} (#{values_found}) does not match status requested (#{value})"
 
         when 'patient'
-          references_found = resolve_path(resource, 'subject.reference')
-          match_found = references_found.any? { |reference| [value, 'Patient/' + value].include? reference }
-          assert match_found, "patient in  DiagnosticReport/#{resource.id} (#{references_found}) does not match patient requested (#{value})"
+          values_found = resolve_path(resource, 'subject.reference')
+          match_found = values_found.any? { |reference| [value, 'Patient/' + value].include? reference }
+          assert match_found, "patient in DiagnosticReport/#{resource.id} (#{values_found}) does not match patient requested (#{value})"
 
         when 'category'
-          values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           values_found = resolve_path(resource, 'category.coding.code')
+          values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
-          assert match_found.present?, "category in  DiagnosticReport/#{resource.id} (#{values_found}) does not match category requested (#{values})"
+          assert match_found, "category in DiagnosticReport/#{resource.id} (#{values_found}) does not match category requested (#{value})"
 
         when 'code'
-          values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           values_found = resolve_path(resource, 'code.coding.code')
+          values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
-          assert match_found.present?, "code in  DiagnosticReport/#{resource.id} (#{values_found}) does not match code requested (#{values})"
+          assert match_found, "code in DiagnosticReport/#{resource.id} (#{values_found}) does not match code requested (#{value})"
 
         when 'date'
           values_found = resolve_path(resource, 'effective')

--- a/lib/modules/uscore_v3.1.0/us_core_diagnosticreport_note_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_diagnosticreport_note_sequence.rb
@@ -72,26 +72,31 @@ module Inferno
 
         when 'status'
           values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
-          value_found = resolve_element_from_path(resource, 'status') { |value_in_resource| values.include? value_in_resource }
-          assert value_found.present?, 'status on resource does not match status requested'
+          values_found = resolve_path(resource, 'status')
+          match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
+          assert match_found.present?, "status in  DiagnosticReport/#{resource.id} (#{values_found}) does not match status requested (#{values})"
 
         when 'patient'
-          value_found = resolve_element_from_path(resource, 'subject.reference') { |reference| [value, 'Patient/' + value].include? reference }
-          assert value_found.present?, 'patient on resource does not match patient requested'
+          references_found = resolve_path(resource, 'subject.reference')
+          match_found = references_found.any? { |reference| [value, 'Patient/' + value].include? reference }
+          assert match_found, "patient in  DiagnosticReport/#{resource.id} (#{references_found}) does not match patient requested (#{value})"
 
         when 'category'
           values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
-          value_found = resolve_element_from_path(resource, 'category.coding.code') { |value_in_resource| values.include? value_in_resource }
-          assert value_found.present?, 'category on resource does not match category requested'
+          values_found = resolve_path(resource, 'category.coding.code')
+          match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
+          assert match_found.present?, "category in  DiagnosticReport/#{resource.id} (#{values_found}) does not match category requested (#{values})"
 
         when 'code'
           values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
-          value_found = resolve_element_from_path(resource, 'code.coding.code') { |value_in_resource| values.include? value_in_resource }
-          assert value_found.present?, 'code on resource does not match code requested'
+          values_found = resolve_path(resource, 'code.coding.code')
+          match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
+          assert match_found.present?, "code in  DiagnosticReport/#{resource.id} (#{values_found}) does not match code requested (#{values})"
 
         when 'date'
-          value_found = resolve_element_from_path(resource, 'effective') { |date| validate_date_search(value, date) }
-          assert value_found.present?, 'date on resource does not match date requested'
+          values_found = resolve_path(resource, 'effective')
+          match_found = values_found.any? { |date| validate_date_search(value, date) }
+          assert match_found, "date in DiagnosticReport/#{resource.id} (#{values_found}) does not match date requested (#{value})"
 
         end
       end

--- a/lib/modules/uscore_v3.1.0/us_core_documentreference_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_documentreference_sequence.rb
@@ -72,39 +72,39 @@ module Inferno
         case property
 
         when '_id'
-          values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           values_found = resolve_path(resource, 'id')
+          values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
-          assert match_found.present?, "_id in  DocumentReference/#{resource.id} (#{values_found}) does not match _id requested (#{values})"
+          assert match_found, "_id in DocumentReference/#{resource.id} (#{values_found}) does not match _id requested (#{value})"
 
         when 'status'
-          values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           values_found = resolve_path(resource, 'status')
+          values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
-          assert match_found.present?, "status in  DocumentReference/#{resource.id} (#{values_found}) does not match status requested (#{values})"
+          assert match_found, "status in DocumentReference/#{resource.id} (#{values_found}) does not match status requested (#{value})"
 
         when 'patient'
-          references_found = resolve_path(resource, 'subject.reference')
-          match_found = references_found.any? { |reference| [value, 'Patient/' + value].include? reference }
-          assert match_found, "patient in  DocumentReference/#{resource.id} (#{references_found}) does not match patient requested (#{value})"
+          values_found = resolve_path(resource, 'subject.reference')
+          match_found = values_found.any? { |reference| [value, 'Patient/' + value].include? reference }
+          assert match_found, "patient in DocumentReference/#{resource.id} (#{values_found}) does not match patient requested (#{value})"
 
         when 'category'
-          values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           values_found = resolve_path(resource, 'category.coding.code')
+          values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
-          assert match_found.present?, "category in  DocumentReference/#{resource.id} (#{values_found}) does not match category requested (#{values})"
+          assert match_found, "category in DocumentReference/#{resource.id} (#{values_found}) does not match category requested (#{value})"
 
         when 'type'
-          values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           values_found = resolve_path(resource, 'type.coding.code')
+          values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
-          assert match_found.present?, "type in  DocumentReference/#{resource.id} (#{values_found}) does not match type requested (#{values})"
+          assert match_found, "type in DocumentReference/#{resource.id} (#{values_found}) does not match type requested (#{value})"
 
         when 'date'
-          values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           values_found = resolve_path(resource, 'date')
+          values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
-          assert match_found.present?, "date in  DocumentReference/#{resource.id} (#{values_found}) does not match date requested (#{values})"
+          assert match_found, "date in DocumentReference/#{resource.id} (#{values_found}) does not match date requested (#{value})"
 
         when 'period'
           values_found = resolve_path(resource, 'context.period')

--- a/lib/modules/uscore_v3.1.0/us_core_documentreference_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_documentreference_sequence.rb
@@ -73,36 +73,43 @@ module Inferno
 
         when '_id'
           values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
-          value_found = resolve_element_from_path(resource, 'id') { |value_in_resource| values.include? value_in_resource }
-          assert value_found.present?, '_id on resource does not match _id requested'
+          values_found = resolve_path(resource, 'id')
+          match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
+          assert match_found.present?, "_id in  DocumentReference/#{resource.id} (#{values_found}) does not match _id requested (#{values})"
 
         when 'status'
           values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
-          value_found = resolve_element_from_path(resource, 'status') { |value_in_resource| values.include? value_in_resource }
-          assert value_found.present?, 'status on resource does not match status requested'
+          values_found = resolve_path(resource, 'status')
+          match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
+          assert match_found.present?, "status in  DocumentReference/#{resource.id} (#{values_found}) does not match status requested (#{values})"
 
         when 'patient'
-          value_found = resolve_element_from_path(resource, 'subject.reference') { |reference| [value, 'Patient/' + value].include? reference }
-          assert value_found.present?, 'patient on resource does not match patient requested'
+          references_found = resolve_path(resource, 'subject.reference')
+          match_found = references_found.any? { |reference| [value, 'Patient/' + value].include? reference }
+          assert match_found, "patient in  DocumentReference/#{resource.id} (#{references_found}) does not match patient requested (#{value})"
 
         when 'category'
           values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
-          value_found = resolve_element_from_path(resource, 'category.coding.code') { |value_in_resource| values.include? value_in_resource }
-          assert value_found.present?, 'category on resource does not match category requested'
+          values_found = resolve_path(resource, 'category.coding.code')
+          match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
+          assert match_found.present?, "category in  DocumentReference/#{resource.id} (#{values_found}) does not match category requested (#{values})"
 
         when 'type'
           values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
-          value_found = resolve_element_from_path(resource, 'type.coding.code') { |value_in_resource| values.include? value_in_resource }
-          assert value_found.present?, 'type on resource does not match type requested'
+          values_found = resolve_path(resource, 'type.coding.code')
+          match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
+          assert match_found.present?, "type in  DocumentReference/#{resource.id} (#{values_found}) does not match type requested (#{values})"
 
         when 'date'
           values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
-          value_found = resolve_element_from_path(resource, 'date') { |value_in_resource| values.include? value_in_resource }
-          assert value_found.present?, 'date on resource does not match date requested'
+          values_found = resolve_path(resource, 'date')
+          match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
+          assert match_found.present?, "date in  DocumentReference/#{resource.id} (#{values_found}) does not match date requested (#{values})"
 
         when 'period'
-          value_found = resolve_element_from_path(resource, 'context.period') { |date| validate_date_search(value, date) }
-          assert value_found.present?, 'period on resource does not match period requested'
+          values_found = resolve_path(resource, 'context.period')
+          match_found = values_found.any? { |date| validate_date_search(value, date) }
+          assert match_found, "period in DocumentReference/#{resource.id} (#{values_found}) does not match period requested (#{value})"
 
         end
       end

--- a/lib/modules/uscore_v3.1.0/us_core_encounter_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_encounter_sequence.rb
@@ -56,36 +56,43 @@ module Inferno
 
         when '_id'
           values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
-          value_found = resolve_element_from_path(resource, 'id') { |value_in_resource| values.include? value_in_resource }
-          assert value_found.present?, '_id on resource does not match _id requested'
+          values_found = resolve_path(resource, 'id')
+          match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
+          assert match_found.present?, "_id in  Encounter/#{resource.id} (#{values_found}) does not match _id requested (#{values})"
 
         when 'class'
           values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
-          value_found = resolve_element_from_path(resource, 'local_class.code') { |value_in_resource| values.include? value_in_resource }
-          assert value_found.present?, 'class on resource does not match class requested'
+          values_found = resolve_path(resource, 'local_class.code')
+          match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
+          assert match_found.present?, "class in  Encounter/#{resource.id} (#{values_found}) does not match class requested (#{values})"
 
         when 'date'
-          value_found = resolve_element_from_path(resource, 'period') { |date| validate_date_search(value, date) }
-          assert value_found.present?, 'date on resource does not match date requested'
+          values_found = resolve_path(resource, 'period')
+          match_found = values_found.any? { |date| validate_date_search(value, date) }
+          assert match_found, "date in Encounter/#{resource.id} (#{values_found}) does not match date requested (#{value})"
 
         when 'identifier'
           values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
-          value_found = resolve_element_from_path(resource, 'identifier.value') { |value_in_resource| values.include? value_in_resource }
-          assert value_found.present?, 'identifier on resource does not match identifier requested'
+          values_found = resolve_path(resource, 'identifier.value')
+          match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
+          assert match_found.present?, "identifier in  Encounter/#{resource.id} (#{values_found}) does not match identifier requested (#{values})"
 
         when 'patient'
-          value_found = resolve_element_from_path(resource, 'subject.reference') { |reference| [value, 'Patient/' + value].include? reference }
-          assert value_found.present?, 'patient on resource does not match patient requested'
+          references_found = resolve_path(resource, 'subject.reference')
+          match_found = references_found.any? { |reference| [value, 'Patient/' + value].include? reference }
+          assert match_found, "patient in  Encounter/#{resource.id} (#{references_found}) does not match patient requested (#{value})"
 
         when 'status'
           values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
-          value_found = resolve_element_from_path(resource, 'status') { |value_in_resource| values.include? value_in_resource }
-          assert value_found.present?, 'status on resource does not match status requested'
+          values_found = resolve_path(resource, 'status')
+          match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
+          assert match_found.present?, "status in  Encounter/#{resource.id} (#{values_found}) does not match status requested (#{values})"
 
         when 'type'
           values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
-          value_found = resolve_element_from_path(resource, 'type.coding.code') { |value_in_resource| values.include? value_in_resource }
-          assert value_found.present?, 'type on resource does not match type requested'
+          values_found = resolve_path(resource, 'type.coding.code')
+          match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
+          assert match_found.present?, "type in  Encounter/#{resource.id} (#{values_found}) does not match type requested (#{values})"
 
         end
       end

--- a/lib/modules/uscore_v3.1.0/us_core_encounter_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_encounter_sequence.rb
@@ -55,16 +55,16 @@ module Inferno
         case property
 
         when '_id'
-          values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           values_found = resolve_path(resource, 'id')
+          values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
-          assert match_found.present?, "_id in  Encounter/#{resource.id} (#{values_found}) does not match _id requested (#{values})"
+          assert match_found, "_id in Encounter/#{resource.id} (#{values_found}) does not match _id requested (#{value})"
 
         when 'class'
-          values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           values_found = resolve_path(resource, 'local_class.code')
+          values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
-          assert match_found.present?, "class in  Encounter/#{resource.id} (#{values_found}) does not match class requested (#{values})"
+          assert match_found, "class in Encounter/#{resource.id} (#{values_found}) does not match class requested (#{value})"
 
         when 'date'
           values_found = resolve_path(resource, 'period')
@@ -72,27 +72,27 @@ module Inferno
           assert match_found, "date in Encounter/#{resource.id} (#{values_found}) does not match date requested (#{value})"
 
         when 'identifier'
-          values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           values_found = resolve_path(resource, 'identifier.value')
+          values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
-          assert match_found.present?, "identifier in  Encounter/#{resource.id} (#{values_found}) does not match identifier requested (#{values})"
+          assert match_found, "identifier in Encounter/#{resource.id} (#{values_found}) does not match identifier requested (#{value})"
 
         when 'patient'
-          references_found = resolve_path(resource, 'subject.reference')
-          match_found = references_found.any? { |reference| [value, 'Patient/' + value].include? reference }
-          assert match_found, "patient in  Encounter/#{resource.id} (#{references_found}) does not match patient requested (#{value})"
+          values_found = resolve_path(resource, 'subject.reference')
+          match_found = values_found.any? { |reference| [value, 'Patient/' + value].include? reference }
+          assert match_found, "patient in Encounter/#{resource.id} (#{values_found}) does not match patient requested (#{value})"
 
         when 'status'
-          values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           values_found = resolve_path(resource, 'status')
+          values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
-          assert match_found.present?, "status in  Encounter/#{resource.id} (#{values_found}) does not match status requested (#{values})"
+          assert match_found, "status in Encounter/#{resource.id} (#{values_found}) does not match status requested (#{value})"
 
         when 'type'
-          values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           values_found = resolve_path(resource, 'type.coding.code')
+          values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
-          assert match_found.present?, "type in  Encounter/#{resource.id} (#{values_found}) does not match type requested (#{values})"
+          assert match_found, "type in Encounter/#{resource.id} (#{values_found}) does not match type requested (#{value})"
 
         end
       end

--- a/lib/modules/uscore_v3.1.0/us_core_goal_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_goal_sequence.rb
@@ -68,15 +68,15 @@ module Inferno
         case property
 
         when 'lifecycle-status'
-          values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           values_found = resolve_path(resource, 'lifecycleStatus')
+          values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
-          assert match_found.present?, "lifecycle-status in  Goal/#{resource.id} (#{values_found}) does not match lifecycle-status requested (#{values})"
+          assert match_found, "lifecycle-status in Goal/#{resource.id} (#{values_found}) does not match lifecycle-status requested (#{value})"
 
         when 'patient'
-          references_found = resolve_path(resource, 'subject.reference')
-          match_found = references_found.any? { |reference| [value, 'Patient/' + value].include? reference }
-          assert match_found, "patient in  Goal/#{resource.id} (#{references_found}) does not match patient requested (#{value})"
+          values_found = resolve_path(resource, 'subject.reference')
+          match_found = values_found.any? { |reference| [value, 'Patient/' + value].include? reference }
+          assert match_found, "patient in Goal/#{resource.id} (#{values_found}) does not match patient requested (#{value})"
 
         when 'target-date'
           values_found = resolve_path(resource, 'target.dueDate')

--- a/lib/modules/uscore_v3.1.0/us_core_goal_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_goal_sequence.rb
@@ -69,16 +69,19 @@ module Inferno
 
         when 'lifecycle-status'
           values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
-          value_found = resolve_element_from_path(resource, 'lifecycleStatus') { |value_in_resource| values.include? value_in_resource }
-          assert value_found.present?, 'lifecycle-status on resource does not match lifecycle-status requested'
+          values_found = resolve_path(resource, 'lifecycleStatus')
+          match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
+          assert match_found.present?, "lifecycle-status in  Goal/#{resource.id} (#{values_found}) does not match lifecycle-status requested (#{values})"
 
         when 'patient'
-          value_found = resolve_element_from_path(resource, 'subject.reference') { |reference| [value, 'Patient/' + value].include? reference }
-          assert value_found.present?, 'patient on resource does not match patient requested'
+          references_found = resolve_path(resource, 'subject.reference')
+          match_found = references_found.any? { |reference| [value, 'Patient/' + value].include? reference }
+          assert match_found, "patient in  Goal/#{resource.id} (#{references_found}) does not match patient requested (#{value})"
 
         when 'target-date'
-          value_found = resolve_element_from_path(resource, 'target.dueDate') { |date| validate_date_search(value, date) }
-          assert value_found.present?, 'target-date on resource does not match target-date requested'
+          values_found = resolve_path(resource, 'target.dueDate')
+          match_found = values_found.any? { |date| validate_date_search(value, date) }
+          assert match_found, "target-date in Goal/#{resource.id} (#{values_found}) does not match target-date requested (#{value})"
 
         end
       end

--- a/lib/modules/uscore_v3.1.0/us_core_immunization_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_immunization_sequence.rb
@@ -68,15 +68,15 @@ module Inferno
         case property
 
         when 'patient'
-          references_found = resolve_path(resource, 'patient.reference')
-          match_found = references_found.any? { |reference| [value, 'Patient/' + value].include? reference }
-          assert match_found, "patient in  Immunization/#{resource.id} (#{references_found}) does not match patient requested (#{value})"
+          values_found = resolve_path(resource, 'patient.reference')
+          match_found = values_found.any? { |reference| [value, 'Patient/' + value].include? reference }
+          assert match_found, "patient in Immunization/#{resource.id} (#{values_found}) does not match patient requested (#{value})"
 
         when 'status'
-          values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           values_found = resolve_path(resource, 'status')
+          values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
-          assert match_found.present?, "status in  Immunization/#{resource.id} (#{values_found}) does not match status requested (#{values})"
+          assert match_found, "status in Immunization/#{resource.id} (#{values_found}) does not match status requested (#{value})"
 
         when 'date'
           values_found = resolve_path(resource, 'occurrence')

--- a/lib/modules/uscore_v3.1.0/us_core_immunization_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_immunization_sequence.rb
@@ -68,17 +68,20 @@ module Inferno
         case property
 
         when 'patient'
-          value_found = resolve_element_from_path(resource, 'patient.reference') { |reference| [value, 'Patient/' + value].include? reference }
-          assert value_found.present?, 'patient on resource does not match patient requested'
+          references_found = resolve_path(resource, 'patient.reference')
+          match_found = references_found.any? { |reference| [value, 'Patient/' + value].include? reference }
+          assert match_found, "patient in  Immunization/#{resource.id} (#{references_found}) does not match patient requested (#{value})"
 
         when 'status'
           values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
-          value_found = resolve_element_from_path(resource, 'status') { |value_in_resource| values.include? value_in_resource }
-          assert value_found.present?, 'status on resource does not match status requested'
+          values_found = resolve_path(resource, 'status')
+          match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
+          assert match_found.present?, "status in  Immunization/#{resource.id} (#{values_found}) does not match status requested (#{values})"
 
         when 'date'
-          value_found = resolve_element_from_path(resource, 'occurrence') { |date| validate_date_search(value, date) }
-          assert value_found.present?, 'date on resource does not match date requested'
+          values_found = resolve_path(resource, 'occurrence')
+          match_found = values_found.any? { |date| validate_date_search(value, date) }
+          assert match_found, "date in Immunization/#{resource.id} (#{values_found}) does not match date requested (#{value})"
 
         end
       end

--- a/lib/modules/uscore_v3.1.0/us_core_implantable_device_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_implantable_device_sequence.rb
@@ -71,13 +71,15 @@ module Inferno
         case property
 
         when 'patient'
-          value_found = resolve_element_from_path(resource, 'patient.reference') { |reference| [value, 'Patient/' + value].include? reference }
-          assert value_found.present?, 'patient on resource does not match patient requested'
+          references_found = resolve_path(resource, 'patient.reference')
+          match_found = references_found.any? { |reference| [value, 'Patient/' + value].include? reference }
+          assert match_found, "patient in  Device/#{resource.id} (#{references_found}) does not match patient requested (#{value})"
 
         when 'type'
           values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
-          value_found = resolve_element_from_path(resource, 'type.coding.code') { |value_in_resource| values.include? value_in_resource }
-          assert value_found.present?, 'type on resource does not match type requested'
+          values_found = resolve_path(resource, 'type.coding.code')
+          match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
+          assert match_found.present?, "type in  Device/#{resource.id} (#{values_found}) does not match type requested (#{values})"
 
         end
       end

--- a/lib/modules/uscore_v3.1.0/us_core_implantable_device_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_implantable_device_sequence.rb
@@ -71,15 +71,15 @@ module Inferno
         case property
 
         when 'patient'
-          references_found = resolve_path(resource, 'patient.reference')
-          match_found = references_found.any? { |reference| [value, 'Patient/' + value].include? reference }
-          assert match_found, "patient in  Device/#{resource.id} (#{references_found}) does not match patient requested (#{value})"
+          values_found = resolve_path(resource, 'patient.reference')
+          match_found = values_found.any? { |reference| [value, 'Patient/' + value].include? reference }
+          assert match_found, "patient in Device/#{resource.id} (#{values_found}) does not match patient requested (#{value})"
 
         when 'type'
-          values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           values_found = resolve_path(resource, 'type.coding.code')
+          values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
-          assert match_found.present?, "type in  Device/#{resource.id} (#{values_found}) does not match type requested (#{values})"
+          assert match_found, "type in Device/#{resource.id} (#{values_found}) does not match type requested (#{value})"
 
         end
       end

--- a/lib/modules/uscore_v3.1.0/us_core_location_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_location_sequence.rb
@@ -56,33 +56,38 @@ module Inferno
 
         when 'name'
           values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
-          value_found = resolve_element_from_path(resource, 'name') { |value_in_resource| values.include? value_in_resource }
-          assert value_found.present?, 'name on resource does not match name requested'
+          values_found = resolve_path(resource, 'name')
+          match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
+          assert match_found.present?, "name in  Location/#{resource.id} (#{values_found}) does not match name requested (#{values})"
 
         when 'address'
-          value_found = resolve_element_from_path(resource, 'address') do |address|
+          values_found = resolve_path(resource, 'address')
+          match_found = values_found.any? do |address|
             address&.text&.start_with?(value) ||
               address&.city&.start_with?(value) ||
               address&.state&.start_with?(value) ||
               address&.postalCode&.start_with?(value) ||
               address&.country&.start_with?(value)
           end
-          assert value_found.present?, 'address on resource does not match address requested'
+          assert match_found, "address in Location/#{resource.id} (#{values_found}) does not match address requested (#{value})"
 
         when 'address-city'
           values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
-          value_found = resolve_element_from_path(resource, 'address.city') { |value_in_resource| values.include? value_in_resource }
-          assert value_found.present?, 'address-city on resource does not match address-city requested'
+          values_found = resolve_path(resource, 'address.city')
+          match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
+          assert match_found.present?, "address-city in  Location/#{resource.id} (#{values_found}) does not match address-city requested (#{values})"
 
         when 'address-state'
           values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
-          value_found = resolve_element_from_path(resource, 'address.state') { |value_in_resource| values.include? value_in_resource }
-          assert value_found.present?, 'address-state on resource does not match address-state requested'
+          values_found = resolve_path(resource, 'address.state')
+          match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
+          assert match_found.present?, "address-state in  Location/#{resource.id} (#{values_found}) does not match address-state requested (#{values})"
 
         when 'address-postalcode'
           values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
-          value_found = resolve_element_from_path(resource, 'address.postalCode') { |value_in_resource| values.include? value_in_resource }
-          assert value_found.present?, 'address-postalcode on resource does not match address-postalcode requested'
+          values_found = resolve_path(resource, 'address.postalCode')
+          match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
+          assert match_found.present?, "address-postalcode in  Location/#{resource.id} (#{values_found}) does not match address-postalcode requested (#{values})"
 
         end
       end

--- a/lib/modules/uscore_v3.1.0/us_core_location_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_location_sequence.rb
@@ -55,10 +55,10 @@ module Inferno
         case property
 
         when 'name'
-          values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           values_found = resolve_path(resource, 'name')
+          values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
-          assert match_found.present?, "name in  Location/#{resource.id} (#{values_found}) does not match name requested (#{values})"
+          assert match_found, "name in Location/#{resource.id} (#{values_found}) does not match name requested (#{value})"
 
         when 'address'
           values_found = resolve_path(resource, 'address')
@@ -72,22 +72,22 @@ module Inferno
           assert match_found, "address in Location/#{resource.id} (#{values_found}) does not match address requested (#{value})"
 
         when 'address-city'
-          values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           values_found = resolve_path(resource, 'address.city')
+          values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
-          assert match_found.present?, "address-city in  Location/#{resource.id} (#{values_found}) does not match address-city requested (#{values})"
+          assert match_found, "address-city in Location/#{resource.id} (#{values_found}) does not match address-city requested (#{value})"
 
         when 'address-state'
-          values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           values_found = resolve_path(resource, 'address.state')
+          values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
-          assert match_found.present?, "address-state in  Location/#{resource.id} (#{values_found}) does not match address-state requested (#{values})"
+          assert match_found, "address-state in Location/#{resource.id} (#{values_found}) does not match address-state requested (#{value})"
 
         when 'address-postalcode'
-          values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           values_found = resolve_path(resource, 'address.postalCode')
+          values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
-          assert match_found.present?, "address-postalcode in  Location/#{resource.id} (#{values_found}) does not match address-postalcode requested (#{values})"
+          assert match_found, "address-postalcode in Location/#{resource.id} (#{values_found}) does not match address-postalcode requested (#{value})"
 
         end
       end

--- a/lib/modules/uscore_v3.1.0/us_core_medicationrequest_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_medicationrequest_sequence.rb
@@ -69,33 +69,33 @@ module Inferno
         case property
 
         when 'status'
-          values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           values_found = resolve_path(resource, 'status')
+          values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
-          assert match_found.present?, "status in  MedicationRequest/#{resource.id} (#{values_found}) does not match status requested (#{values})"
+          assert match_found, "status in MedicationRequest/#{resource.id} (#{values_found}) does not match status requested (#{value})"
 
         when 'intent'
-          values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           values_found = resolve_path(resource, 'intent')
+          values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
-          assert match_found.present?, "intent in  MedicationRequest/#{resource.id} (#{values_found}) does not match intent requested (#{values})"
+          assert match_found, "intent in MedicationRequest/#{resource.id} (#{values_found}) does not match intent requested (#{value})"
 
         when 'patient'
-          references_found = resolve_path(resource, 'subject.reference')
-          match_found = references_found.any? { |reference| [value, 'Patient/' + value].include? reference }
-          assert match_found, "patient in  MedicationRequest/#{resource.id} (#{references_found}) does not match patient requested (#{value})"
+          values_found = resolve_path(resource, 'subject.reference')
+          match_found = values_found.any? { |reference| [value, 'Patient/' + value].include? reference }
+          assert match_found, "patient in MedicationRequest/#{resource.id} (#{values_found}) does not match patient requested (#{value})"
 
         when 'encounter'
-          values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           values_found = resolve_path(resource, 'encounter.reference')
+          values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
-          assert match_found.present?, "encounter in  MedicationRequest/#{resource.id} (#{values_found}) does not match encounter requested (#{values})"
+          assert match_found, "encounter in MedicationRequest/#{resource.id} (#{values_found}) does not match encounter requested (#{value})"
 
         when 'authoredon'
-          values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           values_found = resolve_path(resource, 'authoredOn')
+          values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
-          assert match_found.present?, "authoredon in  MedicationRequest/#{resource.id} (#{values_found}) does not match authoredon requested (#{values})"
+          assert match_found, "authoredon in MedicationRequest/#{resource.id} (#{values_found}) does not match authoredon requested (#{value})"
 
         end
       end

--- a/lib/modules/uscore_v3.1.0/us_core_medicationrequest_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_medicationrequest_sequence.rb
@@ -70,27 +70,32 @@ module Inferno
 
         when 'status'
           values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
-          value_found = resolve_element_from_path(resource, 'status') { |value_in_resource| values.include? value_in_resource }
-          assert value_found.present?, 'status on resource does not match status requested'
+          values_found = resolve_path(resource, 'status')
+          match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
+          assert match_found.present?, "status in  MedicationRequest/#{resource.id} (#{values_found}) does not match status requested (#{values})"
 
         when 'intent'
           values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
-          value_found = resolve_element_from_path(resource, 'intent') { |value_in_resource| values.include? value_in_resource }
-          assert value_found.present?, 'intent on resource does not match intent requested'
+          values_found = resolve_path(resource, 'intent')
+          match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
+          assert match_found.present?, "intent in  MedicationRequest/#{resource.id} (#{values_found}) does not match intent requested (#{values})"
 
         when 'patient'
-          value_found = resolve_element_from_path(resource, 'subject.reference') { |reference| [value, 'Patient/' + value].include? reference }
-          assert value_found.present?, 'patient on resource does not match patient requested'
+          references_found = resolve_path(resource, 'subject.reference')
+          match_found = references_found.any? { |reference| [value, 'Patient/' + value].include? reference }
+          assert match_found, "patient in  MedicationRequest/#{resource.id} (#{references_found}) does not match patient requested (#{value})"
 
         when 'encounter'
           values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
-          value_found = resolve_element_from_path(resource, 'encounter.reference') { |value_in_resource| values.include? value_in_resource }
-          assert value_found.present?, 'encounter on resource does not match encounter requested'
+          values_found = resolve_path(resource, 'encounter.reference')
+          match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
+          assert match_found.present?, "encounter in  MedicationRequest/#{resource.id} (#{values_found}) does not match encounter requested (#{values})"
 
         when 'authoredon'
           values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
-          value_found = resolve_element_from_path(resource, 'authoredOn') { |value_in_resource| values.include? value_in_resource }
-          assert value_found.present?, 'authoredon on resource does not match authoredon requested'
+          values_found = resolve_path(resource, 'authoredOn')
+          match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
+          assert match_found.present?, "authoredon in  MedicationRequest/#{resource.id} (#{values_found}) does not match authoredon requested (#{values})"
 
         end
       end

--- a/lib/modules/uscore_v3.1.0/us_core_observation_lab_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_observation_lab_sequence.rb
@@ -70,22 +70,22 @@ module Inferno
         case property
 
         when 'status'
-          values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           values_found = resolve_path(resource, 'status')
+          values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
-          assert match_found.present?, "status in  Observation/#{resource.id} (#{values_found}) does not match status requested (#{values})"
+          assert match_found, "status in Observation/#{resource.id} (#{values_found}) does not match status requested (#{value})"
 
         when 'category'
-          values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           values_found = resolve_path(resource, 'category.coding.code')
+          values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
-          assert match_found.present?, "category in  Observation/#{resource.id} (#{values_found}) does not match category requested (#{values})"
+          assert match_found, "category in Observation/#{resource.id} (#{values_found}) does not match category requested (#{value})"
 
         when 'code'
-          values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           values_found = resolve_path(resource, 'code.coding.code')
+          values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
-          assert match_found.present?, "code in  Observation/#{resource.id} (#{values_found}) does not match code requested (#{values})"
+          assert match_found, "code in Observation/#{resource.id} (#{values_found}) does not match code requested (#{value})"
 
         when 'date'
           values_found = resolve_path(resource, 'effective')
@@ -93,9 +93,9 @@ module Inferno
           assert match_found, "date in Observation/#{resource.id} (#{values_found}) does not match date requested (#{value})"
 
         when 'patient'
-          references_found = resolve_path(resource, 'subject.reference')
-          match_found = references_found.any? { |reference| [value, 'Patient/' + value].include? reference }
-          assert match_found, "patient in  Observation/#{resource.id} (#{references_found}) does not match patient requested (#{value})"
+          values_found = resolve_path(resource, 'subject.reference')
+          match_found = values_found.any? { |reference| [value, 'Patient/' + value].include? reference }
+          assert match_found, "patient in Observation/#{resource.id} (#{values_found}) does not match patient requested (#{value})"
 
         end
       end

--- a/lib/modules/uscore_v3.1.0/us_core_observation_lab_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_observation_lab_sequence.rb
@@ -71,26 +71,31 @@ module Inferno
 
         when 'status'
           values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
-          value_found = resolve_element_from_path(resource, 'status') { |value_in_resource| values.include? value_in_resource }
-          assert value_found.present?, 'status on resource does not match status requested'
+          values_found = resolve_path(resource, 'status')
+          match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
+          assert match_found.present?, "status in  Observation/#{resource.id} (#{values_found}) does not match status requested (#{values})"
 
         when 'category'
           values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
-          value_found = resolve_element_from_path(resource, 'category.coding.code') { |value_in_resource| values.include? value_in_resource }
-          assert value_found.present?, 'category on resource does not match category requested'
+          values_found = resolve_path(resource, 'category.coding.code')
+          match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
+          assert match_found.present?, "category in  Observation/#{resource.id} (#{values_found}) does not match category requested (#{values})"
 
         when 'code'
           values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
-          value_found = resolve_element_from_path(resource, 'code.coding.code') { |value_in_resource| values.include? value_in_resource }
-          assert value_found.present?, 'code on resource does not match code requested'
+          values_found = resolve_path(resource, 'code.coding.code')
+          match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
+          assert match_found.present?, "code in  Observation/#{resource.id} (#{values_found}) does not match code requested (#{values})"
 
         when 'date'
-          value_found = resolve_element_from_path(resource, 'effective') { |date| validate_date_search(value, date) }
-          assert value_found.present?, 'date on resource does not match date requested'
+          values_found = resolve_path(resource, 'effective')
+          match_found = values_found.any? { |date| validate_date_search(value, date) }
+          assert match_found, "date in Observation/#{resource.id} (#{values_found}) does not match date requested (#{value})"
 
         when 'patient'
-          value_found = resolve_element_from_path(resource, 'subject.reference') { |reference| [value, 'Patient/' + value].include? reference }
-          assert value_found.present?, 'patient on resource does not match patient requested'
+          references_found = resolve_path(resource, 'subject.reference')
+          match_found = references_found.any? { |reference| [value, 'Patient/' + value].include? reference }
+          assert match_found, "patient in  Observation/#{resource.id} (#{references_found}) does not match patient requested (#{value})"
 
         end
       end

--- a/lib/modules/uscore_v3.1.0/us_core_organization_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_organization_sequence.rb
@@ -55,10 +55,10 @@ module Inferno
         case property
 
         when 'name'
-          values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           values_found = resolve_path(resource, 'name')
+          values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
-          assert match_found.present?, "name in  Organization/#{resource.id} (#{values_found}) does not match name requested (#{values})"
+          assert match_found, "name in Organization/#{resource.id} (#{values_found}) does not match name requested (#{value})"
 
         when 'address'
           values_found = resolve_path(resource, 'address')

--- a/lib/modules/uscore_v3.1.0/us_core_organization_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_organization_sequence.rb
@@ -56,18 +56,20 @@ module Inferno
 
         when 'name'
           values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
-          value_found = resolve_element_from_path(resource, 'name') { |value_in_resource| values.include? value_in_resource }
-          assert value_found.present?, 'name on resource does not match name requested'
+          values_found = resolve_path(resource, 'name')
+          match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
+          assert match_found.present?, "name in  Organization/#{resource.id} (#{values_found}) does not match name requested (#{values})"
 
         when 'address'
-          value_found = resolve_element_from_path(resource, 'address') do |address|
+          values_found = resolve_path(resource, 'address')
+          match_found = values_found.any? do |address|
             address&.text&.start_with?(value) ||
               address&.city&.start_with?(value) ||
               address&.state&.start_with?(value) ||
               address&.postalCode&.start_with?(value) ||
               address&.country&.start_with?(value)
           end
-          assert value_found.present?, 'address on resource does not match address requested'
+          assert match_found, "address in Organization/#{resource.id} (#{values_found}) does not match address requested (#{value})"
 
         end
       end

--- a/lib/modules/uscore_v3.1.0/us_core_patient_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_patient_sequence.rb
@@ -73,43 +73,50 @@ module Inferno
 
         when '_id'
           values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
-          value_found = resolve_element_from_path(resource, 'id') { |value_in_resource| values.include? value_in_resource }
-          assert value_found.present?, '_id on resource does not match _id requested'
+          values_found = resolve_path(resource, 'id')
+          match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
+          assert match_found.present?, "_id in  Patient/#{resource.id} (#{values_found}) does not match _id requested (#{values})"
 
         when 'birthdate'
-          value_found = resolve_element_from_path(resource, 'birthDate') { |date| validate_date_search(value, date) }
-          assert value_found.present?, 'birthdate on resource does not match birthdate requested'
+          values_found = resolve_path(resource, 'birthDate')
+          match_found = values_found.any? { |date| validate_date_search(value, date) }
+          assert match_found, "birthdate in Patient/#{resource.id} (#{values_found}) does not match birthdate requested (#{value})"
 
         when 'family'
           values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
-          value_found = resolve_element_from_path(resource, 'name.family') { |value_in_resource| values.include? value_in_resource }
-          assert value_found.present?, 'family on resource does not match family requested'
+          values_found = resolve_path(resource, 'name.family')
+          match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
+          assert match_found.present?, "family in  Patient/#{resource.id} (#{values_found}) does not match family requested (#{values})"
 
         when 'gender'
           values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
-          value_found = resolve_element_from_path(resource, 'gender') { |value_in_resource| values.include? value_in_resource }
-          assert value_found.present?, 'gender on resource does not match gender requested'
+          values_found = resolve_path(resource, 'gender')
+          match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
+          assert match_found.present?, "gender in  Patient/#{resource.id} (#{values_found}) does not match gender requested (#{values})"
 
         when 'given'
           values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
-          value_found = resolve_element_from_path(resource, 'name.given') { |value_in_resource| values.include? value_in_resource }
-          assert value_found.present?, 'given on resource does not match given requested'
+          values_found = resolve_path(resource, 'name.given')
+          match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
+          assert match_found.present?, "given in  Patient/#{resource.id} (#{values_found}) does not match given requested (#{values})"
 
         when 'identifier'
           values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
-          value_found = resolve_element_from_path(resource, 'identifier.value') { |value_in_resource| values.include? value_in_resource }
-          assert value_found.present?, 'identifier on resource does not match identifier requested'
+          values_found = resolve_path(resource, 'identifier.value')
+          match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
+          assert match_found.present?, "identifier in  Patient/#{resource.id} (#{values_found}) does not match identifier requested (#{values})"
 
         when 'name'
-          value = value.downcase
-          value_found = resolve_element_from_path(resource, 'name') do |name|
-            name&.text&.start_with?(value) ||
-              name&.family&.downcase&.include?(value) ||
-              name&.given&.any? { |given| given.downcase.start_with?(value) } ||
-              name&.prefix&.any? { |prefix| prefix.downcase.start_with?(value) } ||
-              name&.suffix&.any? { |suffix| suffix.downcase.start_with?(value) }
+          value_downcase = value.downcase
+          values_found = resolve_path(resource, 'name')
+          match_found = values_found.any? do |name|
+            name&.text&.downcase&.start_with?(value_downcase) ||
+              name&.family&.downcase&.include?(value_downcase) ||
+              name&.given&.any? { |given| given.downcase.start_with?(value_downcase) } ||
+              name&.prefix&.any? { |prefix| prefix.downcase.start_with?(value_downcase) } ||
+              name&.suffix&.any? { |suffix| suffix.downcase.start_with?(value_downcase) }
           end
-          assert value_found.present?, 'name on resource does not match name requested'
+          assert match_found, "name in Patient/#{resource.id} (#{values_found}) does not match name requested (#{value})"
 
         end
       end

--- a/lib/modules/uscore_v3.1.0/us_core_patient_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_patient_sequence.rb
@@ -72,10 +72,10 @@ module Inferno
         case property
 
         when '_id'
-          values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           values_found = resolve_path(resource, 'id')
+          values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
-          assert match_found.present?, "_id in  Patient/#{resource.id} (#{values_found}) does not match _id requested (#{values})"
+          assert match_found, "_id in Patient/#{resource.id} (#{values_found}) does not match _id requested (#{value})"
 
         when 'birthdate'
           values_found = resolve_path(resource, 'birthDate')
@@ -83,32 +83,32 @@ module Inferno
           assert match_found, "birthdate in Patient/#{resource.id} (#{values_found}) does not match birthdate requested (#{value})"
 
         when 'family'
-          values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           values_found = resolve_path(resource, 'name.family')
+          values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
-          assert match_found.present?, "family in  Patient/#{resource.id} (#{values_found}) does not match family requested (#{values})"
+          assert match_found, "family in Patient/#{resource.id} (#{values_found}) does not match family requested (#{value})"
 
         when 'gender'
-          values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           values_found = resolve_path(resource, 'gender')
+          values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
-          assert match_found.present?, "gender in  Patient/#{resource.id} (#{values_found}) does not match gender requested (#{values})"
+          assert match_found, "gender in Patient/#{resource.id} (#{values_found}) does not match gender requested (#{value})"
 
         when 'given'
-          values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           values_found = resolve_path(resource, 'name.given')
+          values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
-          assert match_found.present?, "given in  Patient/#{resource.id} (#{values_found}) does not match given requested (#{values})"
+          assert match_found, "given in Patient/#{resource.id} (#{values_found}) does not match given requested (#{value})"
 
         when 'identifier'
-          values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           values_found = resolve_path(resource, 'identifier.value')
+          values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
-          assert match_found.present?, "identifier in  Patient/#{resource.id} (#{values_found}) does not match identifier requested (#{values})"
+          assert match_found, "identifier in Patient/#{resource.id} (#{values_found}) does not match identifier requested (#{value})"
 
         when 'name'
-          value_downcase = value.downcase
           values_found = resolve_path(resource, 'name')
+          value_downcase = value.downcase
           match_found = values_found.any? do |name|
             name&.text&.downcase&.start_with?(value_downcase) ||
               name&.family&.downcase&.include?(value_downcase) ||

--- a/lib/modules/uscore_v3.1.0/us_core_practitioner_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_practitioner_sequence.rb
@@ -55,20 +55,22 @@ module Inferno
         case property
 
         when 'name'
-          value = value.downcase
-          value_found = resolve_element_from_path(resource, 'name') do |name|
-            name&.text&.start_with?(value) ||
-              name&.family&.downcase&.include?(value) ||
-              name&.given&.any? { |given| given.downcase.start_with?(value) } ||
-              name&.prefix&.any? { |prefix| prefix.downcase.start_with?(value) } ||
-              name&.suffix&.any? { |suffix| suffix.downcase.start_with?(value) }
+          value_downcase = value.downcase
+          values_found = resolve_path(resource, 'name')
+          match_found = values_found.any? do |name|
+            name&.text&.downcase&.start_with?(value_downcase) ||
+              name&.family&.downcase&.include?(value_downcase) ||
+              name&.given&.any? { |given| given.downcase.start_with?(value_downcase) } ||
+              name&.prefix&.any? { |prefix| prefix.downcase.start_with?(value_downcase) } ||
+              name&.suffix&.any? { |suffix| suffix.downcase.start_with?(value_downcase) }
           end
-          assert value_found.present?, 'name on resource does not match name requested'
+          assert match_found, "name in Practitioner/#{resource.id} (#{values_found}) does not match name requested (#{value})"
 
         when 'identifier'
           values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
-          value_found = resolve_element_from_path(resource, 'identifier.value') { |value_in_resource| values.include? value_in_resource }
-          assert value_found.present?, 'identifier on resource does not match identifier requested'
+          values_found = resolve_path(resource, 'identifier.value')
+          match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
+          assert match_found.present?, "identifier in  Practitioner/#{resource.id} (#{values_found}) does not match identifier requested (#{values})"
 
         end
       end

--- a/lib/modules/uscore_v3.1.0/us_core_practitioner_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_practitioner_sequence.rb
@@ -55,8 +55,8 @@ module Inferno
         case property
 
         when 'name'
-          value_downcase = value.downcase
           values_found = resolve_path(resource, 'name')
+          value_downcase = value.downcase
           match_found = values_found.any? do |name|
             name&.text&.downcase&.start_with?(value_downcase) ||
               name&.family&.downcase&.include?(value_downcase) ||
@@ -67,10 +67,10 @@ module Inferno
           assert match_found, "name in Practitioner/#{resource.id} (#{values_found}) does not match name requested (#{value})"
 
         when 'identifier'
-          values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           values_found = resolve_path(resource, 'identifier.value')
+          values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
-          assert match_found.present?, "identifier in  Practitioner/#{resource.id} (#{values_found}) does not match identifier requested (#{values})"
+          assert match_found, "identifier in Practitioner/#{resource.id} (#{values_found}) does not match identifier requested (#{value})"
 
         end
       end

--- a/lib/modules/uscore_v3.1.0/us_core_practitionerrole_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_practitionerrole_sequence.rb
@@ -56,13 +56,15 @@ module Inferno
 
         when 'specialty'
           values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
-          value_found = resolve_element_from_path(resource, 'specialty.coding.code') { |value_in_resource| values.include? value_in_resource }
-          assert value_found.present?, 'specialty on resource does not match specialty requested'
+          values_found = resolve_path(resource, 'specialty.coding.code')
+          match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
+          assert match_found.present?, "specialty in  PractitionerRole/#{resource.id} (#{values_found}) does not match specialty requested (#{values})"
 
         when 'practitioner'
           values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
-          value_found = resolve_element_from_path(resource, 'practitioner.reference') { |value_in_resource| values.include? value_in_resource }
-          assert value_found.present?, 'practitioner on resource does not match practitioner requested'
+          values_found = resolve_path(resource, 'practitioner.reference')
+          match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
+          assert match_found.present?, "practitioner in  PractitionerRole/#{resource.id} (#{values_found}) does not match practitioner requested (#{values})"
 
         end
       end

--- a/lib/modules/uscore_v3.1.0/us_core_practitionerrole_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_practitionerrole_sequence.rb
@@ -55,16 +55,16 @@ module Inferno
         case property
 
         when 'specialty'
-          values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           values_found = resolve_path(resource, 'specialty.coding.code')
+          values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
-          assert match_found.present?, "specialty in  PractitionerRole/#{resource.id} (#{values_found}) does not match specialty requested (#{values})"
+          assert match_found, "specialty in PractitionerRole/#{resource.id} (#{values_found}) does not match specialty requested (#{value})"
 
         when 'practitioner'
-          values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           values_found = resolve_path(resource, 'practitioner.reference')
+          values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
-          assert match_found.present?, "practitioner in  PractitionerRole/#{resource.id} (#{values_found}) does not match practitioner requested (#{values})"
+          assert match_found, "practitioner in PractitionerRole/#{resource.id} (#{values_found}) does not match practitioner requested (#{value})"
 
         end
       end

--- a/lib/modules/uscore_v3.1.0/us_core_procedure_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_procedure_sequence.rb
@@ -70,21 +70,25 @@ module Inferno
 
         when 'status'
           values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
-          value_found = resolve_element_from_path(resource, 'status') { |value_in_resource| values.include? value_in_resource }
-          assert value_found.present?, 'status on resource does not match status requested'
+          values_found = resolve_path(resource, 'status')
+          match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
+          assert match_found.present?, "status in  Procedure/#{resource.id} (#{values_found}) does not match status requested (#{values})"
 
         when 'patient'
-          value_found = resolve_element_from_path(resource, 'subject.reference') { |reference| [value, 'Patient/' + value].include? reference }
-          assert value_found.present?, 'patient on resource does not match patient requested'
+          references_found = resolve_path(resource, 'subject.reference')
+          match_found = references_found.any? { |reference| [value, 'Patient/' + value].include? reference }
+          assert match_found, "patient in  Procedure/#{resource.id} (#{references_found}) does not match patient requested (#{value})"
 
         when 'date'
-          value_found = resolve_element_from_path(resource, 'performed') { |date| validate_date_search(value, date) }
-          assert value_found.present?, 'date on resource does not match date requested'
+          values_found = resolve_path(resource, 'performed')
+          match_found = values_found.any? { |date| validate_date_search(value, date) }
+          assert match_found, "date in Procedure/#{resource.id} (#{values_found}) does not match date requested (#{value})"
 
         when 'code'
           values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
-          value_found = resolve_element_from_path(resource, 'code.coding.code') { |value_in_resource| values.include? value_in_resource }
-          assert value_found.present?, 'code on resource does not match code requested'
+          values_found = resolve_path(resource, 'code.coding.code')
+          match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
+          assert match_found.present?, "code in  Procedure/#{resource.id} (#{values_found}) does not match code requested (#{values})"
 
         end
       end

--- a/lib/modules/uscore_v3.1.0/us_core_procedure_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_procedure_sequence.rb
@@ -69,15 +69,15 @@ module Inferno
         case property
 
         when 'status'
-          values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           values_found = resolve_path(resource, 'status')
+          values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
-          assert match_found.present?, "status in  Procedure/#{resource.id} (#{values_found}) does not match status requested (#{values})"
+          assert match_found, "status in Procedure/#{resource.id} (#{values_found}) does not match status requested (#{value})"
 
         when 'patient'
-          references_found = resolve_path(resource, 'subject.reference')
-          match_found = references_found.any? { |reference| [value, 'Patient/' + value].include? reference }
-          assert match_found, "patient in  Procedure/#{resource.id} (#{references_found}) does not match patient requested (#{value})"
+          values_found = resolve_path(resource, 'subject.reference')
+          match_found = values_found.any? { |reference| [value, 'Patient/' + value].include? reference }
+          assert match_found, "patient in Procedure/#{resource.id} (#{values_found}) does not match patient requested (#{value})"
 
         when 'date'
           values_found = resolve_path(resource, 'performed')
@@ -85,10 +85,10 @@ module Inferno
           assert match_found, "date in Procedure/#{resource.id} (#{values_found}) does not match date requested (#{value})"
 
         when 'code'
-          values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           values_found = resolve_path(resource, 'code.coding.code')
+          values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
-          assert match_found.present?, "code in  Procedure/#{resource.id} (#{values_found}) does not match code requested (#{values})"
+          assert match_found, "code in Procedure/#{resource.id} (#{values_found}) does not match code requested (#{value})"
 
         end
       end

--- a/lib/modules/uscore_v3.1.0/us_core_pulse_oximetry_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_pulse_oximetry_sequence.rb
@@ -70,22 +70,22 @@ module Inferno
         case property
 
         when 'status'
-          values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           values_found = resolve_path(resource, 'status')
+          values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
-          assert match_found.present?, "status in  Observation/#{resource.id} (#{values_found}) does not match status requested (#{values})"
+          assert match_found, "status in Observation/#{resource.id} (#{values_found}) does not match status requested (#{value})"
 
         when 'category'
-          values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           values_found = resolve_path(resource, 'category.coding.code')
+          values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
-          assert match_found.present?, "category in  Observation/#{resource.id} (#{values_found}) does not match category requested (#{values})"
+          assert match_found, "category in Observation/#{resource.id} (#{values_found}) does not match category requested (#{value})"
 
         when 'code'
-          values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           values_found = resolve_path(resource, 'code.coding.code')
+          values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
-          assert match_found.present?, "code in  Observation/#{resource.id} (#{values_found}) does not match code requested (#{values})"
+          assert match_found, "code in Observation/#{resource.id} (#{values_found}) does not match code requested (#{value})"
 
         when 'date'
           values_found = resolve_path(resource, 'effective')
@@ -93,9 +93,9 @@ module Inferno
           assert match_found, "date in Observation/#{resource.id} (#{values_found}) does not match date requested (#{value})"
 
         when 'patient'
-          references_found = resolve_path(resource, 'subject.reference')
-          match_found = references_found.any? { |reference| [value, 'Patient/' + value].include? reference }
-          assert match_found, "patient in  Observation/#{resource.id} (#{references_found}) does not match patient requested (#{value})"
+          values_found = resolve_path(resource, 'subject.reference')
+          match_found = values_found.any? { |reference| [value, 'Patient/' + value].include? reference }
+          assert match_found, "patient in Observation/#{resource.id} (#{values_found}) does not match patient requested (#{value})"
 
         end
       end

--- a/lib/modules/uscore_v3.1.0/us_core_pulse_oximetry_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_pulse_oximetry_sequence.rb
@@ -71,26 +71,31 @@ module Inferno
 
         when 'status'
           values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
-          value_found = resolve_element_from_path(resource, 'status') { |value_in_resource| values.include? value_in_resource }
-          assert value_found.present?, 'status on resource does not match status requested'
+          values_found = resolve_path(resource, 'status')
+          match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
+          assert match_found.present?, "status in  Observation/#{resource.id} (#{values_found}) does not match status requested (#{values})"
 
         when 'category'
           values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
-          value_found = resolve_element_from_path(resource, 'category.coding.code') { |value_in_resource| values.include? value_in_resource }
-          assert value_found.present?, 'category on resource does not match category requested'
+          values_found = resolve_path(resource, 'category.coding.code')
+          match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
+          assert match_found.present?, "category in  Observation/#{resource.id} (#{values_found}) does not match category requested (#{values})"
 
         when 'code'
           values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
-          value_found = resolve_element_from_path(resource, 'code.coding.code') { |value_in_resource| values.include? value_in_resource }
-          assert value_found.present?, 'code on resource does not match code requested'
+          values_found = resolve_path(resource, 'code.coding.code')
+          match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
+          assert match_found.present?, "code in  Observation/#{resource.id} (#{values_found}) does not match code requested (#{values})"
 
         when 'date'
-          value_found = resolve_element_from_path(resource, 'effective') { |date| validate_date_search(value, date) }
-          assert value_found.present?, 'date on resource does not match date requested'
+          values_found = resolve_path(resource, 'effective')
+          match_found = values_found.any? { |date| validate_date_search(value, date) }
+          assert match_found, "date in Observation/#{resource.id} (#{values_found}) does not match date requested (#{value})"
 
         when 'patient'
-          value_found = resolve_element_from_path(resource, 'subject.reference') { |reference| [value, 'Patient/' + value].include? reference }
-          assert value_found.present?, 'patient on resource does not match patient requested'
+          references_found = resolve_path(resource, 'subject.reference')
+          match_found = references_found.any? { |reference| [value, 'Patient/' + value].include? reference }
+          assert match_found, "patient in  Observation/#{resource.id} (#{references_found}) does not match patient requested (#{value})"
 
         end
       end

--- a/lib/modules/uscore_v3.1.0/us_core_smokingstatus_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_smokingstatus_sequence.rb
@@ -70,22 +70,22 @@ module Inferno
         case property
 
         when 'status'
-          values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           values_found = resolve_path(resource, 'status')
+          values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
-          assert match_found.present?, "status in  Observation/#{resource.id} (#{values_found}) does not match status requested (#{values})"
+          assert match_found, "status in Observation/#{resource.id} (#{values_found}) does not match status requested (#{value})"
 
         when 'category'
-          values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           values_found = resolve_path(resource, 'category.coding.code')
+          values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
-          assert match_found.present?, "category in  Observation/#{resource.id} (#{values_found}) does not match category requested (#{values})"
+          assert match_found, "category in Observation/#{resource.id} (#{values_found}) does not match category requested (#{value})"
 
         when 'code'
-          values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           values_found = resolve_path(resource, 'code.coding.code')
+          values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
           match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
-          assert match_found.present?, "code in  Observation/#{resource.id} (#{values_found}) does not match code requested (#{values})"
+          assert match_found, "code in Observation/#{resource.id} (#{values_found}) does not match code requested (#{value})"
 
         when 'date'
           values_found = resolve_path(resource, 'effective')
@@ -93,9 +93,9 @@ module Inferno
           assert match_found, "date in Observation/#{resource.id} (#{values_found}) does not match date requested (#{value})"
 
         when 'patient'
-          references_found = resolve_path(resource, 'subject.reference')
-          match_found = references_found.any? { |reference| [value, 'Patient/' + value].include? reference }
-          assert match_found, "patient in  Observation/#{resource.id} (#{references_found}) does not match patient requested (#{value})"
+          values_found = resolve_path(resource, 'subject.reference')
+          match_found = values_found.any? { |reference| [value, 'Patient/' + value].include? reference }
+          assert match_found, "patient in Observation/#{resource.id} (#{values_found}) does not match patient requested (#{value})"
 
         end
       end

--- a/lib/modules/uscore_v3.1.0/us_core_smokingstatus_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_smokingstatus_sequence.rb
@@ -71,26 +71,31 @@ module Inferno
 
         when 'status'
           values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
-          value_found = resolve_element_from_path(resource, 'status') { |value_in_resource| values.include? value_in_resource }
-          assert value_found.present?, 'status on resource does not match status requested'
+          values_found = resolve_path(resource, 'status')
+          match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
+          assert match_found.present?, "status in  Observation/#{resource.id} (#{values_found}) does not match status requested (#{values})"
 
         when 'category'
           values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
-          value_found = resolve_element_from_path(resource, 'category.coding.code') { |value_in_resource| values.include? value_in_resource }
-          assert value_found.present?, 'category on resource does not match category requested'
+          values_found = resolve_path(resource, 'category.coding.code')
+          match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
+          assert match_found.present?, "category in  Observation/#{resource.id} (#{values_found}) does not match category requested (#{values})"
 
         when 'code'
           values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
-          value_found = resolve_element_from_path(resource, 'code.coding.code') { |value_in_resource| values.include? value_in_resource }
-          assert value_found.present?, 'code on resource does not match code requested'
+          values_found = resolve_path(resource, 'code.coding.code')
+          match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
+          assert match_found.present?, "code in  Observation/#{resource.id} (#{values_found}) does not match code requested (#{values})"
 
         when 'date'
-          value_found = resolve_element_from_path(resource, 'effective') { |date| validate_date_search(value, date) }
-          assert value_found.present?, 'date on resource does not match date requested'
+          values_found = resolve_path(resource, 'effective')
+          match_found = values_found.any? { |date| validate_date_search(value, date) }
+          assert match_found, "date in Observation/#{resource.id} (#{values_found}) does not match date requested (#{value})"
 
         when 'patient'
-          value_found = resolve_element_from_path(resource, 'subject.reference') { |reference| [value, 'Patient/' + value].include? reference }
-          assert value_found.present?, 'patient on resource does not match patient requested'
+          references_found = resolve_path(resource, 'subject.reference')
+          match_found = references_found.any? { |reference| [value, 'Patient/' + value].include? reference }
+          assert match_found, "patient in  Observation/#{resource.id} (#{references_found}) does not match patient requested (#{value})"
 
         end
       end

--- a/test/unit/sequence_base_test.rb
+++ b/test/unit/sequence_base_test.rb
@@ -51,11 +51,13 @@ class SequenceBaseTest < MiniTest::Test
         'patient': '1234',
         'clinical-status': 'inactive'
       }
-      assert_raises(Inferno::AssertionException) do
+      error = assert_raises(Inferno::AssertionException) do
         search_params.each do |key, value|
           @sequence.validate_resource_item(@allergy_intolerance_resource, key.to_s, value)
         end
       end
+      expected_error_msg = 'clinical-status in  AllergyIntolerance/SMART-AllergyIntolerance-28 (["active"]) does not match clinical-status requested (["inactive"])'
+      assert error.message == expected_error_msg, "expected: #{expected_error_msg}, actual: #{error.message}"
     end
   end
 

--- a/test/unit/sequence_base_test.rb
+++ b/test/unit/sequence_base_test.rb
@@ -56,7 +56,7 @@ class SequenceBaseTest < MiniTest::Test
           @sequence.validate_resource_item(@allergy_intolerance_resource, key.to_s, value)
         end
       end
-      expected_error_msg = 'clinical-status in  AllergyIntolerance/SMART-AllergyIntolerance-28 (["active"]) does not match clinical-status requested (["inactive"])'
+      expected_error_msg = 'clinical-status in AllergyIntolerance/SMART-AllergyIntolerance-28 (["active"]) does not match clinical-status requested (inactive)'
       assert error.message == expected_error_msg, "expected: #{expected_error_msg}, actual: #{error.message}"
     end
   end

--- a/test/unit/sequence_base_test.rb
+++ b/test/unit/sequence_base_test.rb
@@ -27,6 +27,38 @@ class SequenceBaseTest < MiniTest::Test
     @sequence = Inferno::Sequence::SequenceBase.new(@instance, client, true)
   end
 
+  describe '#validate_reply_entries' do
+    before do
+      @instance = Inferno::Models::TestingInstance.create
+      client = FHIR::Client.new('')
+      @sequence = Inferno::Sequence::USCore310AllergyintoleranceSequence.new(@instance, client, true)
+      allergy_intolerance_bundle = FHIR.from_contents(load_fixture(:us_core_r4_allergy_intolerance))
+      @allergy_intolerance_resource = allergy_intolerance_bundle.entry.first.resource
+    end
+
+    it 'passes if results match search params' do
+      search_params = {
+        'patient': '1234',
+        'clinical-status': 'active'
+      }
+      search_params.each do |key, value|
+        @sequence.validate_resource_item(@allergy_intolerance_resource, key.to_s, value)
+      end
+    end
+
+    it 'fails when results do not match search params' do
+      search_params = {
+        'patient': '1234',
+        'clinical-status': 'inactive'
+      }
+      assert_raises(Inferno::AssertionException) do
+        search_params.each do |key, value|
+          @sequence.validate_resource_item(@allergy_intolerance_resource, key.to_s, value)
+        end
+      end
+    end
+  end
+
   describe '#save_delayed_sequence_references' do
     before do
       @instance = Inferno::Models::TestingInstance.create(selected_module: 'uscore_v3.0.0')


### PR DESCRIPTION
This PR makes the error messages better when parameters don't match. Now it's in the format of:
clinical-status in  AllergyIntolerance/SMART-AllergyIntolerance-28 (["active"]) does not match clinical-status requested (["inactive"])

**Submitter:**
- [X] This pull request describes why these changes were made
- [X] Internal ticket for this PR: https://oncprojectracking.healthit.gov/support/browse/FI-749
- [X] Internal ticket links to this PR
- [X] Internal ticket is properly labeled (Community/Program)
- [X] Internal ticket has a justification for its Community/Program label
- [X] Code diff has been reviewed for extraneous/missing code
- [X] Tests are included and test edge cases
- [X] Tests/code quality metrics have been run locally and pass


**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
