### PR TITLE
Ensure frozen literals arent mutated when saving request body.

### DIFF
--- a/lib/app/models/request_response.rb
+++ b/lib/app/models/request_response.rb
@@ -23,7 +23,8 @@ module Inferno
         request = req.request
         response = req.response
 
-        unescape_unicode(response[:body])
+        escaped_body = response[:body].dup # In case body is frozen from string literal
+        unescape_unicode(escaped_body)
 
         new(
           direction: direction || req&.direction,
@@ -33,7 +34,7 @@ module Inferno
           request_payload: request[:payload],
           response_code: response[:code],
           response_headers: response[:headers].to_json,
-          response_body: response[:body],
+          response_body: escaped_body,
           instance_id: instance_id,
           timestamp: response[:timestamp]
         )


### PR DESCRIPTION
When there are too many resources being streamed back, Inferno fails due to a 'frozen string error' when trying to save the requests. This is because Inferno caps the number of resources logged in the interface, and adds a message in the response body indicating it is truncated. Recent code updates to fix html encoding needs to be able to mutate strings, but this string in particular is frozen.

Pull requests into Inferno require the following items to be completed. Submitter and reviewer 
should check the relevant check boxes when the associated item is done. For items that are not 
applicable, note it's not applicable ("N/A") and check the box. For example, external Pull 
Requests do not require ticket links.

**Submitter:**
- [x] This pull request describes why these changes were made
- [x] Internal ticket for this PR:
- [x] Internal ticket links to this PR
- [x] Internal ticket is properly labeled (Community/Program)
- [x] Internal ticket has a justification for its Community/Program label
- [x] Code diff has been reviewed for extraneous/missing code
- n/a Tests are included and test edge cases
- [x] Tests/code quality metrics have been run locally and pass


**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
