### PR TITLE
FI-736 Remove "Manual Key Registration" Section

### DIFF
--- a/lib/app/views/onc_program.erb
+++ b/lib/app/views/onc_program.erb
@@ -584,12 +584,11 @@
              <div class="prerequisite-group-box">
 
              <%= erb(:prerequisite_field,{},{prerequisite: :bulk_jwks_url_auth,
-                    label: 'JWK Set URL (recommended)',
+                    label: 'JWK Set URL',
                     instance: instance,
                     description: %(
                       Register Inferno using this JWK Set URL to communicate keys if supported by the server.  Note that the
-                      server must be able to resolve the URL in order for this to function properly.  If the server does not
-                      support this method you may register Inferno using the JWK Set directly instead.
+                      server must be able to resolve the URL in order for this to function properly.
                     ),
                     value: instance.bulk_jwks_url_auth || "#{instance.base_url}#{base_path}/.well-known/jwks.json",
                     readonly: true

--- a/lib/app/views/onc_program.erb
+++ b/lib/app/views/onc_program.erb
@@ -593,18 +593,7 @@
                     ),
                     value: instance.bulk_jwks_url_auth || "#{instance.base_url}#{base_path}/.well-known/jwks.json",
                     readonly: true
-                    })%>
-
-              <div class="form-group">
-                    
-              <label for="bulk_jwks_manual_keys">Manual Key Registration
-                <small>If the server does not support registering URLs to provide JWK Sets, you may register Inferno as a client using the following RS384 and ES384 keys.</small>
-              </label>
-
-             <textarea readonly="readonly" class="form-control" id="bulk_jwks_manual_keys" rows=4 style="overflow: hidden">
-                <%= instance.bulk_public_key_set %></textarea>
-             </div>
-             
+                    })%>             
              </div>
           </div>
           <div class="show-uris" style="display:none">


### PR DESCRIPTION
ONC program requires bulk data client register with JWK Sets URL specified in SMART Backend Services: Authorization Guide Section 5 (http://hl7.org/fhir/uv/bulkdata/authorization/index.html#registering-a-smart-backend-service-communicating-public-keys). To avoid confusion, the "Manual Key Registration" section from Multi-Patient Query test preparation dialog is removed.

**Submitter:**
- [x] This pull request describes why these changes were made
- [x] Internal ticket for this PR: FI-736
- [x] Internal ticket links to this PR
- [x] Internal ticket is properly labeled (Community/Program)
- [x] Internal ticket has a justification for its Community/Program label
- [x] Code diff has been reviewed for extraneous/missing code
- [x] Tests are included and test edge cases
- [x] Tests/code quality metrics have been run locally and pass


**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
