### PR TITLE
FI-768 Validate all resources even some is invalid

### DIFF
--- a/lib/app/models/request_response.rb
+++ b/lib/app/models/request_response.rb
@@ -23,7 +23,8 @@ module Inferno
         request = req.request
         response = req.response
 
-        unescape_unicode(response[:body])
+        escaped_body = response[:body].dup # In case body is frozen from string literal
+        unescape_unicode(escaped_body)
 
         new(
           direction: direction || req&.direction,
@@ -33,7 +34,7 @@ module Inferno
           request_payload: request[:payload],
           response_code: response[:code],
           response_headers: response[:headers].to_json,
-          response_body: response[:body],
+          response_body: escaped_body,
           instance_id: instance_id,
           timestamp: response[:timestamp]
         )

--- a/lib/app/views/onc_program.erb
+++ b/lib/app/views/onc_program.erb
@@ -553,7 +553,7 @@
               label: 'Limit validation to a maximum resource count',
               description: %(
                 While testing we need to validate resources in downloaded NDJSON file.
-                Please enter a integer to limit the number of resources validated per resource type.                 
+                Please enter an integer to limit the number of resources validated per resource type.                 
                 To validate all resources, leave this blank.
               ),              
               value: instance.bulk_lines_to_validate}); %>

--- a/lib/app/views/onc_program.erb
+++ b/lib/app/views/onc_program.erb
@@ -553,7 +553,7 @@
               label: 'Limit validation to a maximum resource count',
               description: %(
                 While testing we need to validate resources in downloaded NDJSON file.
-                Please enter a number to limit the number of resources validated per resource type.                 
+                Please enter a integer to limit the number of resources validated per resource type.                 
                 To validate all resources, leave this blank.
               ),              
               value: instance.bulk_lines_to_validate}); %>

--- a/lib/app/views/onc_program.erb
+++ b/lib/app/views/onc_program.erb
@@ -553,8 +553,7 @@
               label: 'Limit validation to a maximum resource count',
               description: %(
                 While testing we need to validate resources in downloaded NDJSON file.
-                Please enter a number to limit the number of resoruces validated per resource type.                 
-                To skip resource validation, enter 0.
+                Please enter a number to limit the number of resources validated per resource type.                 
                 To validate all resources, leave this blank.
               ),              
               value: instance.bulk_lines_to_validate}); %>

--- a/lib/app/views/onc_program.erb
+++ b/lib/app/views/onc_program.erb
@@ -553,9 +553,9 @@
               label: 'Limit validation to a maximum resource count',
               description: %(
                 While testing we need to validate resources in downloaded NDJSON file.
-                Please enter the number of lines/resources that would be validated for each NDJSON file. 
+                Please enter a number to limit the number of resoruces validated per resource type.                 
                 To skip resource validation, enter 0.
-                To validate all resources, enter *.
+                To validate all resources, leave this blank.
               ),              
               value: instance.bulk_lines_to_validate}); %>
 

--- a/lib/modules/onc_program/bulk_data_export_sequence.rb
+++ b/lib/modules/onc_program/bulk_data_export_sequence.rb
@@ -120,6 +120,7 @@ module Inferno
       def assert_requires_access_token(status_response = @status_response)
         omit 'Require Access Token Test has been disabled by configuration.' if @instance.disable_bulk_data_require_access_token_test
 
+        assert status_response.present?, 'Bulk Data server response is empty'
         requires_access_token = status_response['requiresAccessToken']
         assert requires_access_token.present? && requires_access_token.to_s.downcase == 'true', 'Bulk Data file server access SHALL require access token.'
       end

--- a/lib/modules/onc_program/bulk_data_group_validation_sequence.rb
+++ b/lib/modules/onc_program/bulk_data_group_validation_sequence.rb
@@ -146,10 +146,12 @@ module Inferno
           validation_error_collection[line_count] = resource_validation_errors unless resource_validation_errors.empty?
         end
 
-        response_for_log[:body] = line_collection.join
-        LoggedRestClient.record_response(request_for_log, response_for_log)
+        unless validate_all
+          response_for_log[:body] = line_collection.join
+          LoggedRestClient.record_response(request_for_log, response_for_log)
+        end
 
-        prorcess_validation_errors(validation_error_collection, line_count, klass)
+        process_validation_errors(validation_error_collection, line_count, klass)
 
         assert_must_supports_found(must_supports) if validate_all || lines_to_validate.positive?
 
@@ -162,7 +164,7 @@ module Inferno
         line_count
       end
 
-      def prorcess_validation_errors(validation_error_collection, line_count, klass)
+      def process_validation_errors(validation_error_collection, line_count, klass)
         error_count = 0
         first_error = ''
         validation_error_collection.each do |line_number, resource_validation_errors|

--- a/lib/modules/onc_program/bulk_data_group_validation_sequence.rb
+++ b/lib/modules/onc_program/bulk_data_group_validation_sequence.rb
@@ -177,7 +177,7 @@ module Inferno
           @information_messages.concat(resource_validation_errors[:information].map { |e| "Line ##{line_number}: #{e}" })
         end
 
