### PR TITLE
FI-776: fix set_params in development

### DIFF
--- a/lib/modules/onc_program/bulk_data_group_validation_sequence.rb
+++ b/lib/modules/onc_program/bulk_data_group_validation_sequence.rb
@@ -161,7 +161,7 @@ module Inferno
       def streamed_ndjson_get(url, headers)
         ctx = OpenSSL::SSL::SSLContext.new
         ctx.verify_mode = OpenSSL::SSL::VERIFY_PEER # set globally to VERIFY_NONE if disable_verify_peer set
-        ctx.set_params
+        ctx.set_params unless OpenSSL::SSL::VERIFY_PEER == OpenSSL::SSL::VERIFY_NONE
         response = HTTP.headers(headers).get(url, ssl_context: ctx)
 
         # We need to log the request, but don't know what will be in the body


### PR DESCRIPTION
`OpenSSL::SSL::Context#set_params` apparently was setting params even when SSL verification was turned off. This is not the correct behavior, so this PR adds a conditional to check that the `VERIFY_PEER` and `VERIFY_NONE` constants are not the same (an indicator that SSL verification has been turned off).

To test:
* Ensure that SSL verification is turned off in `config.yml` (set `disable_verify_peer` to `true`), and restart Inferno
* Run the Multi-patient query sequence, and ensure that all the tests complete (aka, don't throw a `self-signed certificate in cert chain` error)
* Turn SSL verification back on (set `disable_verify_peer` to `false`), and restart Inferno
* Run the same sequence, and ensure that the majority of the tests fail (aka, _do_ throw `self-signed certificate in cert chain` errors)

Pull requests into Inferno require the following items to be completed. Submitter and reviewer 
should check the relevant check boxes when the associated item is done. For items that are not 
applicable, note it's not applicable ("N/A") and check the box. For example, external Pull 
Requests do not require ticket links.

**Submitter:**
- [x] This pull request describes why these changes were made
- [x] Internal ticket for this PR:
- [x] Internal ticket links to this PR
- [x] Internal ticket is properly labeled (Community/Program)
- [x] Internal ticket has a justification for its Community/Program label
- [x] Code diff has been reviewed for extraneous/missing code
- [x] Tests are included and test edge cases
- [x] Tests/code quality metrics have been run locally and pass


**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
