### PR TITLE
fi-658 expand skipped tests by default

### DIFF
--- a/lib/app/endpoint/test_set_endpoints.rb
+++ b/lib/app/endpoint/test_set_endpoints.rb
@@ -142,7 +142,7 @@ module Inferno
 
             test_group = nil
             test_group = test_set.test_case_by_id(submitted_test_cases.first).test_group
-            failed_test_cases = []
+            expanded_test_cases = []
             all_test_cases = []
 
             timer_count = 0
@@ -199,7 +199,7 @@ module Inferno
                 sequence_result.next_test_cases = ([next_test_case] + submitted_test_cases).join(',')
 
                 all_test_cases << test_case.id
-                failed_test_cases << test_case.id if sequence_result.fail?
+                expanded_test_cases << test_case.id if sequence_result.fail? || sequence_result.skip?
 
                 sequence_result.save!
                 if sequence_result.redirect_to_url
@@ -216,7 +216,7 @@ module Inferno
                 end
               end
 
-              query_target = failed_test_cases.join(',')
+              query_target = expanded_test_cases.join(',')
               query_target = all_test_cases.join(',') if all_test_cases.length == 1
 
               query_target = "#{test_group.id}/#{query_target}" unless test_group.nil?

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -347,10 +347,10 @@ $(function(){
 
     if(testCasePart.length > 0){
       testCasePart.split(',').forEach(function(tc){
-        var testCase = $('#' + tc);
+        var testCase = $('[data-test-case='+tc+']');
         var details = $('#' + tc + '-details');
         details.collapse('show')
-        testCase.parents('.sequence-row').find('.sequence-expand-button').text("Hide Details")
+        testCase.find('.sequence-expand-button').text('Hide Details')
       })
     }
   }


### PR DESCRIPTION
This makes it so that skipped tests are expanded when the test results are done. It also fixes the "show details" text to be "hide details" for the expanded test cases.

**Submitter:**
- [X] This pull request describes why these changes were made
- [X] Internal ticket for this PR: https://oncprojectracking.healthit.gov/support/browse/FI-658
- [X] Internal ticket links to this PR
- [X] Internal ticket is properly labeled (Community/Program)
- [X] Internal ticket has a justification for its Community/Program label
- [X] Code diff has been reviewed for extraneous/missing code
- NA Tests are included and test edge cases
- [X] Tests/code quality metrics have been run locally and pass


**Reviewer 1:**

Name:
- [x] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