-        assert error_count.zero?, "#{error_count} / #{line_count} #{klass} resources failed profile validation. #{first_error}}"
+        assert error_count.zero?, "#{error_count} / #{line_count} #{klass} resources failed profile validation. #{first_error}"
       end
 
       def assert_must_supports_found(must_supports)

--- a/lib/modules/onc_program/test/bulk_group_validation_sequence_test.rb
+++ b/lib/modules/onc_program/test/bulk_group_validation_sequence_test.rb
@@ -237,20 +237,18 @@ describe Inferno::Sequence::BulkDataGroupExportValidationSequence do
       assert result[:lines_to_validate].zero?
     end
 
-    it 'get 0 when input is empty' do
+    it 'get validate_all when input is empty' do
       result = @sequence.get_lines_to_validate('')
-      assert !result[:validate_all]
-      assert result[:lines_to_validate].zero?
+      assert result[:validate_all]
     end
 
-    it 'get 0 when input is nil' do
+    it 'get validate_all when input is nil' do
       result = @sequence.get_lines_to_validate(nil)
-      assert !result[:validate_all]
-      assert result[:lines_to_validate].zero?
+      assert result[:validate_all]
     end
 
-    it 'get validate_all when input is *' do
-      result = @sequence.get_lines_to_validate('*')
+    it 'get validate_all when input is blank' do
+      result = @sequence.get_lines_to_validate('  ')
       assert result[:validate_all]
     end
   end

--- a/lib/modules/onc_program/test/bulk_group_validation_sequence_test.rb
+++ b/lib/modules/onc_program/test/bulk_group_validation_sequence_test.rb
@@ -426,7 +426,8 @@ describe Inferno::Sequence::BulkDataGroupExportValidationSequence do
       assert_match(/invalid code '001'/, error.message)
     end
 
-    it 'succeeds when validate first line in output file having invalid resource' do
+    it 'succeeds when validate only first two lines in output file' do
+      # this male patient is on the 3rd place
       invalid_patient_export = @patient_export.sub('"male"', '"001"')
       stub_request(:get, 'https://www.example.com/wrong_patient_export.json')
         .with(headers: @file_request_headers)
@@ -438,7 +439,7 @@ describe Inferno::Sequence::BulkDataGroupExportValidationSequence do
 
       file = @output.find { |line| line['type'] == 'Patient' }
       file['url'] = 'https://www.example.com/wrong_patient_export.json'
-      @sequence.check_file_request(file, 'Patient', false, 1, [])
+      @sequence.check_file_request(file, 'Patient', false, 2, [])
     end
 
     it 'succeeds when NDJSON is valid and has at least two patients' do
@@ -463,6 +464,46 @@ describe Inferno::Sequence::BulkDataGroupExportValidationSequence do
       file['url'] = 'https://www.example.com/single_patient_export.json'
       @sequence.check_file_request(file, 'Patient', false, 0, [])
       assert !@sequence.has_min_patient_count
+    end
+
+    it 'tests two patients when one of patient is invalid' do
+      # the first two patients are female
+      invalid_patient_export = @patient_export.sub('"female"', '"001"')
+      stub_request(:get, 'https://www.example.com/wrong_patient_export.json')
+        .with(headers: @file_request_headers)
+        .to_return(
+          status: 200,
+          headers: { content_type: 'application/fhir+ndjson' },
+          body: invalid_patient_export
+        )
+
+      error = assert_raises(Inferno::AssertionException) do
+        file = @output.find { |line| line['type'] == 'Patient' }
+        file['url'] = 'https://www.example.com/wrong_patient_export.json'
+        @sequence.check_file_request(file, 'Patient', false, 1, [])
+      end
+
+      assert_match(%r{^1 / 2}, error.message)
+    end
+
+    it 'tests at least two patients when two patients are invalid' do
+      # the first two patients are female
+      invalid_patient_export = @patient_export.gsub('"female"', '"001"')
+      stub_request(:get, 'https://www.example.com/wrong_patient_export.json')
+        .with(headers: @file_request_headers)
+        .to_return(
+          status: 200,
+          headers: { content_type: 'application/fhir+ndjson' },
+          body: invalid_patient_export
+        )
+
+      error = assert_raises(Inferno::AssertionException) do
+        file = @output.find { |line| line['type'] == 'Patient' }
+        file['url'] = 'https://www.example.com/wrong_patient_export.json'
+        @sequence.check_file_request(file, 'Patient', false, 1, [])
+      end
+
+      assert_match(%r{^2 / 2}, error.message)
     end
 
     it 'warns when count does not match number of resources' do


### PR DESCRIPTION
If one resource is invalid, instead of raising AssertionException, saving errors in an array and continue to the next resources. So the validation does not stop at the first invalid resource.
Also add logic to collect resources for response logging.
Add two more unit tests

**Submitter:**
- [x] This pull request describes why these changes were made
- [x] Internal ticket for this PR: FI-768
- [x] Internal ticket links to this PR
- [x] Internal ticket is properly labeled (Community/Program)
- [x] Internal ticket has a justification for its Community/Program label
- [x] Code diff has been reviewed for extraneous/missing code
- [x] Tests are included and test edge cases
- [x] Tests/code quality metrics have been run locally and pass


**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
