### PR TITLE
fi-585 Add a search with system included for token searches

### DIFF
--- a/generator/uscore/templates/unit_tests/search_unit_test.rb.erb
+++ b/generator/uscore/templates/unit_tests/search_unit_test.rb.erb
@@ -12,6 +12,12 @@ describe '<%= resource_type %> search by <%= search_params.keys.join('+') %> tes
     @query = {
       <%= search_param_string %>
     }
+
+  <% if token_param%>
+    @query_with_system = {
+      <%= token_with_system_search_string %>
+    }
+  <% end %>
   end
 
   it 'skips if the search params are not supported' do
@@ -157,6 +163,11 @@ describe '<%= resource_type %> search by <%= search_params.keys.join('+') %> tes
   <% else %>
     stub_request(:get, "#{@base_url}/<%= resource_type %>")
       .with(query: @query, headers: @auth_header)
+      .to_return(status: 200, body: wrap_resources_in_bundle(@<%= resource_var_name %>_ary<%='.values.flatten' unless delayed_sequence %>).to_json)
+  <% end %>
+  <% if token_param %>
+    stub_request(:get, "#{@base_url}/<%= resource_type %>")
+      .with(query: @query_with_system, headers: @auth_header)
       .to_return(status: 200, body: wrap_resources_in_bundle(@<%= resource_var_name %>_ary<%='.values.flatten' unless delayed_sequence %>).to_json)
   <% end %>
 
@@ -315,6 +326,11 @@ describe '<%= resource_type %> search by <%= search_params.keys.join('+') %> tes
       stub_request(:get, "#{@base_url}/<%= resource_type %>")
         .with(query: @query.merge(<%= status_param[:param] %>: [<%= status_param[:value] %>].first), headers: @auth_header)
         .to_return(status: 200, body: wrap_resources_in_bundle([@<%= resource_var_name %>]).to_json)
+    <% end %>
+    <% if token_param %>
+    stub_request(:get, "#{@base_url}/<%= resource_type %>")
+      .with(query: @query_with_system.merge(<%= status_param[:param] %>: [<%= status_param[:value] %>].first), headers: @auth_header)
+      .to_return(status: 200, body: wrap_resources_in_bundle([@<%= resource_var_name %>]).to_json)
     <% end %>
 
       @sequence.run_test(@test)

--- a/generator/uscore/us_core_unit_test_generator.rb
+++ b/generator/uscore/us_core_unit_test_generator.rb
@@ -47,7 +47,8 @@ module Inferno
         class_name:,
         sequence_name:,
         delayed_sequence:,
-        status_param:
+        status_param:,
+        token_param:
       )
 
         template = ERB.new(File.read(File.join(__dir__, 'templates', 'unit_tests', 'search_unit_test.rb.erb')))
@@ -77,7 +78,9 @@ module Inferno
           fixed_value_search_string: fixed_value_search_param&.dig(:values)&.map { |value| "'#{value}'" }&.join(', '),
           fixed_value_search_path: fixed_value_search_param&.dig(:path),
           delayed_sequence: delayed_sequence,
-          status_param: status_param
+          status_param: status_param,
+          token_param: token_param,
+          token_with_system_search_string: search_params_to_string(search_params, token_param)
         )
         tests[class_name] << test
       end
@@ -141,10 +144,10 @@ module Inferno
         end
       end
 
-      def search_params_to_string(search_params)
+      def search_params_to_string(search_params, token_param = nil)
         search_params.map do |param, value|
           if dynamic_search_param? value
-            dynamic_search_param_string(param, value)
+            dynamic_search_param_string(param, value, param == token_param)
           elsif value.start_with? '@'
             "'#{param}': #{value}"
           elsif value == 'patient'
@@ -155,12 +158,12 @@ module Inferno
         end.join(",\n")
       end
 
-      def dynamic_search_param_string(param, value)
+      def dynamic_search_param_string(param, value, include_system)
         param_info = dynamic_search_param(value)
         path = param_info[:resource_path]
         variable_name = param_info[:variable_name]
         variable_name.gsub!('[patient]', '[@sequence.patient_ids.first]')
-        "'#{param}': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(#{variable_name}, '#{path}'))"
+        "'#{param}': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(#{variable_name}, '#{path}')#{', true' if include_system})"
       end
 
       def dynamic_search_param?(param_value)

--- a/lib/app/sequence_base.rb
+++ b/lib/app/sequence_base.rb
@@ -794,7 +794,7 @@ module Inferno
         nil
       end
 
-      def get_value_for_search_param(element)
+      def get_value_for_search_param(element, include_system = false)
         search_value = case element
                        when FHIR::Period
                          if element.start.present?
@@ -805,11 +805,24 @@ module Inferno
                        when FHIR::Reference
                          element.reference
                        when FHIR::CodeableConcept
-                         resolve_element_from_path(element, 'coding.code')
+                         if include_system
+                           coding_with_code = resolve_element_from_path(element, 'coding') { |coding| coding.code.present? }
+                           "#{coding_with_code.system}|#{coding_with_code.code}"
+                         else
+                           resolve_element_from_path(element, 'coding.code')
+                         end
                        when FHIR::Identifier
-                         element.value
+                         if include_system
+                           "#{element.system}|#{element.value}"
+                         else
+                           element.value
+                         end
                        when FHIR::Coding
-                         element.code
+                         if include_system
+                           "#{element.system}|#{element.code}"
+                         else
+                           element.code
+                         end
                        when FHIR::HumanName
                          element.family || element.given&.first || element.text
                        when FHIR::Address

--- a/lib/modules/uscore_v3.1.0/bodyheight_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/bodyheight_sequence.rb
@@ -76,15 +76,29 @@ module Inferno
           assert match_found, "status in Observation/#{resource.id} (#{values_found}) does not match status requested (#{value})"
 
         when 'category'
-          values_found = resolve_path(resource, 'category.coding.code')
-          values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
-          match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
+          values_found = resolve_path(resource, 'category')
+          coding_system = value.split('|').first.empty? ? nil : value.split('|').first
+          coding_value = value.split('|').last
+          match_found = values_found.any? do |codeable_concept|
+            if value.include? '|'
+              codeable_concept.coding.any? { |coding| coding.system == coding_system && coding.code == coding_value }
+            else
+              codeable_concept.coding.any? { |coding| coding.code == value }
+            end
+          end
           assert match_found, "category in Observation/#{resource.id} (#{values_found}) does not match category requested (#{value})"
 
         when 'code'
-          values_found = resolve_path(resource, 'code.coding.code')
-          values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
-          match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
+          values_found = resolve_path(resource, 'code')
+          coding_system = value.split('|').first.empty? ? nil : value.split('|').first
+          coding_value = value.split('|').last
+          match_found = values_found.any? do |codeable_concept|
+            if value.include? '|'
+              codeable_concept.coding.any? { |coding| coding.system == coding_system && coding.code == coding_value }
+            else
+              codeable_concept.coding.any? { |coding| coding.code == value }
+            end
+          end
           assert match_found, "code in Observation/#{resource.id} (#{values_found}) does not match code requested (#{value})"
 
         when 'date'
@@ -180,6 +194,11 @@ module Inferno
             save_delayed_sequence_references(resources_returned, USCore310BodyheightSequenceDefinitions::DELAYED_REFERENCES)
             validate_reply_entries(resources_returned, search_params)
 
+            value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'code'), true)
+            token_with_system_search_params = search_params.merge('code': value_with_system)
+            reply = get_resource_by_params(versioned_resource_class('Observation'), token_with_system_search_params)
+            validate_search_reply(versioned_resource_class('Observation'), reply, token_with_system_search_params)
+
             break
           end
         end
@@ -232,6 +251,11 @@ module Inferno
             reply = get_resource_by_params(versioned_resource_class('Observation'), comparator_search_params)
             validate_search_reply(versioned_resource_class('Observation'), reply, comparator_search_params)
           end
+
+          value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category'), true)
+          token_with_system_search_params = search_params.merge('category': value_with_system)
+          reply = get_resource_by_params(versioned_resource_class('Observation'), token_with_system_search_params)
+          validate_search_reply(versioned_resource_class('Observation'), reply, token_with_system_search_params)
         end
 
         skip 'Could not resolve all parameters (patient, category, date) in any resource.' unless resolved_one
@@ -271,6 +295,11 @@ module Inferno
           reply = perform_search_with_status(reply, search_params) if reply.code == 400
 
           validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
+
+          value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category'), true)
+          token_with_system_search_params = search_params.merge('category': value_with_system)
+          reply = get_resource_by_params(versioned_resource_class('Observation'), token_with_system_search_params)
+          validate_search_reply(versioned_resource_class('Observation'), reply, token_with_system_search_params)
         end
 
         skip 'Could not resolve all parameters (patient, category) in any resource.' unless resolved_one
@@ -323,6 +352,11 @@ module Inferno
             reply = get_resource_by_params(versioned_resource_class('Observation'), comparator_search_params)
             validate_search_reply(versioned_resource_class('Observation'), reply, comparator_search_params)
           end
+
+          value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'code'), true)
+          token_with_system_search_params = search_params.merge('code': value_with_system)
+          reply = get_resource_by_params(versioned_resource_class('Observation'), token_with_system_search_params)
+          validate_search_reply(versioned_resource_class('Observation'), reply, token_with_system_search_params)
         end
 
         skip 'Could not resolve all parameters (patient, code, date) in any resource.' unless resolved_one
@@ -362,6 +396,11 @@ module Inferno
           reply = get_resource_by_params(versioned_resource_class('Observation'), search_params)
 
           validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
+
+          value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category'), true)
+          token_with_system_search_params = search_params.merge('category': value_with_system)
+          reply = get_resource_by_params(versioned_resource_class('Observation'), token_with_system_search_params)
+          validate_search_reply(versioned_resource_class('Observation'), reply, token_with_system_search_params)
         end
 
         skip 'Could not resolve all parameters (patient, category, status) in any resource.' unless resolved_one

--- a/lib/modules/uscore_v3.1.0/bodytemp_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/bodytemp_sequence.rb
@@ -76,15 +76,29 @@ module Inferno
           assert match_found, "status in Observation/#{resource.id} (#{values_found}) does not match status requested (#{value})"
 
         when 'category'
-          values_found = resolve_path(resource, 'category.coding.code')
-          values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
-          match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
+          values_found = resolve_path(resource, 'category')
+          coding_system = value.split('|').first.empty? ? nil : value.split('|').first
+          coding_value = value.split('|').last
+          match_found = values_found.any? do |codeable_concept|
+            if value.include? '|'
+              codeable_concept.coding.any? { |coding| coding.system == coding_system && coding.code == coding_value }
+            else
+              codeable_concept.coding.any? { |coding| coding.code == value }
+            end
+          end
           assert match_found, "category in Observation/#{resource.id} (#{values_found}) does not match category requested (#{value})"
 
         when 'code'
-          values_found = resolve_path(resource, 'code.coding.code')
-          values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
-          match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
+          values_found = resolve_path(resource, 'code')
+          coding_system = value.split('|').first.empty? ? nil : value.split('|').first
+          coding_value = value.split('|').last
+          match_found = values_found.any? do |codeable_concept|
+            if value.include? '|'
+              codeable_concept.coding.any? { |coding| coding.system == coding_system && coding.code == coding_value }
+            else
+              codeable_concept.coding.any? { |coding| coding.code == value }
+            end
+          end
           assert match_found, "code in Observation/#{resource.id} (#{values_found}) does not match code requested (#{value})"
 
         when 'date'
@@ -180,6 +194,11 @@ module Inferno
             save_delayed_sequence_references(resources_returned, USCore310BodytempSequenceDefinitions::DELAYED_REFERENCES)
             validate_reply_entries(resources_returned, search_params)
 
+            value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'code'), true)
+            token_with_system_search_params = search_params.merge('code': value_with_system)
+            reply = get_resource_by_params(versioned_resource_class('Observation'), token_with_system_search_params)
+            validate_search_reply(versioned_resource_class('Observation'), reply, token_with_system_search_params)
+
             break
           end
         end
@@ -232,6 +251,11 @@ module Inferno
             reply = get_resource_by_params(versioned_resource_class('Observation'), comparator_search_params)
             validate_search_reply(versioned_resource_class('Observation'), reply, comparator_search_params)
           end
+
+          value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category'), true)
+          token_with_system_search_params = search_params.merge('category': value_with_system)
+          reply = get_resource_by_params(versioned_resource_class('Observation'), token_with_system_search_params)
+          validate_search_reply(versioned_resource_class('Observation'), reply, token_with_system_search_params)
         end
 
         skip 'Could not resolve all parameters (patient, category, date) in any resource.' unless resolved_one
@@ -271,6 +295,11 @@ module Inferno
           reply = perform_search_with_status(reply, search_params) if reply.code == 400
 
           validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
+
+          value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category'), true)
+          token_with_system_search_params = search_params.merge('category': value_with_system)
+          reply = get_resource_by_params(versioned_resource_class('Observation'), token_with_system_search_params)
+          validate_search_reply(versioned_resource_class('Observation'), reply, token_with_system_search_params)
         end
 
         skip 'Could not resolve all parameters (patient, category) in any resource.' unless resolved_one
@@ -323,6 +352,11 @@ module Inferno
             reply = get_resource_by_params(versioned_resource_class('Observation'), comparator_search_params)
             validate_search_reply(versioned_resource_class('Observation'), reply, comparator_search_params)
           end
+
+          value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'code'), true)
+          token_with_system_search_params = search_params.merge('code': value_with_system)
+          reply = get_resource_by_params(versioned_resource_class('Observation'), token_with_system_search_params)
+          validate_search_reply(versioned_resource_class('Observation'), reply, token_with_system_search_params)
         end
 
         skip 'Could not resolve all parameters (patient, code, date) in any resource.' unless resolved_one
@@ -362,6 +396,11 @@ module Inferno
           reply = get_resource_by_params(versioned_resource_class('Observation'), search_params)
 
           validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
+
+          value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category'), true)
+          token_with_system_search_params = search_params.merge('category': value_with_system)
+          reply = get_resource_by_params(versioned_resource_class('Observation'), token_with_system_search_params)
+          validate_search_reply(versioned_resource_class('Observation'), reply, token_with_system_search_params)
         end
 
         skip 'Could not resolve all parameters (patient, category, status) in any resource.' unless resolved_one

--- a/lib/modules/uscore_v3.1.0/bodyweight_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/bodyweight_sequence.rb
@@ -76,15 +76,29 @@ module Inferno
           assert match_found, "status in Observation/#{resource.id} (#{values_found}) does not match status requested (#{value})"
 
         when 'category'
-          values_found = resolve_path(resource, 'category.coding.code')
-          values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
-          match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
+          values_found = resolve_path(resource, 'category')
+          coding_system = value.split('|').first.empty? ? nil : value.split('|').first
+          coding_value = value.split('|').last
+          match_found = values_found.any? do |codeable_concept|
+            if value.include? '|'
+              codeable_concept.coding.any? { |coding| coding.system == coding_system && coding.code == coding_value }
+            else
+              codeable_concept.coding.any? { |coding| coding.code == value }
+            end
+          end
           assert match_found, "category in Observation/#{resource.id} (#{values_found}) does not match category requested (#{value})"
 
         when 'code'
-          values_found = resolve_path(resource, 'code.coding.code')
-          values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
-          match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
+          values_found = resolve_path(resource, 'code')
+          coding_system = value.split('|').first.empty? ? nil : value.split('|').first
+          coding_value = value.split('|').last
+          match_found = values_found.any? do |codeable_concept|
+            if value.include? '|'
+              codeable_concept.coding.any? { |coding| coding.system == coding_system && coding.code == coding_value }
+            else
+              codeable_concept.coding.any? { |coding| coding.code == value }
+            end
+          end
           assert match_found, "code in Observation/#{resource.id} (#{values_found}) does not match code requested (#{value})"
 
         when 'date'
@@ -180,6 +194,11 @@ module Inferno
             save_delayed_sequence_references(resources_returned, USCore310BodyweightSequenceDefinitions::DELAYED_REFERENCES)
             validate_reply_entries(resources_returned, search_params)
 
+            value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'code'), true)
+            token_with_system_search_params = search_params.merge('code': value_with_system)
+            reply = get_resource_by_params(versioned_resource_class('Observation'), token_with_system_search_params)
+            validate_search_reply(versioned_resource_class('Observation'), reply, token_with_system_search_params)
+
             break
           end
         end
@@ -232,6 +251,11 @@ module Inferno
             reply = get_resource_by_params(versioned_resource_class('Observation'), comparator_search_params)
             validate_search_reply(versioned_resource_class('Observation'), reply, comparator_search_params)
           end
+
+          value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category'), true)
+          token_with_system_search_params = search_params.merge('category': value_with_system)
+          reply = get_resource_by_params(versioned_resource_class('Observation'), token_with_system_search_params)
+          validate_search_reply(versioned_resource_class('Observation'), reply, token_with_system_search_params)
         end
 
         skip 'Could not resolve all parameters (patient, category, date) in any resource.' unless resolved_one
@@ -271,6 +295,11 @@ module Inferno
           reply = perform_search_with_status(reply, search_params) if reply.code == 400
 
           validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
+
+          value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category'), true)
+          token_with_system_search_params = search_params.merge('category': value_with_system)
+          reply = get_resource_by_params(versioned_resource_class('Observation'), token_with_system_search_params)
+          validate_search_reply(versioned_resource_class('Observation'), reply, token_with_system_search_params)
         end
 
         skip 'Could not resolve all parameters (patient, category) in any resource.' unless resolved_one
@@ -323,6 +352,11 @@ module Inferno
             reply = get_resource_by_params(versioned_resource_class('Observation'), comparator_search_params)
             validate_search_reply(versioned_resource_class('Observation'), reply, comparator_search_params)
           end
+
+          value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'code'), true)
+          token_with_system_search_params = search_params.merge('code': value_with_system)
+          reply = get_resource_by_params(versioned_resource_class('Observation'), token_with_system_search_params)
+          validate_search_reply(versioned_resource_class('Observation'), reply, token_with_system_search_params)
         end
 
         skip 'Could not resolve all parameters (patient, code, date) in any resource.' unless resolved_one
@@ -362,6 +396,11 @@ module Inferno
           reply = get_resource_by_params(versioned_resource_class('Observation'), search_params)
 
           validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
+
+          value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category'), true)
+          token_with_system_search_params = search_params.merge('category': value_with_system)
+          reply = get_resource_by_params(versioned_resource_class('Observation'), token_with_system_search_params)
+          validate_search_reply(versioned_resource_class('Observation'), reply, token_with_system_search_params)
         end
 
         skip 'Could not resolve all parameters (patient, category, status) in any resource.' unless resolved_one

--- a/lib/modules/uscore_v3.1.0/bp_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/bp_sequence.rb
@@ -76,15 +76,29 @@ module Inferno
           assert match_found, "status in Observation/#{resource.id} (#{values_found}) does not match status requested (#{value})"
 
         when 'category'
-          values_found = resolve_path(resource, 'category.coding.code')
-          values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
-          match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
+          values_found = resolve_path(resource, 'category')
+          coding_system = value.split('|').first.empty? ? nil : value.split('|').first
+          coding_value = value.split('|').last
+          match_found = values_found.any? do |codeable_concept|
+            if value.include? '|'
+              codeable_concept.coding.any? { |coding| coding.system == coding_system && coding.code == coding_value }
+            else
+              codeable_concept.coding.any? { |coding| coding.code == value }
+            end
+          end
           assert match_found, "category in Observation/#{resource.id} (#{values_found}) does not match category requested (#{value})"
 
         when 'code'
-          values_found = resolve_path(resource, 'code.coding.code')
-          values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
-          match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
+          values_found = resolve_path(resource, 'code')
+          coding_system = value.split('|').first.empty? ? nil : value.split('|').first
+          coding_value = value.split('|').last
+          match_found = values_found.any? do |codeable_concept|
+            if value.include? '|'
+              codeable_concept.coding.any? { |coding| coding.system == coding_system && coding.code == coding_value }
+            else
+              codeable_concept.coding.any? { |coding| coding.code == value }
+            end
+          end
           assert match_found, "code in Observation/#{resource.id} (#{values_found}) does not match code requested (#{value})"
 
         when 'date'
@@ -180,6 +194,11 @@ module Inferno
             save_delayed_sequence_references(resources_returned, USCore310BpSequenceDefinitions::DELAYED_REFERENCES)
             validate_reply_entries(resources_returned, search_params)
 
+            value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'code'), true)
+            token_with_system_search_params = search_params.merge('code': value_with_system)
+            reply = get_resource_by_params(versioned_resource_class('Observation'), token_with_system_search_params)
+            validate_search_reply(versioned_resource_class('Observation'), reply, token_with_system_search_params)
+
             break
           end
         end
@@ -232,6 +251,11 @@ module Inferno
             reply = get_resource_by_params(versioned_resource_class('Observation'), comparator_search_params)
             validate_search_reply(versioned_resource_class('Observation'), reply, comparator_search_params)
           end
+
+          value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category'), true)
+          token_with_system_search_params = search_params.merge('category': value_with_system)
+          reply = get_resource_by_params(versioned_resource_class('Observation'), token_with_system_search_params)
+          validate_search_reply(versioned_resource_class('Observation'), reply, token_with_system_search_params)
         end
 
         skip 'Could not resolve all parameters (patient, category, date) in any resource.' unless resolved_one
@@ -271,6 +295,11 @@ module Inferno
           reply = perform_search_with_status(reply, search_params) if reply.code == 400
 
           validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
+
+          value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category'), true)
+          token_with_system_search_params = search_params.merge('category': value_with_system)
+          reply = get_resource_by_params(versioned_resource_class('Observation'), token_with_system_search_params)
+          validate_search_reply(versioned_resource_class('Observation'), reply, token_with_system_search_params)
         end
 
         skip 'Could not resolve all parameters (patient, category) in any resource.' unless resolved_one
@@ -323,6 +352,11 @@ module Inferno
             reply = get_resource_by_params(versioned_resource_class('Observation'), comparator_search_params)
             validate_search_reply(versioned_resource_class('Observation'), reply, comparator_search_params)
           end
+
+          value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'code'), true)
+          token_with_system_search_params = search_params.merge('code': value_with_system)
+          reply = get_resource_by_params(versioned_resource_class('Observation'), token_with_system_search_params)
+          validate_search_reply(versioned_resource_class('Observation'), reply, token_with_system_search_params)
         end
 
         skip 'Could not resolve all parameters (patient, code, date) in any resource.' unless resolved_one
@@ -362,6 +396,11 @@ module Inferno
           reply = get_resource_by_params(versioned_resource_class('Observation'), search_params)
 
           validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
+
+          value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category'), true)
+          token_with_system_search_params = search_params.merge('category': value_with_system)
+          reply = get_resource_by_params(versioned_resource_class('Observation'), token_with_system_search_params)
+          validate_search_reply(versioned_resource_class('Observation'), reply, token_with_system_search_params)
         end
 
         skip 'Could not resolve all parameters (patient, category, status) in any resource.' unless resolved_one

--- a/lib/modules/uscore_v3.1.0/headcircum_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/headcircum_sequence.rb
@@ -76,15 +76,29 @@ module Inferno
           assert match_found, "status in Observation/#{resource.id} (#{values_found}) does not match status requested (#{value})"
 
         when 'category'
-          values_found = resolve_path(resource, 'category.coding.code')
-          values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
-          match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
+          values_found = resolve_path(resource, 'category')
+          coding_system = value.split('|').first.empty? ? nil : value.split('|').first
+          coding_value = value.split('|').last
+          match_found = values_found.any? do |codeable_concept|
+            if value.include? '|'
+              codeable_concept.coding.any? { |coding| coding.system == coding_system && coding.code == coding_value }
+            else
+              codeable_concept.coding.any? { |coding| coding.code == value }
+            end
+          end
           assert match_found, "category in Observation/#{resource.id} (#{values_found}) does not match category requested (#{value})"
 
         when 'code'
-          values_found = resolve_path(resource, 'code.coding.code')
-          values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
-          match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
+          values_found = resolve_path(resource, 'code')
+          coding_system = value.split('|').first.empty? ? nil : value.split('|').first
+          coding_value = value.split('|').last
+          match_found = values_found.any? do |codeable_concept|
+            if value.include? '|'
+              codeable_concept.coding.any? { |coding| coding.system == coding_system && coding.code == coding_value }
+            else
+              codeable_concept.coding.any? { |coding| coding.code == value }
+            end
+          end
           assert match_found, "code in Observation/#{resource.id} (#{values_found}) does not match code requested (#{value})"
 
         when 'date'
@@ -180,6 +194,11 @@ module Inferno
             save_delayed_sequence_references(resources_returned, USCore310HeadcircumSequenceDefinitions::DELAYED_REFERENCES)
             validate_reply_entries(resources_returned, search_params)
 
+            value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'code'), true)
+            token_with_system_search_params = search_params.merge('code': value_with_system)
+            reply = get_resource_by_params(versioned_resource_class('Observation'), token_with_system_search_params)
+            validate_search_reply(versioned_resource_class('Observation'), reply, token_with_system_search_params)
+
             break
           end
         end
@@ -232,6 +251,11 @@ module Inferno
             reply = get_resource_by_params(versioned_resource_class('Observation'), comparator_search_params)
             validate_search_reply(versioned_resource_class('Observation'), reply, comparator_search_params)
           end
+
+          value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category'), true)
+          token_with_system_search_params = search_params.merge('category': value_with_system)
+          reply = get_resource_by_params(versioned_resource_class('Observation'), token_with_system_search_params)
+          validate_search_reply(versioned_resource_class('Observation'), reply, token_with_system_search_params)
         end
 
         skip 'Could not resolve all parameters (patient, category, date) in any resource.' unless resolved_one
@@ -271,6 +295,11 @@ module Inferno
           reply = perform_search_with_status(reply, search_params) if reply.code == 400
 
           validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
+
+          value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category'), true)
+          token_with_system_search_params = search_params.merge('category': value_with_system)
+          reply = get_resource_by_params(versioned_resource_class('Observation'), token_with_system_search_params)
+          validate_search_reply(versioned_resource_class('Observation'), reply, token_with_system_search_params)
         end
 
         skip 'Could not resolve all parameters (patient, category) in any resource.' unless resolved_one
@@ -323,6 +352,11 @@ module Inferno
             reply = get_resource_by_params(versioned_resource_class('Observation'), comparator_search_params)
             validate_search_reply(versioned_resource_class('Observation'), reply, comparator_search_params)
           end
+
+          value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'code'), true)
+          token_with_system_search_params = search_params.merge('code': value_with_system)
+          reply = get_resource_by_params(versioned_resource_class('Observation'), token_with_system_search_params)
+          validate_search_reply(versioned_resource_class('Observation'), reply, token_with_system_search_params)
         end
 
         skip 'Could not resolve all parameters (patient, code, date) in any resource.' unless resolved_one
@@ -362,6 +396,11 @@ module Inferno
           reply = get_resource_by_params(versioned_resource_class('Observation'), search_params)
 
           validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
+
+          value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category'), true)
+          token_with_system_search_params = search_params.merge('category': value_with_system)
+          reply = get_resource_by_params(versioned_resource_class('Observation'), token_with_system_search_params)
+          validate_search_reply(versioned_resource_class('Observation'), reply, token_with_system_search_params)
         end
 
         skip 'Could not resolve all parameters (patient, category, status) in any resource.' unless resolved_one

--- a/lib/modules/uscore_v3.1.0/heartrate_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/heartrate_sequence.rb
@@ -76,15 +76,29 @@ module Inferno
           assert match_found, "status in Observation/#{resource.id} (#{values_found}) does not match status requested (#{value})"
 
         when 'category'
-          values_found = resolve_path(resource, 'category.coding.code')
-          values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
-          match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
+          values_found = resolve_path(resource, 'category')
+          coding_system = value.split('|').first.empty? ? nil : value.split('|').first
+          coding_value = value.split('|').last
+          match_found = values_found.any? do |codeable_concept|
+            if value.include? '|'
+              codeable_concept.coding.any? { |coding| coding.system == coding_system && coding.code == coding_value }
+            else
+              codeable_concept.coding.any? { |coding| coding.code == value }
+            end
+          end
           assert match_found, "category in Observation/#{resource.id} (#{values_found}) does not match category requested (#{value})"
 
         when 'code'
-          values_found = resolve_path(resource, 'code.coding.code')
-          values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
-          match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
+          values_found = resolve_path(resource, 'code')
+          coding_system = value.split('|').first.empty? ? nil : value.split('|').first
+          coding_value = value.split('|').last
+          match_found = values_found.any? do |codeable_concept|
+            if value.include? '|'
+              codeable_concept.coding.any? { |coding| coding.system == coding_system && coding.code == coding_value }
+            else
+              codeable_concept.coding.any? { |coding| coding.code == value }
+            end
+          end
           assert match_found, "code in Observation/#{resource.id} (#{values_found}) does not match code requested (#{value})"
 
         when 'date'
@@ -180,6 +194,11 @@ module Inferno
             save_delayed_sequence_references(resources_returned, USCore310HeartrateSequenceDefinitions::DELAYED_REFERENCES)
             validate_reply_entries(resources_returned, search_params)
 
+            value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'code'), true)
+            token_with_system_search_params = search_params.merge('code': value_with_system)
+            reply = get_resource_by_params(versioned_resource_class('Observation'), token_with_system_search_params)
+            validate_search_reply(versioned_resource_class('Observation'), reply, token_with_system_search_params)
+
             break
           end
         end
@@ -232,6 +251,11 @@ module Inferno
             reply = get_resource_by_params(versioned_resource_class('Observation'), comparator_search_params)
             validate_search_reply(versioned_resource_class('Observation'), reply, comparator_search_params)
           end
+
+          value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category'), true)
+          token_with_system_search_params = search_params.merge('category': value_with_system)
+          reply = get_resource_by_params(versioned_resource_class('Observation'), token_with_system_search_params)
+          validate_search_reply(versioned_resource_class('Observation'), reply, token_with_system_search_params)
         end
 
         skip 'Could not resolve all parameters (patient, category, date) in any resource.' unless resolved_one
@@ -271,6 +295,11 @@ module Inferno
           reply = perform_search_with_status(reply, search_params) if reply.code == 400
 
           validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
+
+          value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category'), true)
+          token_with_system_search_params = search_params.merge('category': value_with_system)
+          reply = get_resource_by_params(versioned_resource_class('Observation'), token_with_system_search_params)
+          validate_search_reply(versioned_resource_class('Observation'), reply, token_with_system_search_params)
         end
 
         skip 'Could not resolve all parameters (patient, category) in any resource.' unless resolved_one
@@ -323,6 +352,11 @@ module Inferno
             reply = get_resource_by_params(versioned_resource_class('Observation'), comparator_search_params)
             validate_search_reply(versioned_resource_class('Observation'), reply, comparator_search_params)
           end
+
+          value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'code'), true)
+          token_with_system_search_params = search_params.merge('code': value_with_system)
+          reply = get_resource_by_params(versioned_resource_class('Observation'), token_with_system_search_params)
+          validate_search_reply(versioned_resource_class('Observation'), reply, token_with_system_search_params)
         end
 
         skip 'Could not resolve all parameters (patient, code, date) in any resource.' unless resolved_one
@@ -362,6 +396,11 @@ module Inferno
           reply = get_resource_by_params(versioned_resource_class('Observation'), search_params)
 
           validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
+
+          value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category'), true)
+          token_with_system_search_params = search_params.merge('category': value_with_system)
+          reply = get_resource_by_params(versioned_resource_class('Observation'), token_with_system_search_params)
+          validate_search_reply(versioned_resource_class('Observation'), reply, token_with_system_search_params)
         end
 
         skip 'Could not resolve all parameters (patient, category, status) in any resource.' unless resolved_one

--- a/lib/modules/uscore_v3.1.0/pediatric_bmi_for_age_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/pediatric_bmi_for_age_sequence.rb
@@ -76,15 +76,29 @@ module Inferno
           assert match_found, "status in Observation/#{resource.id} (#{values_found}) does not match status requested (#{value})"
 
         when 'category'
-          values_found = resolve_path(resource, 'category.coding.code')
-          values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
-          match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
+          values_found = resolve_path(resource, 'category')
+          coding_system = value.split('|').first.empty? ? nil : value.split('|').first
+          coding_value = value.split('|').last
+          match_found = values_found.any? do |codeable_concept|
+            if value.include? '|'
+              codeable_concept.coding.any? { |coding| coding.system == coding_system && coding.code == coding_value }
+            else
+              codeable_concept.coding.any? { |coding| coding.code == value }
+            end
+          end
           assert match_found, "category in Observation/#{resource.id} (#{values_found}) does not match category requested (#{value})"
 
         when 'code'
-          values_found = resolve_path(resource, 'code.coding.code')
-          values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
-          match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
+          values_found = resolve_path(resource, 'code')
+          coding_system = value.split('|').first.empty? ? nil : value.split('|').first
+          coding_value = value.split('|').last
+          match_found = values_found.any? do |codeable_concept|
+            if value.include? '|'
+              codeable_concept.coding.any? { |coding| coding.system == coding_system && coding.code == coding_value }
+            else
+              codeable_concept.coding.any? { |coding| coding.code == value }
+            end
+          end
           assert match_found, "code in Observation/#{resource.id} (#{values_found}) does not match code requested (#{value})"
 
         when 'date'
@@ -180,6 +194,11 @@ module Inferno
             save_delayed_sequence_references(resources_returned, USCore310PediatricBmiForAgeSequenceDefinitions::DELAYED_REFERENCES)
             validate_reply_entries(resources_returned, search_params)
 
+            value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'code'), true)
+            token_with_system_search_params = search_params.merge('code': value_with_system)
+            reply = get_resource_by_params(versioned_resource_class('Observation'), token_with_system_search_params)
+            validate_search_reply(versioned_resource_class('Observation'), reply, token_with_system_search_params)
+
             break
           end
         end
@@ -232,6 +251,11 @@ module Inferno
             reply = get_resource_by_params(versioned_resource_class('Observation'), comparator_search_params)
             validate_search_reply(versioned_resource_class('Observation'), reply, comparator_search_params)
           end
+
+          value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category'), true)
+          token_with_system_search_params = search_params.merge('category': value_with_system)
+          reply = get_resource_by_params(versioned_resource_class('Observation'), token_with_system_search_params)
+          validate_search_reply(versioned_resource_class('Observation'), reply, token_with_system_search_params)
         end
 
         skip 'Could not resolve all parameters (patient, category, date) in any resource.' unless resolved_one
@@ -271,6 +295,11 @@ module Inferno
           reply = perform_search_with_status(reply, search_params) if reply.code == 400
 
           validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
+
+          value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category'), true)
+          token_with_system_search_params = search_params.merge('category': value_with_system)
+          reply = get_resource_by_params(versioned_resource_class('Observation'), token_with_system_search_params)
+          validate_search_reply(versioned_resource_class('Observation'), reply, token_with_system_search_params)
         end
 
         skip 'Could not resolve all parameters (patient, category) in any resource.' unless resolved_one
@@ -323,6 +352,11 @@ module Inferno
             reply = get_resource_by_params(versioned_resource_class('Observation'), comparator_search_params)
             validate_search_reply(versioned_resource_class('Observation'), reply, comparator_search_params)
           end
+
+          value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'code'), true)
+          token_with_system_search_params = search_params.merge('code': value_with_system)
+          reply = get_resource_by_params(versioned_resource_class('Observation'), token_with_system_search_params)
+          validate_search_reply(versioned_resource_class('Observation'), reply, token_with_system_search_params)
         end
 
         skip 'Could not resolve all parameters (patient, code, date) in any resource.' unless resolved_one
@@ -362,6 +396,11 @@ module Inferno
           reply = get_resource_by_params(versioned_resource_class('Observation'), search_params)
 
           validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
+
+          value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category'), true)
+          token_with_system_search_params = search_params.merge('category': value_with_system)
+          reply = get_resource_by_params(versioned_resource_class('Observation'), token_with_system_search_params)
+          validate_search_reply(versioned_resource_class('Observation'), reply, token_with_system_search_params)
         end
 
         skip 'Could not resolve all parameters (patient, category, status) in any resource.' unless resolved_one

--- a/lib/modules/uscore_v3.1.0/pediatric_weight_for_height_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/pediatric_weight_for_height_sequence.rb
@@ -76,15 +76,29 @@ module Inferno
           assert match_found, "status in Observation/#{resource.id} (#{values_found}) does not match status requested (#{value})"
 
         when 'category'
-          values_found = resolve_path(resource, 'category.coding.code')
-          values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
-          match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
+          values_found = resolve_path(resource, 'category')
+          coding_system = value.split('|').first.empty? ? nil : value.split('|').first
+          coding_value = value.split('|').last
+          match_found = values_found.any? do |codeable_concept|
+            if value.include? '|'
+              codeable_concept.coding.any? { |coding| coding.system == coding_system && coding.code == coding_value }
+            else
+              codeable_concept.coding.any? { |coding| coding.code == value }
+            end
+          end
           assert match_found, "category in Observation/#{resource.id} (#{values_found}) does not match category requested (#{value})"
 
         when 'code'
-          values_found = resolve_path(resource, 'code.coding.code')
-          values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
-          match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
+          values_found = resolve_path(resource, 'code')
+          coding_system = value.split('|').first.empty? ? nil : value.split('|').first
+          coding_value = value.split('|').last
+          match_found = values_found.any? do |codeable_concept|
+            if value.include? '|'
+              codeable_concept.coding.any? { |coding| coding.system == coding_system && coding.code == coding_value }
+            else
+              codeable_concept.coding.any? { |coding| coding.code == value }
+            end
+          end
           assert match_found, "code in Observation/#{resource.id} (#{values_found}) does not match code requested (#{value})"
 
         when 'date'
@@ -180,6 +194,11 @@ module Inferno
             save_delayed_sequence_references(resources_returned, USCore310PediatricWeightForHeightSequenceDefinitions::DELAYED_REFERENCES)
             validate_reply_entries(resources_returned, search_params)
 
+            value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'code'), true)
+            token_with_system_search_params = search_params.merge('code': value_with_system)
+            reply = get_resource_by_params(versioned_resource_class('Observation'), token_with_system_search_params)
+            validate_search_reply(versioned_resource_class('Observation'), reply, token_with_system_search_params)
+
             break
           end
         end
@@ -232,6 +251,11 @@ module Inferno
             reply = get_resource_by_params(versioned_resource_class('Observation'), comparator_search_params)
             validate_search_reply(versioned_resource_class('Observation'), reply, comparator_search_params)
           end
+
+          value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category'), true)
+          token_with_system_search_params = search_params.merge('category': value_with_system)
+          reply = get_resource_by_params(versioned_resource_class('Observation'), token_with_system_search_params)
+          validate_search_reply(versioned_resource_class('Observation'), reply, token_with_system_search_params)
         end
 
         skip 'Could not resolve all parameters (patient, category, date) in any resource.' unless resolved_one
@@ -271,6 +295,11 @@ module Inferno
           reply = perform_search_with_status(reply, search_params) if reply.code == 400
 
           validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
+
+          value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category'), true)
+          token_with_system_search_params = search_params.merge('category': value_with_system)
+          reply = get_resource_by_params(versioned_resource_class('Observation'), token_with_system_search_params)
+          validate_search_reply(versioned_resource_class('Observation'), reply, token_with_system_search_params)
         end
 
         skip 'Could not resolve all parameters (patient, category) in any resource.' unless resolved_one
@@ -323,6 +352,11 @@ module Inferno
             reply = get_resource_by_params(versioned_resource_class('Observation'), comparator_search_params)
             validate_search_reply(versioned_resource_class('Observation'), reply, comparator_search_params)
           end
+
+          value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'code'), true)
+          token_with_system_search_params = search_params.merge('code': value_with_system)
+          reply = get_resource_by_params(versioned_resource_class('Observation'), token_with_system_search_params)
+          validate_search_reply(versioned_resource_class('Observation'), reply, token_with_system_search_params)
         end
 
         skip 'Could not resolve all parameters (patient, code, date) in any resource.' unless resolved_one
@@ -362,6 +396,11 @@ module Inferno
           reply = get_resource_by_params(versioned_resource_class('Observation'), search_params)
 
           validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
+
+          value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category'), true)
+          token_with_system_search_params = search_params.merge('category': value_with_system)
+          reply = get_resource_by_params(versioned_resource_class('Observation'), token_with_system_search_params)
+          validate_search_reply(versioned_resource_class('Observation'), reply, token_with_system_search_params)
         end
 
         skip 'Could not resolve all parameters (patient, category, status) in any resource.' unless resolved_one

--- a/lib/modules/uscore_v3.1.0/resprate_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/resprate_sequence.rb
@@ -76,15 +76,29 @@ module Inferno
           assert match_found, "status in Observation/#{resource.id} (#{values_found}) does not match status requested (#{value})"
 
         when 'category'
-          values_found = resolve_path(resource, 'category.coding.code')
-          values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
-          match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
+          values_found = resolve_path(resource, 'category')
+          coding_system = value.split('|').first.empty? ? nil : value.split('|').first
+          coding_value = value.split('|').last
+          match_found = values_found.any? do |codeable_concept|
+            if value.include? '|'
+              codeable_concept.coding.any? { |coding| coding.system == coding_system && coding.code == coding_value }
+            else
+              codeable_concept.coding.any? { |coding| coding.code == value }
+            end
+          end
           assert match_found, "category in Observation/#{resource.id} (#{values_found}) does not match category requested (#{value})"
 
         when 'code'
-          values_found = resolve_path(resource, 'code.coding.code')
-          values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
-          match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
+          values_found = resolve_path(resource, 'code')
+          coding_system = value.split('|').first.empty? ? nil : value.split('|').first
+          coding_value = value.split('|').last
+          match_found = values_found.any? do |codeable_concept|
+            if value.include? '|'
+              codeable_concept.coding.any? { |coding| coding.system == coding_system && coding.code == coding_value }
+            else
+              codeable_concept.coding.any? { |coding| coding.code == value }
+            end
+          end
           assert match_found, "code in Observation/#{resource.id} (#{values_found}) does not match code requested (#{value})"
 
         when 'date'
@@ -180,6 +194,11 @@ module Inferno
             save_delayed_sequence_references(resources_returned, USCore310ResprateSequenceDefinitions::DELAYED_REFERENCES)
             validate_reply_entries(resources_returned, search_params)
 
+            value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'code'), true)
+            token_with_system_search_params = search_params.merge('code': value_with_system)
+            reply = get_resource_by_params(versioned_resource_class('Observation'), token_with_system_search_params)
+            validate_search_reply(versioned_resource_class('Observation'), reply, token_with_system_search_params)
+
             break
           end
         end
@@ -232,6 +251,11 @@ module Inferno
             reply = get_resource_by_params(versioned_resource_class('Observation'), comparator_search_params)
             validate_search_reply(versioned_resource_class('Observation'), reply, comparator_search_params)
           end
+
+          value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category'), true)
+          token_with_system_search_params = search_params.merge('category': value_with_system)
+          reply = get_resource_by_params(versioned_resource_class('Observation'), token_with_system_search_params)
+          validate_search_reply(versioned_resource_class('Observation'), reply, token_with_system_search_params)
         end
 
         skip 'Could not resolve all parameters (patient, category, date) in any resource.' unless resolved_one
@@ -271,6 +295,11 @@ module Inferno
           reply = perform_search_with_status(reply, search_params) if reply.code == 400
 
           validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
+
+          value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category'), true)
+          token_with_system_search_params = search_params.merge('category': value_with_system)
+          reply = get_resource_by_params(versioned_resource_class('Observation'), token_with_system_search_params)
+          validate_search_reply(versioned_resource_class('Observation'), reply, token_with_system_search_params)
         end
 
         skip 'Could not resolve all parameters (patient, category) in any resource.' unless resolved_one
@@ -323,6 +352,11 @@ module Inferno
             reply = get_resource_by_params(versioned_resource_class('Observation'), comparator_search_params)
             validate_search_reply(versioned_resource_class('Observation'), reply, comparator_search_params)
           end
+
+          value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'code'), true)
+          token_with_system_search_params = search_params.merge('code': value_with_system)
+          reply = get_resource_by_params(versioned_resource_class('Observation'), token_with_system_search_params)
+          validate_search_reply(versioned_resource_class('Observation'), reply, token_with_system_search_params)
         end
 
         skip 'Could not resolve all parameters (patient, code, date) in any resource.' unless resolved_one
@@ -362,6 +396,11 @@ module Inferno
           reply = get_resource_by_params(versioned_resource_class('Observation'), search_params)
 
           validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
+
+          value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category'), true)
+          token_with_system_search_params = search_params.merge('category': value_with_system)
+          reply = get_resource_by_params(versioned_resource_class('Observation'), token_with_system_search_params)
+          validate_search_reply(versioned_resource_class('Observation'), reply, token_with_system_search_params)
         end
 
         skip 'Could not resolve all parameters (patient, category, status) in any resource.' unless resolved_one

--- a/lib/modules/uscore_v3.1.0/test/bodyheight_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/bodyheight_test.rb
@@ -30,6 +30,11 @@ describe Inferno::Sequence::USCore310BodyheightSequence do
         'patient': @sequence.patient_ids.first,
         'code': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'code'))
       }
+
+      @query_with_system = {
+        'patient': @sequence.patient_ids.first,
+        'code': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'code'), true)
+      }
     end
 
     it 'skips if the search params are not supported' do
@@ -125,6 +130,10 @@ describe Inferno::Sequence::USCore310BodyheightSequence do
           .to_return(status: 200, body: body)
       end
 
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query_with_system, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@observation_ary.values.flatten).to_json)
+
       @sequence.run_test(@test)
     end
 
@@ -217,6 +226,10 @@ describe Inferno::Sequence::USCore310BodyheightSequence do
             .to_return(status: 200, body: wrap_resources_in_bundle([@observation]).to_json)
         end
 
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query_with_system.merge('status': ['registered,preliminary,final,amended,corrected,cancelled,entered-in-error,unknown'].first), headers: @auth_header)
+          .to_return(status: 200, body: wrap_resources_in_bundle([@observation]).to_json)
+
         @sequence.run_test(@test)
       end
     end
@@ -236,6 +249,12 @@ describe Inferno::Sequence::USCore310BodyheightSequence do
       @query = {
         'patient': @sequence.patient_ids.first,
         'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'category')),
+        'date': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'effective'))
+      }
+
+      @query_with_system = {
+        'patient': @sequence.patient_ids.first,
+        'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'category'), true),
         'date': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'effective'))
       }
     end
@@ -366,6 +385,11 @@ describe Inferno::Sequence::USCore310BodyheightSequence do
         'patient': @sequence.patient_ids.first,
         'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'category'))
       }
+
+      @query_with_system = {
+        'patient': @sequence.patient_ids.first,
+        'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'category'), true)
+      }
     end
 
     it 'skips if the search params are not supported' do
@@ -431,6 +455,10 @@ describe Inferno::Sequence::USCore310BodyheightSequence do
         .with(query: @query, headers: @auth_header)
         .to_return(status: 200, body: wrap_resources_in_bundle(@observation_ary.values.flatten).to_json)
 
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query_with_system, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@observation_ary.values.flatten).to_json)
+
       @sequence.run_test(@test)
     end
 
@@ -493,6 +521,10 @@ describe Inferno::Sequence::USCore310BodyheightSequence do
           .with(query: @query.merge('status': ['registered,preliminary,final,amended,corrected,cancelled,entered-in-error,unknown'].first), headers: @auth_header)
           .to_return(status: 200, body: wrap_resources_in_bundle([@observation]).to_json)
 
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query_with_system.merge('status': ['registered,preliminary,final,amended,corrected,cancelled,entered-in-error,unknown'].first), headers: @auth_header)
+          .to_return(status: 200, body: wrap_resources_in_bundle([@observation]).to_json)
+
         @sequence.run_test(@test)
       end
     end
@@ -512,6 +544,12 @@ describe Inferno::Sequence::USCore310BodyheightSequence do
       @query = {
         'patient': @sequence.patient_ids.first,
         'code': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'code')),
+        'date': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'effective'))
+      }
+
+      @query_with_system = {
+        'patient': @sequence.patient_ids.first,
+        'code': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'code'), true),
         'date': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'effective'))
       }
     end
@@ -643,6 +681,12 @@ describe Inferno::Sequence::USCore310BodyheightSequence do
         'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'category')),
         'status': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'status'))
       }
+
+      @query_with_system = {
+        'patient': @sequence.patient_ids.first,
+        'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'category'), true),
+        'status': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'status'))
+      }
     end
 
     it 'skips if the search params are not supported' do
@@ -706,6 +750,10 @@ describe Inferno::Sequence::USCore310BodyheightSequence do
     it 'succeeds when a bundle containing a valid resource matching the search parameters is returned' do
       stub_request(:get, "#{@base_url}/Observation")
         .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@observation_ary.values.flatten).to_json)
+
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query_with_system, headers: @auth_header)
         .to_return(status: 200, body: wrap_resources_in_bundle(@observation_ary.values.flatten).to_json)
 
       @sequence.run_test(@test)

--- a/lib/modules/uscore_v3.1.0/test/bodytemp_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/bodytemp_test.rb
@@ -30,6 +30,11 @@ describe Inferno::Sequence::USCore310BodytempSequence do
         'patient': @sequence.patient_ids.first,
         'code': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'code'))
       }
+
+      @query_with_system = {
+        'patient': @sequence.patient_ids.first,
+        'code': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'code'), true)
+      }
     end
 
     it 'skips if the search params are not supported' do
@@ -125,6 +130,10 @@ describe Inferno::Sequence::USCore310BodytempSequence do
           .to_return(status: 200, body: body)
       end
 
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query_with_system, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@observation_ary.values.flatten).to_json)
+
       @sequence.run_test(@test)
     end
 
@@ -217,6 +226,10 @@ describe Inferno::Sequence::USCore310BodytempSequence do
             .to_return(status: 200, body: wrap_resources_in_bundle([@observation]).to_json)
         end
 
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query_with_system.merge('status': ['registered,preliminary,final,amended,corrected,cancelled,entered-in-error,unknown'].first), headers: @auth_header)
+          .to_return(status: 200, body: wrap_resources_in_bundle([@observation]).to_json)
+
         @sequence.run_test(@test)
       end
     end
@@ -236,6 +249,12 @@ describe Inferno::Sequence::USCore310BodytempSequence do
       @query = {
         'patient': @sequence.patient_ids.first,
         'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'category')),
+        'date': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'effective'))
+      }
+
+      @query_with_system = {
+        'patient': @sequence.patient_ids.first,
+        'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'category'), true),
         'date': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'effective'))
       }
     end
@@ -366,6 +385,11 @@ describe Inferno::Sequence::USCore310BodytempSequence do
         'patient': @sequence.patient_ids.first,
         'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'category'))
       }
+
+      @query_with_system = {
+        'patient': @sequence.patient_ids.first,
+        'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'category'), true)
+      }
     end
 
     it 'skips if the search params are not supported' do
@@ -431,6 +455,10 @@ describe Inferno::Sequence::USCore310BodytempSequence do
         .with(query: @query, headers: @auth_header)
         .to_return(status: 200, body: wrap_resources_in_bundle(@observation_ary.values.flatten).to_json)
 
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query_with_system, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@observation_ary.values.flatten).to_json)
+
       @sequence.run_test(@test)
     end
 
@@ -493,6 +521,10 @@ describe Inferno::Sequence::USCore310BodytempSequence do
           .with(query: @query.merge('status': ['registered,preliminary,final,amended,corrected,cancelled,entered-in-error,unknown'].first), headers: @auth_header)
           .to_return(status: 200, body: wrap_resources_in_bundle([@observation]).to_json)
 
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query_with_system.merge('status': ['registered,preliminary,final,amended,corrected,cancelled,entered-in-error,unknown'].first), headers: @auth_header)
+          .to_return(status: 200, body: wrap_resources_in_bundle([@observation]).to_json)
+
         @sequence.run_test(@test)
       end
     end
@@ -512,6 +544,12 @@ describe Inferno::Sequence::USCore310BodytempSequence do
       @query = {
         'patient': @sequence.patient_ids.first,
         'code': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'code')),
+        'date': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'effective'))
+      }
+
+      @query_with_system = {
+        'patient': @sequence.patient_ids.first,
+        'code': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'code'), true),
         'date': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'effective'))
       }
     end
@@ -643,6 +681,12 @@ describe Inferno::Sequence::USCore310BodytempSequence do
         'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'category')),
         'status': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'status'))
       }
+
+      @query_with_system = {
+        'patient': @sequence.patient_ids.first,
+        'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'category'), true),
+        'status': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'status'))
+      }
     end
 
     it 'skips if the search params are not supported' do
@@ -706,6 +750,10 @@ describe Inferno::Sequence::USCore310BodytempSequence do
     it 'succeeds when a bundle containing a valid resource matching the search parameters is returned' do
       stub_request(:get, "#{@base_url}/Observation")
         .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@observation_ary.values.flatten).to_json)
+
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query_with_system, headers: @auth_header)
         .to_return(status: 200, body: wrap_resources_in_bundle(@observation_ary.values.flatten).to_json)
 
       @sequence.run_test(@test)

--- a/lib/modules/uscore_v3.1.0/test/bodyweight_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/bodyweight_test.rb
@@ -30,6 +30,11 @@ describe Inferno::Sequence::USCore310BodyweightSequence do
         'patient': @sequence.patient_ids.first,
         'code': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'code'))
       }
+
+      @query_with_system = {
+        'patient': @sequence.patient_ids.first,
+        'code': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'code'), true)
+      }
     end
 
     it 'skips if the search params are not supported' do
@@ -125,6 +130,10 @@ describe Inferno::Sequence::USCore310BodyweightSequence do
           .to_return(status: 200, body: body)
       end
 
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query_with_system, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@observation_ary.values.flatten).to_json)
+
       @sequence.run_test(@test)
     end
 
@@ -217,6 +226,10 @@ describe Inferno::Sequence::USCore310BodyweightSequence do
             .to_return(status: 200, body: wrap_resources_in_bundle([@observation]).to_json)
         end
 
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query_with_system.merge('status': ['registered,preliminary,final,amended,corrected,cancelled,entered-in-error,unknown'].first), headers: @auth_header)
+          .to_return(status: 200, body: wrap_resources_in_bundle([@observation]).to_json)
+
         @sequence.run_test(@test)
       end
     end
@@ -236,6 +249,12 @@ describe Inferno::Sequence::USCore310BodyweightSequence do
       @query = {
         'patient': @sequence.patient_ids.first,
         'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'category')),
+        'date': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'effective'))
+      }
+
+      @query_with_system = {
+        'patient': @sequence.patient_ids.first,
+        'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'category'), true),
         'date': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'effective'))
       }
     end
@@ -366,6 +385,11 @@ describe Inferno::Sequence::USCore310BodyweightSequence do
         'patient': @sequence.patient_ids.first,
         'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'category'))
       }
+
+      @query_with_system = {
+        'patient': @sequence.patient_ids.first,
+        'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'category'), true)
+      }
     end
 
     it 'skips if the search params are not supported' do
@@ -431,6 +455,10 @@ describe Inferno::Sequence::USCore310BodyweightSequence do
         .with(query: @query, headers: @auth_header)
         .to_return(status: 200, body: wrap_resources_in_bundle(@observation_ary.values.flatten).to_json)
 
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query_with_system, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@observation_ary.values.flatten).to_json)
+
       @sequence.run_test(@test)
     end
 
@@ -493,6 +521,10 @@ describe Inferno::Sequence::USCore310BodyweightSequence do
           .with(query: @query.merge('status': ['registered,preliminary,final,amended,corrected,cancelled,entered-in-error,unknown'].first), headers: @auth_header)
           .to_return(status: 200, body: wrap_resources_in_bundle([@observation]).to_json)
 
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query_with_system.merge('status': ['registered,preliminary,final,amended,corrected,cancelled,entered-in-error,unknown'].first), headers: @auth_header)
+          .to_return(status: 200, body: wrap_resources_in_bundle([@observation]).to_json)
+
         @sequence.run_test(@test)
       end
     end
@@ -512,6 +544,12 @@ describe Inferno::Sequence::USCore310BodyweightSequence do
       @query = {
         'patient': @sequence.patient_ids.first,
         'code': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'code')),
+        'date': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'effective'))
+      }
+
+      @query_with_system = {
+        'patient': @sequence.patient_ids.first,
+        'code': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'code'), true),
         'date': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'effective'))
       }
     end
@@ -643,6 +681,12 @@ describe Inferno::Sequence::USCore310BodyweightSequence do
         'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'category')),
         'status': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'status'))
       }
+
+      @query_with_system = {
+        'patient': @sequence.patient_ids.first,
+        'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'category'), true),
+        'status': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'status'))
+      }
     end
 
     it 'skips if the search params are not supported' do
@@ -706,6 +750,10 @@ describe Inferno::Sequence::USCore310BodyweightSequence do
     it 'succeeds when a bundle containing a valid resource matching the search parameters is returned' do
       stub_request(:get, "#{@base_url}/Observation")
         .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@observation_ary.values.flatten).to_json)
+
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query_with_system, headers: @auth_header)
         .to_return(status: 200, body: wrap_resources_in_bundle(@observation_ary.values.flatten).to_json)
 
       @sequence.run_test(@test)

--- a/lib/modules/uscore_v3.1.0/test/bp_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/bp_test.rb
@@ -30,6 +30,11 @@ describe Inferno::Sequence::USCore310BpSequence do
         'patient': @sequence.patient_ids.first,
         'code': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'code'))
       }
+
+      @query_with_system = {
+        'patient': @sequence.patient_ids.first,
+        'code': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'code'), true)
+      }
     end
 
     it 'skips if the search params are not supported' do
@@ -125,6 +130,10 @@ describe Inferno::Sequence::USCore310BpSequence do
           .to_return(status: 200, body: body)
       end
 
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query_with_system, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@observation_ary.values.flatten).to_json)
+
       @sequence.run_test(@test)
     end
 
@@ -217,6 +226,10 @@ describe Inferno::Sequence::USCore310BpSequence do
             .to_return(status: 200, body: wrap_resources_in_bundle([@observation]).to_json)
         end
 
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query_with_system.merge('status': ['registered,preliminary,final,amended,corrected,cancelled,entered-in-error,unknown'].first), headers: @auth_header)
+          .to_return(status: 200, body: wrap_resources_in_bundle([@observation]).to_json)
+
         @sequence.run_test(@test)
       end
     end
@@ -236,6 +249,12 @@ describe Inferno::Sequence::USCore310BpSequence do
       @query = {
         'patient': @sequence.patient_ids.first,
         'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'category')),
+        'date': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'effective'))
+      }
+
+      @query_with_system = {
+        'patient': @sequence.patient_ids.first,
+        'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'category'), true),
         'date': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'effective'))
       }
     end
@@ -366,6 +385,11 @@ describe Inferno::Sequence::USCore310BpSequence do
         'patient': @sequence.patient_ids.first,
         'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'category'))
       }
+
+      @query_with_system = {
+        'patient': @sequence.patient_ids.first,
+        'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'category'), true)
+      }
     end
 
     it 'skips if the search params are not supported' do
@@ -431,6 +455,10 @@ describe Inferno::Sequence::USCore310BpSequence do
         .with(query: @query, headers: @auth_header)
         .to_return(status: 200, body: wrap_resources_in_bundle(@observation_ary.values.flatten).to_json)
 
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query_with_system, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@observation_ary.values.flatten).to_json)
+
       @sequence.run_test(@test)
     end
 
@@ -493,6 +521,10 @@ describe Inferno::Sequence::USCore310BpSequence do
           .with(query: @query.merge('status': ['registered,preliminary,final,amended,corrected,cancelled,entered-in-error,unknown'].first), headers: @auth_header)
           .to_return(status: 200, body: wrap_resources_in_bundle([@observation]).to_json)
 
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query_with_system.merge('status': ['registered,preliminary,final,amended,corrected,cancelled,entered-in-error,unknown'].first), headers: @auth_header)
+          .to_return(status: 200, body: wrap_resources_in_bundle([@observation]).to_json)
+
         @sequence.run_test(@test)
       end
     end
@@ -512,6 +544,12 @@ describe Inferno::Sequence::USCore310BpSequence do
       @query = {
         'patient': @sequence.patient_ids.first,
         'code': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'code')),
+        'date': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'effective'))
+      }
+
+      @query_with_system = {
+        'patient': @sequence.patient_ids.first,
+        'code': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'code'), true),
         'date': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'effective'))
       }
     end
@@ -643,6 +681,12 @@ describe Inferno::Sequence::USCore310BpSequence do
         'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'category')),
         'status': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'status'))
       }
+
+      @query_with_system = {
+        'patient': @sequence.patient_ids.first,
+        'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'category'), true),
+        'status': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'status'))
+      }
     end
 
     it 'skips if the search params are not supported' do
@@ -706,6 +750,10 @@ describe Inferno::Sequence::USCore310BpSequence do
     it 'succeeds when a bundle containing a valid resource matching the search parameters is returned' do
       stub_request(:get, "#{@base_url}/Observation")
         .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@observation_ary.values.flatten).to_json)
+
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query_with_system, headers: @auth_header)
         .to_return(status: 200, body: wrap_resources_in_bundle(@observation_ary.values.flatten).to_json)
 
       @sequence.run_test(@test)

--- a/lib/modules/uscore_v3.1.0/test/headcircum_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/headcircum_test.rb
@@ -30,6 +30,11 @@ describe Inferno::Sequence::USCore310HeadcircumSequence do
         'patient': @sequence.patient_ids.first,
         'code': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'code'))
       }
+
+      @query_with_system = {
+        'patient': @sequence.patient_ids.first,
+        'code': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'code'), true)
+      }
     end
 
     it 'skips if the search params are not supported' do
@@ -125,6 +130,10 @@ describe Inferno::Sequence::USCore310HeadcircumSequence do
           .to_return(status: 200, body: body)
       end
 
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query_with_system, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@observation_ary.values.flatten).to_json)
+
       @sequence.run_test(@test)
     end
 
@@ -217,6 +226,10 @@ describe Inferno::Sequence::USCore310HeadcircumSequence do
             .to_return(status: 200, body: wrap_resources_in_bundle([@observation]).to_json)
         end
 
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query_with_system.merge('status': ['registered,preliminary,final,amended,corrected,cancelled,entered-in-error,unknown'].first), headers: @auth_header)
+          .to_return(status: 200, body: wrap_resources_in_bundle([@observation]).to_json)
+
         @sequence.run_test(@test)
       end
     end
@@ -236,6 +249,12 @@ describe Inferno::Sequence::USCore310HeadcircumSequence do
       @query = {
         'patient': @sequence.patient_ids.first,
         'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'category')),
+        'date': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'effective'))
+      }
+
+      @query_with_system = {
+        'patient': @sequence.patient_ids.first,
+        'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'category'), true),
         'date': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'effective'))
       }
     end
@@ -366,6 +385,11 @@ describe Inferno::Sequence::USCore310HeadcircumSequence do
         'patient': @sequence.patient_ids.first,
         'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'category'))
       }
+
+      @query_with_system = {
+        'patient': @sequence.patient_ids.first,
+        'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'category'), true)
+      }
     end
 
     it 'skips if the search params are not supported' do
@@ -431,6 +455,10 @@ describe Inferno::Sequence::USCore310HeadcircumSequence do
         .with(query: @query, headers: @auth_header)
         .to_return(status: 200, body: wrap_resources_in_bundle(@observation_ary.values.flatten).to_json)
 
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query_with_system, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@observation_ary.values.flatten).to_json)
+
       @sequence.run_test(@test)
     end
 
@@ -493,6 +521,10 @@ describe Inferno::Sequence::USCore310HeadcircumSequence do
           .with(query: @query.merge('status': ['registered,preliminary,final,amended,corrected,cancelled,entered-in-error,unknown'].first), headers: @auth_header)
           .to_return(status: 200, body: wrap_resources_in_bundle([@observation]).to_json)
 
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query_with_system.merge('status': ['registered,preliminary,final,amended,corrected,cancelled,entered-in-error,unknown'].first), headers: @auth_header)
+          .to_return(status: 200, body: wrap_resources_in_bundle([@observation]).to_json)
+
         @sequence.run_test(@test)
       end
     end
@@ -512,6 +544,12 @@ describe Inferno::Sequence::USCore310HeadcircumSequence do
       @query = {
         'patient': @sequence.patient_ids.first,
         'code': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'code')),
+        'date': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'effective'))
+      }
+
+      @query_with_system = {
+        'patient': @sequence.patient_ids.first,
+        'code': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'code'), true),
         'date': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'effective'))
       }
     end
@@ -643,6 +681,12 @@ describe Inferno::Sequence::USCore310HeadcircumSequence do
         'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'category')),
         'status': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'status'))
       }
+
+      @query_with_system = {
+        'patient': @sequence.patient_ids.first,
+        'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'category'), true),
+        'status': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'status'))
+      }
     end
 
     it 'skips if the search params are not supported' do
@@ -706,6 +750,10 @@ describe Inferno::Sequence::USCore310HeadcircumSequence do
     it 'succeeds when a bundle containing a valid resource matching the search parameters is returned' do
       stub_request(:get, "#{@base_url}/Observation")
         .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@observation_ary.values.flatten).to_json)
+
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query_with_system, headers: @auth_header)
         .to_return(status: 200, body: wrap_resources_in_bundle(@observation_ary.values.flatten).to_json)
 
       @sequence.run_test(@test)

--- a/lib/modules/uscore_v3.1.0/test/heartrate_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/heartrate_test.rb
@@ -30,6 +30,11 @@ describe Inferno::Sequence::USCore310HeartrateSequence do
         'patient': @sequence.patient_ids.first,
         'code': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'code'))
       }
+
+      @query_with_system = {
+        'patient': @sequence.patient_ids.first,
+        'code': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'code'), true)
+      }
     end
 
     it 'skips if the search params are not supported' do
@@ -125,6 +130,10 @@ describe Inferno::Sequence::USCore310HeartrateSequence do
           .to_return(status: 200, body: body)
       end
 
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query_with_system, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@observation_ary.values.flatten).to_json)
+
       @sequence.run_test(@test)
     end
 
@@ -217,6 +226,10 @@ describe Inferno::Sequence::USCore310HeartrateSequence do
             .to_return(status: 200, body: wrap_resources_in_bundle([@observation]).to_json)
         end
 
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query_with_system.merge('status': ['registered,preliminary,final,amended,corrected,cancelled,entered-in-error,unknown'].first), headers: @auth_header)
+          .to_return(status: 200, body: wrap_resources_in_bundle([@observation]).to_json)
+
         @sequence.run_test(@test)
       end
     end
@@ -236,6 +249,12 @@ describe Inferno::Sequence::USCore310HeartrateSequence do
       @query = {
         'patient': @sequence.patient_ids.first,
         'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'category')),
+        'date': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'effective'))
+      }
+
+      @query_with_system = {
+        'patient': @sequence.patient_ids.first,
+        'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'category'), true),
         'date': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'effective'))
       }
     end
@@ -366,6 +385,11 @@ describe Inferno::Sequence::USCore310HeartrateSequence do
         'patient': @sequence.patient_ids.first,
         'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'category'))
       }
+
+      @query_with_system = {
+        'patient': @sequence.patient_ids.first,
+        'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'category'), true)
+      }
     end
 
     it 'skips if the search params are not supported' do
@@ -431,6 +455,10 @@ describe Inferno::Sequence::USCore310HeartrateSequence do
         .with(query: @query, headers: @auth_header)
         .to_return(status: 200, body: wrap_resources_in_bundle(@observation_ary.values.flatten).to_json)
 
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query_with_system, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@observation_ary.values.flatten).to_json)
+
       @sequence.run_test(@test)
     end
 
@@ -493,6 +521,10 @@ describe Inferno::Sequence::USCore310HeartrateSequence do
           .with(query: @query.merge('status': ['registered,preliminary,final,amended,corrected,cancelled,entered-in-error,unknown'].first), headers: @auth_header)
           .to_return(status: 200, body: wrap_resources_in_bundle([@observation]).to_json)
 
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query_with_system.merge('status': ['registered,preliminary,final,amended,corrected,cancelled,entered-in-error,unknown'].first), headers: @auth_header)
+          .to_return(status: 200, body: wrap_resources_in_bundle([@observation]).to_json)
+
         @sequence.run_test(@test)
       end
     end
@@ -512,6 +544,12 @@ describe Inferno::Sequence::USCore310HeartrateSequence do
       @query = {
         'patient': @sequence.patient_ids.first,
         'code': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'code')),
+        'date': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'effective'))
+      }
+
+      @query_with_system = {
+        'patient': @sequence.patient_ids.first,
+        'code': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'code'), true),
         'date': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'effective'))
       }
     end
@@ -643,6 +681,12 @@ describe Inferno::Sequence::USCore310HeartrateSequence do
         'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'category')),
         'status': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'status'))
       }
+
+      @query_with_system = {
+        'patient': @sequence.patient_ids.first,
+        'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'category'), true),
+        'status': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'status'))
+      }
     end
 
     it 'skips if the search params are not supported' do
@@ -706,6 +750,10 @@ describe Inferno::Sequence::USCore310HeartrateSequence do
     it 'succeeds when a bundle containing a valid resource matching the search parameters is returned' do
       stub_request(:get, "#{@base_url}/Observation")
         .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@observation_ary.values.flatten).to_json)
+
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query_with_system, headers: @auth_header)
         .to_return(status: 200, body: wrap_resources_in_bundle(@observation_ary.values.flatten).to_json)
 
       @sequence.run_test(@test)

--- a/lib/modules/uscore_v3.1.0/test/pediatric_bmi_for_age_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/pediatric_bmi_for_age_test.rb
@@ -30,6 +30,11 @@ describe Inferno::Sequence::USCore310PediatricBmiForAgeSequence do
         'patient': @sequence.patient_ids.first,
         'code': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'code'))
       }
+
+      @query_with_system = {
+        'patient': @sequence.patient_ids.first,
+        'code': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'code'), true)
+      }
     end
 
     it 'skips if the search params are not supported' do
@@ -125,6 +130,10 @@ describe Inferno::Sequence::USCore310PediatricBmiForAgeSequence do
           .to_return(status: 200, body: body)
       end
 
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query_with_system, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@observation_ary.values.flatten).to_json)
+
       @sequence.run_test(@test)
     end
 
@@ -217,6 +226,10 @@ describe Inferno::Sequence::USCore310PediatricBmiForAgeSequence do
             .to_return(status: 200, body: wrap_resources_in_bundle([@observation]).to_json)
         end
 
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query_with_system.merge('status': ['registered,preliminary,final,amended,corrected,cancelled,entered-in-error,unknown'].first), headers: @auth_header)
+          .to_return(status: 200, body: wrap_resources_in_bundle([@observation]).to_json)
+
         @sequence.run_test(@test)
       end
     end
@@ -236,6 +249,12 @@ describe Inferno::Sequence::USCore310PediatricBmiForAgeSequence do
       @query = {
         'patient': @sequence.patient_ids.first,
         'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'category')),
+        'date': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'effective'))
+      }
+
+      @query_with_system = {
+        'patient': @sequence.patient_ids.first,
+        'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'category'), true),
         'date': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'effective'))
       }
     end
@@ -366,6 +385,11 @@ describe Inferno::Sequence::USCore310PediatricBmiForAgeSequence do
         'patient': @sequence.patient_ids.first,
         'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'category'))
       }
+
+      @query_with_system = {
+        'patient': @sequence.patient_ids.first,
+        'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'category'), true)
+      }
     end
 
     it 'skips if the search params are not supported' do
@@ -431,6 +455,10 @@ describe Inferno::Sequence::USCore310PediatricBmiForAgeSequence do
         .with(query: @query, headers: @auth_header)
         .to_return(status: 200, body: wrap_resources_in_bundle(@observation_ary.values.flatten).to_json)
 
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query_with_system, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@observation_ary.values.flatten).to_json)
+
       @sequence.run_test(@test)
     end
 
@@ -493,6 +521,10 @@ describe Inferno::Sequence::USCore310PediatricBmiForAgeSequence do
           .with(query: @query.merge('status': ['registered,preliminary,final,amended,corrected,cancelled,entered-in-error,unknown'].first), headers: @auth_header)
           .to_return(status: 200, body: wrap_resources_in_bundle([@observation]).to_json)
 
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query_with_system.merge('status': ['registered,preliminary,final,amended,corrected,cancelled,entered-in-error,unknown'].first), headers: @auth_header)
+          .to_return(status: 200, body: wrap_resources_in_bundle([@observation]).to_json)
+
         @sequence.run_test(@test)
       end
     end
@@ -512,6 +544,12 @@ describe Inferno::Sequence::USCore310PediatricBmiForAgeSequence do
       @query = {
         'patient': @sequence.patient_ids.first,
         'code': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'code')),
+        'date': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'effective'))
+      }
+
+      @query_with_system = {
+        'patient': @sequence.patient_ids.first,
+        'code': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'code'), true),
         'date': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'effective'))
       }
     end
@@ -643,6 +681,12 @@ describe Inferno::Sequence::USCore310PediatricBmiForAgeSequence do
         'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'category')),
         'status': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'status'))
       }
+
+      @query_with_system = {
+        'patient': @sequence.patient_ids.first,
+        'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'category'), true),
+        'status': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'status'))
+      }
     end
 
     it 'skips if the search params are not supported' do
@@ -706,6 +750,10 @@ describe Inferno::Sequence::USCore310PediatricBmiForAgeSequence do
     it 'succeeds when a bundle containing a valid resource matching the search parameters is returned' do
       stub_request(:get, "#{@base_url}/Observation")
         .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@observation_ary.values.flatten).to_json)
+
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query_with_system, headers: @auth_header)
         .to_return(status: 200, body: wrap_resources_in_bundle(@observation_ary.values.flatten).to_json)
 
       @sequence.run_test(@test)

--- a/lib/modules/uscore_v3.1.0/test/pediatric_weight_for_height_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/pediatric_weight_for_height_test.rb
@@ -30,6 +30,11 @@ describe Inferno::Sequence::USCore310PediatricWeightForHeightSequence do
         'patient': @sequence.patient_ids.first,
         'code': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'code'))
       }
+
+      @query_with_system = {
+        'patient': @sequence.patient_ids.first,
+        'code': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'code'), true)
+      }
     end
 
     it 'skips if the search params are not supported' do
@@ -125,6 +130,10 @@ describe Inferno::Sequence::USCore310PediatricWeightForHeightSequence do
           .to_return(status: 200, body: body)
       end
 
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query_with_system, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@observation_ary.values.flatten).to_json)
+
       @sequence.run_test(@test)
     end
 
@@ -217,6 +226,10 @@ describe Inferno::Sequence::USCore310PediatricWeightForHeightSequence do
             .to_return(status: 200, body: wrap_resources_in_bundle([@observation]).to_json)
         end
 
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query_with_system.merge('status': ['registered,preliminary,final,amended,corrected,cancelled,entered-in-error,unknown'].first), headers: @auth_header)
+          .to_return(status: 200, body: wrap_resources_in_bundle([@observation]).to_json)
+
         @sequence.run_test(@test)
       end
     end
@@ -236,6 +249,12 @@ describe Inferno::Sequence::USCore310PediatricWeightForHeightSequence do
       @query = {
         'patient': @sequence.patient_ids.first,
         'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'category')),
+        'date': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'effective'))
+      }
+
+      @query_with_system = {
+        'patient': @sequence.patient_ids.first,
+        'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'category'), true),
         'date': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'effective'))
       }
     end
@@ -366,6 +385,11 @@ describe Inferno::Sequence::USCore310PediatricWeightForHeightSequence do
         'patient': @sequence.patient_ids.first,
         'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'category'))
       }
+
+      @query_with_system = {
+        'patient': @sequence.patient_ids.first,
+        'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'category'), true)
+      }
     end
 
     it 'skips if the search params are not supported' do
@@ -431,6 +455,10 @@ describe Inferno::Sequence::USCore310PediatricWeightForHeightSequence do
         .with(query: @query, headers: @auth_header)
         .to_return(status: 200, body: wrap_resources_in_bundle(@observation_ary.values.flatten).to_json)
 
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query_with_system, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@observation_ary.values.flatten).to_json)
+
       @sequence.run_test(@test)
     end
 
@@ -493,6 +521,10 @@ describe Inferno::Sequence::USCore310PediatricWeightForHeightSequence do
           .with(query: @query.merge('status': ['registered,preliminary,final,amended,corrected,cancelled,entered-in-error,unknown'].first), headers: @auth_header)
           .to_return(status: 200, body: wrap_resources_in_bundle([@observation]).to_json)
 
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query_with_system.merge('status': ['registered,preliminary,final,amended,corrected,cancelled,entered-in-error,unknown'].first), headers: @auth_header)
+          .to_return(status: 200, body: wrap_resources_in_bundle([@observation]).to_json)
+
         @sequence.run_test(@test)
       end
     end
@@ -512,6 +544,12 @@ describe Inferno::Sequence::USCore310PediatricWeightForHeightSequence do
       @query = {
         'patient': @sequence.patient_ids.first,
         'code': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'code')),
+        'date': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'effective'))
+      }
+
+      @query_with_system = {
+        'patient': @sequence.patient_ids.first,
+        'code': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'code'), true),
         'date': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'effective'))
       }
     end
@@ -643,6 +681,12 @@ describe Inferno::Sequence::USCore310PediatricWeightForHeightSequence do
         'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'category')),
         'status': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'status'))
       }
+
+      @query_with_system = {
+        'patient': @sequence.patient_ids.first,
+        'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'category'), true),
+        'status': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'status'))
+      }
     end
 
     it 'skips if the search params are not supported' do
@@ -706,6 +750,10 @@ describe Inferno::Sequence::USCore310PediatricWeightForHeightSequence do
     it 'succeeds when a bundle containing a valid resource matching the search parameters is returned' do
       stub_request(:get, "#{@base_url}/Observation")
         .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@observation_ary.values.flatten).to_json)
+
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query_with_system, headers: @auth_header)
         .to_return(status: 200, body: wrap_resources_in_bundle(@observation_ary.values.flatten).to_json)
 
       @sequence.run_test(@test)

--- a/lib/modules/uscore_v3.1.0/test/resprate_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/resprate_test.rb
@@ -30,6 +30,11 @@ describe Inferno::Sequence::USCore310ResprateSequence do
         'patient': @sequence.patient_ids.first,
         'code': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'code'))
       }
+
+      @query_with_system = {
+        'patient': @sequence.patient_ids.first,
+        'code': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'code'), true)
+      }
     end
 
     it 'skips if the search params are not supported' do
@@ -125,6 +130,10 @@ describe Inferno::Sequence::USCore310ResprateSequence do
           .to_return(status: 200, body: body)
       end
 
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query_with_system, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@observation_ary.values.flatten).to_json)
+
       @sequence.run_test(@test)
     end
 
@@ -217,6 +226,10 @@ describe Inferno::Sequence::USCore310ResprateSequence do
             .to_return(status: 200, body: wrap_resources_in_bundle([@observation]).to_json)
         end
 
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query_with_system.merge('status': ['registered,preliminary,final,amended,corrected,cancelled,entered-in-error,unknown'].first), headers: @auth_header)
+          .to_return(status: 200, body: wrap_resources_in_bundle([@observation]).to_json)
+
         @sequence.run_test(@test)
       end
     end
@@ -236,6 +249,12 @@ describe Inferno::Sequence::USCore310ResprateSequence do
       @query = {
         'patient': @sequence.patient_ids.first,
         'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'category')),
+        'date': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'effective'))
+      }
+
+      @query_with_system = {
+        'patient': @sequence.patient_ids.first,
+        'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'category'), true),
         'date': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'effective'))
       }
     end
@@ -366,6 +385,11 @@ describe Inferno::Sequence::USCore310ResprateSequence do
         'patient': @sequence.patient_ids.first,
         'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'category'))
       }
+
+      @query_with_system = {
+        'patient': @sequence.patient_ids.first,
+        'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'category'), true)
+      }
     end
 
     it 'skips if the search params are not supported' do
@@ -431,6 +455,10 @@ describe Inferno::Sequence::USCore310ResprateSequence do
         .with(query: @query, headers: @auth_header)
         .to_return(status: 200, body: wrap_resources_in_bundle(@observation_ary.values.flatten).to_json)
 
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query_with_system, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@observation_ary.values.flatten).to_json)
+
       @sequence.run_test(@test)
     end
 
@@ -493,6 +521,10 @@ describe Inferno::Sequence::USCore310ResprateSequence do
           .with(query: @query.merge('status': ['registered,preliminary,final,amended,corrected,cancelled,entered-in-error,unknown'].first), headers: @auth_header)
           .to_return(status: 200, body: wrap_resources_in_bundle([@observation]).to_json)
 
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query_with_system.merge('status': ['registered,preliminary,final,amended,corrected,cancelled,entered-in-error,unknown'].first), headers: @auth_header)
+          .to_return(status: 200, body: wrap_resources_in_bundle([@observation]).to_json)
+
         @sequence.run_test(@test)
       end
     end
@@ -512,6 +544,12 @@ describe Inferno::Sequence::USCore310ResprateSequence do
       @query = {
         'patient': @sequence.patient_ids.first,
         'code': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'code')),
+        'date': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'effective'))
+      }
+
+      @query_with_system = {
+        'patient': @sequence.patient_ids.first,
+        'code': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'code'), true),
         'date': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'effective'))
       }
     end
@@ -643,6 +681,12 @@ describe Inferno::Sequence::USCore310ResprateSequence do
         'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'category')),
         'status': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'status'))
       }
+
+      @query_with_system = {
+        'patient': @sequence.patient_ids.first,
+        'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'category'), true),
+        'status': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'status'))
+      }
     end
 
     it 'skips if the search params are not supported' do
@@ -706,6 +750,10 @@ describe Inferno::Sequence::USCore310ResprateSequence do
     it 'succeeds when a bundle containing a valid resource matching the search parameters is returned' do
       stub_request(:get, "#{@base_url}/Observation")
         .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@observation_ary.values.flatten).to_json)
+
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query_with_system, headers: @auth_header)
         .to_return(status: 200, body: wrap_resources_in_bundle(@observation_ary.values.flatten).to_json)
 
       @sequence.run_test(@test)

--- a/lib/modules/uscore_v3.1.0/test/us_core_allergyintolerance_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_allergyintolerance_test.rb
@@ -170,6 +170,11 @@ describe Inferno::Sequence::USCore310AllergyintoleranceSequence do
         'patient': @sequence.patient_ids.first,
         'clinical-status': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@allergy_intolerance_ary[@sequence.patient_ids.first], 'clinicalStatus'))
       }
+
+      @query_with_system = {
+        'patient': @sequence.patient_ids.first,
+        'clinical-status': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@allergy_intolerance_ary[@sequence.patient_ids.first], 'clinicalStatus'), true)
+      }
     end
 
     it 'skips if the search params are not supported' do
@@ -233,6 +238,10 @@ describe Inferno::Sequence::USCore310AllergyintoleranceSequence do
     it 'succeeds when a bundle containing a valid resource matching the search parameters is returned' do
       stub_request(:get, "#{@base_url}/AllergyIntolerance")
         .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@allergy_intolerance_ary.values.flatten).to_json)
+
+      stub_request(:get, "#{@base_url}/AllergyIntolerance")
+        .with(query: @query_with_system, headers: @auth_header)
         .to_return(status: 200, body: wrap_resources_in_bundle(@allergy_intolerance_ary.values.flatten).to_json)
 
       @sequence.run_test(@test)

--- a/lib/modules/uscore_v3.1.0/test/us_core_careplan_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_careplan_test.rb
@@ -30,6 +30,11 @@ describe Inferno::Sequence::USCore310CareplanSequence do
         'patient': @sequence.patient_ids.first,
         'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@care_plan_ary[@sequence.patient_ids.first], 'category'))
       }
+
+      @query_with_system = {
+        'patient': @sequence.patient_ids.first,
+        'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@care_plan_ary[@sequence.patient_ids.first], 'category'), true)
+      }
     end
 
     it 'skips if the search params are not supported' do
@@ -125,6 +130,10 @@ describe Inferno::Sequence::USCore310CareplanSequence do
           .to_return(status: 200, body: body)
       end
 
+      stub_request(:get, "#{@base_url}/CarePlan")
+        .with(query: @query_with_system, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@care_plan_ary.values.flatten).to_json)
+
       @sequence.run_test(@test)
     end
 
@@ -217,6 +226,10 @@ describe Inferno::Sequence::USCore310CareplanSequence do
             .to_return(status: 200, body: wrap_resources_in_bundle([@care_plan]).to_json)
         end
 
+        stub_request(:get, "#{@base_url}/CarePlan")
+          .with(query: @query_with_system.merge('status': ['draft,active,on-hold,revoked,completed,entered-in-error,unknown'].first), headers: @auth_header)
+          .to_return(status: 200, body: wrap_resources_in_bundle([@care_plan]).to_json)
+
         @sequence.run_test(@test)
       end
     end
@@ -236,6 +249,12 @@ describe Inferno::Sequence::USCore310CareplanSequence do
       @query = {
         'patient': @sequence.patient_ids.first,
         'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@care_plan_ary[@sequence.patient_ids.first], 'category')),
+        'date': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@care_plan_ary[@sequence.patient_ids.first], 'period'))
+      }
+
+      @query_with_system = {
+        'patient': @sequence.patient_ids.first,
+        'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@care_plan_ary[@sequence.patient_ids.first], 'category'), true),
         'date': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@care_plan_ary[@sequence.patient_ids.first], 'period'))
       }
     end
@@ -368,6 +387,13 @@ describe Inferno::Sequence::USCore310CareplanSequence do
         'status': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@care_plan_ary[@sequence.patient_ids.first], 'status')),
         'date': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@care_plan_ary[@sequence.patient_ids.first], 'period'))
       }
+
+      @query_with_system = {
+        'patient': @sequence.patient_ids.first,
+        'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@care_plan_ary[@sequence.patient_ids.first], 'category'), true),
+        'status': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@care_plan_ary[@sequence.patient_ids.first], 'status')),
+        'date': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@care_plan_ary[@sequence.patient_ids.first], 'period'))
+      }
     end
 
     it 'skips if the search params are not supported' do
@@ -445,6 +471,12 @@ describe Inferno::Sequence::USCore310CareplanSequence do
         'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@care_plan_ary[@sequence.patient_ids.first], 'category')),
         'status': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@care_plan_ary[@sequence.patient_ids.first], 'status'))
       }
+
+      @query_with_system = {
+        'patient': @sequence.patient_ids.first,
+        'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@care_plan_ary[@sequence.patient_ids.first], 'category'), true),
+        'status': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@care_plan_ary[@sequence.patient_ids.first], 'status'))
+      }
     end
 
     it 'skips if the search params are not supported' do
@@ -508,6 +540,10 @@ describe Inferno::Sequence::USCore310CareplanSequence do
     it 'succeeds when a bundle containing a valid resource matching the search parameters is returned' do
       stub_request(:get, "#{@base_url}/CarePlan")
         .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@care_plan_ary.values.flatten).to_json)
+
+      stub_request(:get, "#{@base_url}/CarePlan")
+        .with(query: @query_with_system, headers: @auth_header)
         .to_return(status: 200, body: wrap_resources_in_bundle(@care_plan_ary.values.flatten).to_json)
 
       @sequence.run_test(@test)

--- a/lib/modules/uscore_v3.1.0/test/us_core_diagnosticreport_lab_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_diagnosticreport_lab_test.rb
@@ -30,6 +30,11 @@ describe Inferno::Sequence::USCore310DiagnosticreportLabSequence do
         'patient': @sequence.patient_ids.first,
         'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@diagnostic_report_ary[@sequence.patient_ids.first], 'category'))
       }
+
+      @query_with_system = {
+        'patient': @sequence.patient_ids.first,
+        'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@diagnostic_report_ary[@sequence.patient_ids.first], 'category'), true)
+      }
     end
 
     it 'skips if the search params are not supported' do
@@ -125,6 +130,10 @@ describe Inferno::Sequence::USCore310DiagnosticreportLabSequence do
           .to_return(status: 200, body: body)
       end
 
+      stub_request(:get, "#{@base_url}/DiagnosticReport")
+        .with(query: @query_with_system, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@diagnostic_report_ary.values.flatten).to_json)
+
       @sequence.run_test(@test)
     end
 
@@ -216,6 +225,10 @@ describe Inferno::Sequence::USCore310DiagnosticreportLabSequence do
             .with(query: query_params.merge('status': ['registered,partial,preliminary,final,amended,corrected,appended,cancelled,entered-in-error,unknown'].first), headers: @auth_header)
             .to_return(status: 200, body: wrap_resources_in_bundle([@diagnostic_report]).to_json)
         end
+
+        stub_request(:get, "#{@base_url}/DiagnosticReport")
+          .with(query: @query_with_system.merge('status': ['registered,partial,preliminary,final,amended,corrected,appended,cancelled,entered-in-error,unknown'].first), headers: @auth_header)
+          .to_return(status: 200, body: wrap_resources_in_bundle([@diagnostic_report]).to_json)
 
         @sequence.run_test(@test)
       end
@@ -375,6 +388,11 @@ describe Inferno::Sequence::USCore310DiagnosticreportLabSequence do
         'patient': @sequence.patient_ids.first,
         'code': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@diagnostic_report_ary[@sequence.patient_ids.first], 'code'))
       }
+
+      @query_with_system = {
+        'patient': @sequence.patient_ids.first,
+        'code': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@diagnostic_report_ary[@sequence.patient_ids.first], 'code'), true)
+      }
     end
 
     it 'skips if the search params are not supported' do
@@ -440,6 +458,10 @@ describe Inferno::Sequence::USCore310DiagnosticreportLabSequence do
         .with(query: @query, headers: @auth_header)
         .to_return(status: 200, body: wrap_resources_in_bundle(@diagnostic_report_ary.values.flatten).to_json)
 
+      stub_request(:get, "#{@base_url}/DiagnosticReport")
+        .with(query: @query_with_system, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@diagnostic_report_ary.values.flatten).to_json)
+
       @sequence.run_test(@test)
     end
 
@@ -502,6 +524,10 @@ describe Inferno::Sequence::USCore310DiagnosticreportLabSequence do
           .with(query: @query.merge('status': ['registered,partial,preliminary,final,amended,corrected,appended,cancelled,entered-in-error,unknown'].first), headers: @auth_header)
           .to_return(status: 200, body: wrap_resources_in_bundle([@diagnostic_report]).to_json)
 
+        stub_request(:get, "#{@base_url}/DiagnosticReport")
+          .with(query: @query_with_system.merge('status': ['registered,partial,preliminary,final,amended,corrected,appended,cancelled,entered-in-error,unknown'].first), headers: @auth_header)
+          .to_return(status: 200, body: wrap_resources_in_bundle([@diagnostic_report]).to_json)
+
         @sequence.run_test(@test)
       end
     end
@@ -521,6 +547,12 @@ describe Inferno::Sequence::USCore310DiagnosticreportLabSequence do
       @query = {
         'patient': @sequence.patient_ids.first,
         'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@diagnostic_report_ary[@sequence.patient_ids.first], 'category')),
+        'date': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@diagnostic_report_ary[@sequence.patient_ids.first], 'effective'))
+      }
+
+      @query_with_system = {
+        'patient': @sequence.patient_ids.first,
+        'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@diagnostic_report_ary[@sequence.patient_ids.first], 'category'), true),
         'date': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@diagnostic_report_ary[@sequence.patient_ids.first], 'effective'))
       }
     end
@@ -734,6 +766,12 @@ describe Inferno::Sequence::USCore310DiagnosticreportLabSequence do
       @query = {
         'patient': @sequence.patient_ids.first,
         'code': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@diagnostic_report_ary[@sequence.patient_ids.first], 'code')),
+        'date': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@diagnostic_report_ary[@sequence.patient_ids.first], 'effective'))
+      }
+
+      @query_with_system = {
+        'patient': @sequence.patient_ids.first,
+        'code': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@diagnostic_report_ary[@sequence.patient_ids.first], 'code'), true),
         'date': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@diagnostic_report_ary[@sequence.patient_ids.first], 'effective'))
       }
     end

--- a/lib/modules/uscore_v3.1.0/test/us_core_diagnosticreport_note_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_diagnosticreport_note_test.rb
@@ -30,6 +30,11 @@ describe Inferno::Sequence::USCore310DiagnosticreportNoteSequence do
         'patient': @sequence.patient_ids.first,
         'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@diagnostic_report_ary[@sequence.patient_ids.first], 'category'))
       }
+
+      @query_with_system = {
+        'patient': @sequence.patient_ids.first,
+        'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@diagnostic_report_ary[@sequence.patient_ids.first], 'category'), true)
+      }
     end
 
     it 'skips if the search params are not supported' do
@@ -125,6 +130,10 @@ describe Inferno::Sequence::USCore310DiagnosticreportNoteSequence do
           .to_return(status: 200, body: body)
       end
 
+      stub_request(:get, "#{@base_url}/DiagnosticReport")
+        .with(query: @query_with_system, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@diagnostic_report_ary.values.flatten).to_json)
+
       @sequence.run_test(@test)
     end
 
@@ -216,6 +225,10 @@ describe Inferno::Sequence::USCore310DiagnosticreportNoteSequence do
             .with(query: query_params.merge('status': ['registered,partial,preliminary,final,amended,corrected,appended,cancelled,entered-in-error,unknown'].first), headers: @auth_header)
             .to_return(status: 200, body: wrap_resources_in_bundle([@diagnostic_report]).to_json)
         end
+
+        stub_request(:get, "#{@base_url}/DiagnosticReport")
+          .with(query: @query_with_system.merge('status': ['registered,partial,preliminary,final,amended,corrected,appended,cancelled,entered-in-error,unknown'].first), headers: @auth_header)
+          .to_return(status: 200, body: wrap_resources_in_bundle([@diagnostic_report]).to_json)
 
         @sequence.run_test(@test)
       end
@@ -375,6 +388,11 @@ describe Inferno::Sequence::USCore310DiagnosticreportNoteSequence do
         'patient': @sequence.patient_ids.first,
         'code': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@diagnostic_report_ary[@sequence.patient_ids.first], 'code'))
       }
+
+      @query_with_system = {
+        'patient': @sequence.patient_ids.first,
+        'code': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@diagnostic_report_ary[@sequence.patient_ids.first], 'code'), true)
+      }
     end
 
     it 'skips if the search params are not supported' do
@@ -440,6 +458,10 @@ describe Inferno::Sequence::USCore310DiagnosticreportNoteSequence do
         .with(query: @query, headers: @auth_header)
         .to_return(status: 200, body: wrap_resources_in_bundle(@diagnostic_report_ary.values.flatten).to_json)
 
+      stub_request(:get, "#{@base_url}/DiagnosticReport")
+        .with(query: @query_with_system, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@diagnostic_report_ary.values.flatten).to_json)
+
       @sequence.run_test(@test)
     end
 
@@ -502,6 +524,10 @@ describe Inferno::Sequence::USCore310DiagnosticreportNoteSequence do
           .with(query: @query.merge('status': ['registered,partial,preliminary,final,amended,corrected,appended,cancelled,entered-in-error,unknown'].first), headers: @auth_header)
           .to_return(status: 200, body: wrap_resources_in_bundle([@diagnostic_report]).to_json)
 
+        stub_request(:get, "#{@base_url}/DiagnosticReport")
+          .with(query: @query_with_system.merge('status': ['registered,partial,preliminary,final,amended,corrected,appended,cancelled,entered-in-error,unknown'].first), headers: @auth_header)
+          .to_return(status: 200, body: wrap_resources_in_bundle([@diagnostic_report]).to_json)
+
         @sequence.run_test(@test)
       end
     end
@@ -521,6 +547,12 @@ describe Inferno::Sequence::USCore310DiagnosticreportNoteSequence do
       @query = {
         'patient': @sequence.patient_ids.first,
         'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@diagnostic_report_ary[@sequence.patient_ids.first], 'category')),
+        'date': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@diagnostic_report_ary[@sequence.patient_ids.first], 'effective'))
+      }
+
+      @query_with_system = {
+        'patient': @sequence.patient_ids.first,
+        'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@diagnostic_report_ary[@sequence.patient_ids.first], 'category'), true),
         'date': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@diagnostic_report_ary[@sequence.patient_ids.first], 'effective'))
       }
     end
@@ -734,6 +766,12 @@ describe Inferno::Sequence::USCore310DiagnosticreportNoteSequence do
       @query = {
         'patient': @sequence.patient_ids.first,
         'code': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@diagnostic_report_ary[@sequence.patient_ids.first], 'code')),
+        'date': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@diagnostic_report_ary[@sequence.patient_ids.first], 'effective'))
+      }
+
+      @query_with_system = {
+        'patient': @sequence.patient_ids.first,
+        'code': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@diagnostic_report_ary[@sequence.patient_ids.first], 'code'), true),
         'date': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@diagnostic_report_ary[@sequence.patient_ids.first], 'effective'))
       }
     end

--- a/lib/modules/uscore_v3.1.0/test/us_core_documentreference_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_documentreference_test.rb
@@ -316,6 +316,11 @@ describe Inferno::Sequence::USCore310DocumentreferenceSequence do
         'patient': @sequence.patient_ids.first,
         'type': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@document_reference_ary[@sequence.patient_ids.first], 'type'))
       }
+
+      @query_with_system = {
+        'patient': @sequence.patient_ids.first,
+        'type': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@document_reference_ary[@sequence.patient_ids.first], 'type'), true)
+      }
     end
 
     it 'skips if the search params are not supported' do
@@ -381,6 +386,10 @@ describe Inferno::Sequence::USCore310DocumentreferenceSequence do
         .with(query: @query, headers: @auth_header)
         .to_return(status: 200, body: wrap_resources_in_bundle(@document_reference_ary.values.flatten).to_json)
 
+      stub_request(:get, "#{@base_url}/DocumentReference")
+        .with(query: @query_with_system, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@document_reference_ary.values.flatten).to_json)
+
       @sequence.run_test(@test)
     end
 
@@ -443,6 +452,10 @@ describe Inferno::Sequence::USCore310DocumentreferenceSequence do
           .with(query: @query.merge('status': ['current,superseded,entered-in-error'].first), headers: @auth_header)
           .to_return(status: 200, body: wrap_resources_in_bundle([@document_reference]).to_json)
 
+        stub_request(:get, "#{@base_url}/DocumentReference")
+          .with(query: @query_with_system.merge('status': ['current,superseded,entered-in-error'].first), headers: @auth_header)
+          .to_return(status: 200, body: wrap_resources_in_bundle([@document_reference]).to_json)
+
         @sequence.run_test(@test)
       end
     end
@@ -462,6 +475,12 @@ describe Inferno::Sequence::USCore310DocumentreferenceSequence do
       @query = {
         'patient': @sequence.patient_ids.first,
         'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@document_reference_ary[@sequence.patient_ids.first], 'category')),
+        'date': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@document_reference_ary[@sequence.patient_ids.first], 'date'))
+      }
+
+      @query_with_system = {
+        'patient': @sequence.patient_ids.first,
+        'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@document_reference_ary[@sequence.patient_ids.first], 'category'), true),
         'date': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@document_reference_ary[@sequence.patient_ids.first], 'date'))
       }
     end
@@ -529,6 +548,10 @@ describe Inferno::Sequence::USCore310DocumentreferenceSequence do
         .with(query: @query, headers: @auth_header)
         .to_return(status: 200, body: wrap_resources_in_bundle(@document_reference_ary.values.flatten).to_json)
 
+      stub_request(:get, "#{@base_url}/DocumentReference")
+        .with(query: @query_with_system, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@document_reference_ary.values.flatten).to_json)
+
       @sequence.run_test(@test)
     end
 
@@ -591,6 +614,10 @@ describe Inferno::Sequence::USCore310DocumentreferenceSequence do
           .with(query: @query.merge('status': ['current,superseded,entered-in-error'].first), headers: @auth_header)
           .to_return(status: 200, body: wrap_resources_in_bundle([@document_reference]).to_json)
 
+        stub_request(:get, "#{@base_url}/DocumentReference")
+          .with(query: @query_with_system.merge('status': ['current,superseded,entered-in-error'].first), headers: @auth_header)
+          .to_return(status: 200, body: wrap_resources_in_bundle([@document_reference]).to_json)
+
         @sequence.run_test(@test)
       end
     end
@@ -610,6 +637,11 @@ describe Inferno::Sequence::USCore310DocumentreferenceSequence do
       @query = {
         'patient': @sequence.patient_ids.first,
         'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@document_reference_ary[@sequence.patient_ids.first], 'category'))
+      }
+
+      @query_with_system = {
+        'patient': @sequence.patient_ids.first,
+        'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@document_reference_ary[@sequence.patient_ids.first], 'category'), true)
       }
     end
 
@@ -676,6 +708,10 @@ describe Inferno::Sequence::USCore310DocumentreferenceSequence do
         .with(query: @query, headers: @auth_header)
         .to_return(status: 200, body: wrap_resources_in_bundle(@document_reference_ary.values.flatten).to_json)
 
+      stub_request(:get, "#{@base_url}/DocumentReference")
+        .with(query: @query_with_system, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@document_reference_ary.values.flatten).to_json)
+
       @sequence.run_test(@test)
     end
 
@@ -738,6 +774,10 @@ describe Inferno::Sequence::USCore310DocumentreferenceSequence do
           .with(query: @query.merge('status': ['current,superseded,entered-in-error'].first), headers: @auth_header)
           .to_return(status: 200, body: wrap_resources_in_bundle([@document_reference]).to_json)
 
+        stub_request(:get, "#{@base_url}/DocumentReference")
+          .with(query: @query_with_system.merge('status': ['current,superseded,entered-in-error'].first), headers: @auth_header)
+          .to_return(status: 200, body: wrap_resources_in_bundle([@document_reference]).to_json)
+
         @sequence.run_test(@test)
       end
     end
@@ -757,6 +797,12 @@ describe Inferno::Sequence::USCore310DocumentreferenceSequence do
       @query = {
         'patient': @sequence.patient_ids.first,
         'type': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@document_reference_ary[@sequence.patient_ids.first], 'type')),
+        'period': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@document_reference_ary[@sequence.patient_ids.first], 'context.period'))
+      }
+
+      @query_with_system = {
+        'patient': @sequence.patient_ids.first,
+        'type': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@document_reference_ary[@sequence.patient_ids.first], 'type'), true),
         'period': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@document_reference_ary[@sequence.patient_ids.first], 'context.period'))
       }
     end

--- a/lib/modules/uscore_v3.1.0/test/us_core_implantable_device_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_implantable_device_test.rb
@@ -107,6 +107,11 @@ describe Inferno::Sequence::USCore310ImplantableDeviceSequence do
         'patient': @sequence.patient_ids.first,
         'type': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@device_ary[@sequence.patient_ids.first], 'type'))
       }
+
+      @query_with_system = {
+        'patient': @sequence.patient_ids.first,
+        'type': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@device_ary[@sequence.patient_ids.first], 'type'), true)
+      }
     end
 
     it 'skips if the search params are not supported' do
@@ -170,6 +175,10 @@ describe Inferno::Sequence::USCore310ImplantableDeviceSequence do
     it 'succeeds when a bundle containing a valid resource matching the search parameters is returned' do
       stub_request(:get, "#{@base_url}/Device")
         .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@device_ary.values.flatten).to_json)
+
+      stub_request(:get, "#{@base_url}/Device")
+        .with(query: @query_with_system, headers: @auth_header)
         .to_return(status: 200, body: wrap_resources_in_bundle(@device_ary.values.flatten).to_json)
 
       @sequence.run_test(@test)

--- a/lib/modules/uscore_v3.1.0/test/us_core_observation_lab_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_observation_lab_test.rb
@@ -30,6 +30,11 @@ describe Inferno::Sequence::USCore310ObservationLabSequence do
         'patient': @sequence.patient_ids.first,
         'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'category'))
       }
+
+      @query_with_system = {
+        'patient': @sequence.patient_ids.first,
+        'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'category'), true)
+      }
     end
 
     it 'skips if the search params are not supported' do
@@ -125,6 +130,10 @@ describe Inferno::Sequence::USCore310ObservationLabSequence do
           .to_return(status: 200, body: body)
       end
 
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query_with_system, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@observation_ary.values.flatten).to_json)
+
       @sequence.run_test(@test)
     end
 
@@ -217,6 +226,10 @@ describe Inferno::Sequence::USCore310ObservationLabSequence do
             .to_return(status: 200, body: wrap_resources_in_bundle([@observation]).to_json)
         end
 
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query_with_system.merge('status': ['registered,preliminary,final,amended,corrected,cancelled,entered-in-error,unknown'].first), headers: @auth_header)
+          .to_return(status: 200, body: wrap_resources_in_bundle([@observation]).to_json)
+
         @sequence.run_test(@test)
       end
     end
@@ -236,6 +249,11 @@ describe Inferno::Sequence::USCore310ObservationLabSequence do
       @query = {
         'patient': @sequence.patient_ids.first,
         'code': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'code'))
+      }
+
+      @query_with_system = {
+        'patient': @sequence.patient_ids.first,
+        'code': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'code'), true)
       }
     end
 
@@ -302,6 +320,10 @@ describe Inferno::Sequence::USCore310ObservationLabSequence do
         .with(query: @query, headers: @auth_header)
         .to_return(status: 200, body: wrap_resources_in_bundle(@observation_ary.values.flatten).to_json)
 
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query_with_system, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@observation_ary.values.flatten).to_json)
+
       @sequence.run_test(@test)
     end
 
@@ -364,6 +386,10 @@ describe Inferno::Sequence::USCore310ObservationLabSequence do
           .with(query: @query.merge('status': ['registered,preliminary,final,amended,corrected,cancelled,entered-in-error,unknown'].first), headers: @auth_header)
           .to_return(status: 200, body: wrap_resources_in_bundle([@observation]).to_json)
 
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query_with_system.merge('status': ['registered,preliminary,final,amended,corrected,cancelled,entered-in-error,unknown'].first), headers: @auth_header)
+          .to_return(status: 200, body: wrap_resources_in_bundle([@observation]).to_json)
+
         @sequence.run_test(@test)
       end
     end
@@ -383,6 +409,12 @@ describe Inferno::Sequence::USCore310ObservationLabSequence do
       @query = {
         'patient': @sequence.patient_ids.first,
         'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'category')),
+        'date': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'effective'))
+      }
+
+      @query_with_system = {
+        'patient': @sequence.patient_ids.first,
+        'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'category'), true),
         'date': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'effective'))
       }
     end
@@ -514,6 +546,12 @@ describe Inferno::Sequence::USCore310ObservationLabSequence do
         'code': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'code')),
         'date': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'effective'))
       }
+
+      @query_with_system = {
+        'patient': @sequence.patient_ids.first,
+        'code': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'code'), true),
+        'date': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'effective'))
+      }
     end
 
     it 'skips if the search params are not supported' do
@@ -643,6 +681,12 @@ describe Inferno::Sequence::USCore310ObservationLabSequence do
         'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'category')),
         'status': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'status'))
       }
+
+      @query_with_system = {
+        'patient': @sequence.patient_ids.first,
+        'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'category'), true),
+        'status': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'status'))
+      }
     end
 
     it 'skips if the search params are not supported' do
@@ -706,6 +750,10 @@ describe Inferno::Sequence::USCore310ObservationLabSequence do
     it 'succeeds when a bundle containing a valid resource matching the search parameters is returned' do
       stub_request(:get, "#{@base_url}/Observation")
         .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@observation_ary.values.flatten).to_json)
+
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query_with_system, headers: @auth_header)
         .to_return(status: 200, body: wrap_resources_in_bundle(@observation_ary.values.flatten).to_json)
 
       @sequence.run_test(@test)

--- a/lib/modules/uscore_v3.1.0/test/us_core_patient_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_patient_test.rb
@@ -106,6 +106,10 @@ describe Inferno::Sequence::USCore310PatientSequence do
       @query = {
         'identifier': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@patient_ary[@sequence.patient_ids.first], 'identifier'))
       }
+
+      @query_with_system = {
+        'identifier': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@patient_ary[@sequence.patient_ids.first], 'identifier'), true)
+      }
     end
 
     it 'skips if the search params are not supported' do
@@ -169,6 +173,10 @@ describe Inferno::Sequence::USCore310PatientSequence do
     it 'succeeds when a bundle containing a valid resource matching the search parameters is returned' do
       stub_request(:get, "#{@base_url}/Patient")
         .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@patient_ary.values.flatten).to_json)
+
+      stub_request(:get, "#{@base_url}/Patient")
+        .with(query: @query_with_system, headers: @auth_header)
         .to_return(status: 200, body: wrap_resources_in_bundle(@patient_ary.values.flatten).to_json)
 
       @sequence.run_test(@test)

--- a/lib/modules/uscore_v3.1.0/test/us_core_procedure_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_procedure_test.rb
@@ -299,6 +299,12 @@ describe Inferno::Sequence::USCore310ProcedureSequence do
         'code': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@procedure_ary[@sequence.patient_ids.first], 'code')),
         'date': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@procedure_ary[@sequence.patient_ids.first], 'performed'))
       }
+
+      @query_with_system = {
+        'patient': @sequence.patient_ids.first,
+        'code': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@procedure_ary[@sequence.patient_ids.first], 'code'), true),
+        'date': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@procedure_ary[@sequence.patient_ids.first], 'performed'))
+      }
     end
 
     it 'skips if the search params are not supported' do

--- a/lib/modules/uscore_v3.1.0/test/us_core_pulse_oximetry_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_pulse_oximetry_test.rb
@@ -30,6 +30,11 @@ describe Inferno::Sequence::USCore310PulseOximetrySequence do
         'patient': @sequence.patient_ids.first,
         'code': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'code'))
       }
+
+      @query_with_system = {
+        'patient': @sequence.patient_ids.first,
+        'code': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'code'), true)
+      }
     end
 
     it 'skips if the search params are not supported' do
@@ -125,6 +130,10 @@ describe Inferno::Sequence::USCore310PulseOximetrySequence do
           .to_return(status: 200, body: body)
       end
 
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query_with_system, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@observation_ary.values.flatten).to_json)
+
       @sequence.run_test(@test)
     end
 
@@ -217,6 +226,10 @@ describe Inferno::Sequence::USCore310PulseOximetrySequence do
             .to_return(status: 200, body: wrap_resources_in_bundle([@observation]).to_json)
         end
 
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query_with_system.merge('status': ['registered,preliminary,final,amended,corrected,cancelled,entered-in-error,unknown'].first), headers: @auth_header)
+          .to_return(status: 200, body: wrap_resources_in_bundle([@observation]).to_json)
+
         @sequence.run_test(@test)
       end
     end
@@ -236,6 +249,12 @@ describe Inferno::Sequence::USCore310PulseOximetrySequence do
       @query = {
         'patient': @sequence.patient_ids.first,
         'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'category')),
+        'date': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'effective'))
+      }
+
+      @query_with_system = {
+        'patient': @sequence.patient_ids.first,
+        'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'category'), true),
         'date': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'effective'))
       }
     end
@@ -366,6 +385,11 @@ describe Inferno::Sequence::USCore310PulseOximetrySequence do
         'patient': @sequence.patient_ids.first,
         'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'category'))
       }
+
+      @query_with_system = {
+        'patient': @sequence.patient_ids.first,
+        'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'category'), true)
+      }
     end
 
     it 'skips if the search params are not supported' do
@@ -431,6 +455,10 @@ describe Inferno::Sequence::USCore310PulseOximetrySequence do
         .with(query: @query, headers: @auth_header)
         .to_return(status: 200, body: wrap_resources_in_bundle(@observation_ary.values.flatten).to_json)
 
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query_with_system, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@observation_ary.values.flatten).to_json)
+
       @sequence.run_test(@test)
     end
 
@@ -493,6 +521,10 @@ describe Inferno::Sequence::USCore310PulseOximetrySequence do
           .with(query: @query.merge('status': ['registered,preliminary,final,amended,corrected,cancelled,entered-in-error,unknown'].first), headers: @auth_header)
           .to_return(status: 200, body: wrap_resources_in_bundle([@observation]).to_json)
 
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query_with_system.merge('status': ['registered,preliminary,final,amended,corrected,cancelled,entered-in-error,unknown'].first), headers: @auth_header)
+          .to_return(status: 200, body: wrap_resources_in_bundle([@observation]).to_json)
+
         @sequence.run_test(@test)
       end
     end
@@ -512,6 +544,12 @@ describe Inferno::Sequence::USCore310PulseOximetrySequence do
       @query = {
         'patient': @sequence.patient_ids.first,
         'code': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'code')),
+        'date': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'effective'))
+      }
+
+      @query_with_system = {
+        'patient': @sequence.patient_ids.first,
+        'code': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'code'), true),
         'date': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'effective'))
       }
     end
@@ -643,6 +681,12 @@ describe Inferno::Sequence::USCore310PulseOximetrySequence do
         'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'category')),
         'status': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'status'))
       }
+
+      @query_with_system = {
+        'patient': @sequence.patient_ids.first,
+        'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'category'), true),
+        'status': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'status'))
+      }
     end
 
     it 'skips if the search params are not supported' do
@@ -706,6 +750,10 @@ describe Inferno::Sequence::USCore310PulseOximetrySequence do
     it 'succeeds when a bundle containing a valid resource matching the search parameters is returned' do
       stub_request(:get, "#{@base_url}/Observation")
         .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@observation_ary.values.flatten).to_json)
+
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query_with_system, headers: @auth_header)
         .to_return(status: 200, body: wrap_resources_in_bundle(@observation_ary.values.flatten).to_json)
 
       @sequence.run_test(@test)

--- a/lib/modules/uscore_v3.1.0/test/us_core_smokingstatus_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_smokingstatus_test.rb
@@ -30,6 +30,11 @@ describe Inferno::Sequence::USCore310SmokingstatusSequence do
         'patient': @sequence.patient_ids.first,
         'code': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'code'))
       }
+
+      @query_with_system = {
+        'patient': @sequence.patient_ids.first,
+        'code': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'code'), true)
+      }
     end
 
     it 'skips if the search params are not supported' do
@@ -125,6 +130,10 @@ describe Inferno::Sequence::USCore310SmokingstatusSequence do
           .to_return(status: 200, body: body)
       end
 
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query_with_system, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@observation_ary.values.flatten).to_json)
+
       @sequence.run_test(@test)
     end
 
@@ -217,6 +226,10 @@ describe Inferno::Sequence::USCore310SmokingstatusSequence do
             .to_return(status: 200, body: wrap_resources_in_bundle([@observation]).to_json)
         end
 
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query_with_system.merge('status': ['final,entered-in-error'].first), headers: @auth_header)
+          .to_return(status: 200, body: wrap_resources_in_bundle([@observation]).to_json)
+
         @sequence.run_test(@test)
       end
     end
@@ -236,6 +249,12 @@ describe Inferno::Sequence::USCore310SmokingstatusSequence do
       @query = {
         'patient': @sequence.patient_ids.first,
         'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'category')),
+        'date': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'effective'))
+      }
+
+      @query_with_system = {
+        'patient': @sequence.patient_ids.first,
+        'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'category'), true),
         'date': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'effective'))
       }
     end
@@ -366,6 +385,11 @@ describe Inferno::Sequence::USCore310SmokingstatusSequence do
         'patient': @sequence.patient_ids.first,
         'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'category'))
       }
+
+      @query_with_system = {
+        'patient': @sequence.patient_ids.first,
+        'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'category'), true)
+      }
     end
 
     it 'skips if the search params are not supported' do
@@ -431,6 +455,10 @@ describe Inferno::Sequence::USCore310SmokingstatusSequence do
         .with(query: @query, headers: @auth_header)
         .to_return(status: 200, body: wrap_resources_in_bundle(@observation_ary.values.flatten).to_json)
 
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query_with_system, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@observation_ary.values.flatten).to_json)
+
       @sequence.run_test(@test)
     end
 
@@ -493,6 +521,10 @@ describe Inferno::Sequence::USCore310SmokingstatusSequence do
           .with(query: @query.merge('status': ['final,entered-in-error'].first), headers: @auth_header)
           .to_return(status: 200, body: wrap_resources_in_bundle([@observation]).to_json)
 
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: @query_with_system.merge('status': ['final,entered-in-error'].first), headers: @auth_header)
+          .to_return(status: 200, body: wrap_resources_in_bundle([@observation]).to_json)
+
         @sequence.run_test(@test)
       end
     end
@@ -512,6 +544,12 @@ describe Inferno::Sequence::USCore310SmokingstatusSequence do
       @query = {
         'patient': @sequence.patient_ids.first,
         'code': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'code')),
+        'date': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'effective'))
+      }
+
+      @query_with_system = {
+        'patient': @sequence.patient_ids.first,
+        'code': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'code'), true),
         'date': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'effective'))
       }
     end
@@ -643,6 +681,12 @@ describe Inferno::Sequence::USCore310SmokingstatusSequence do
         'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'category')),
         'status': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'status'))
       }
+
+      @query_with_system = {
+        'patient': @sequence.patient_ids.first,
+        'category': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'category'), true),
+        'status': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@observation_ary[@sequence.patient_ids.first], 'status'))
+      }
     end
 
     it 'skips if the search params are not supported' do
@@ -706,6 +750,10 @@ describe Inferno::Sequence::USCore310SmokingstatusSequence do
     it 'succeeds when a bundle containing a valid resource matching the search parameters is returned' do
       stub_request(:get, "#{@base_url}/Observation")
         .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@observation_ary.values.flatten).to_json)
+
+      stub_request(:get, "#{@base_url}/Observation")
+        .with(query: @query_with_system, headers: @auth_header)
         .to_return(status: 200, body: wrap_resources_in_bundle(@observation_ary.values.flatten).to_json)
 
       @sequence.run_test(@test)

--- a/lib/modules/uscore_v3.1.0/us_core_careplan_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_careplan_sequence.rb
@@ -68,9 +68,16 @@ module Inferno
         case property
 
         when 'category'
-          values_found = resolve_path(resource, 'category.coding.code')
-          values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
-          match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
+          values_found = resolve_path(resource, 'category')
+          coding_system = value.split('|').first.empty? ? nil : value.split('|').first
+          coding_value = value.split('|').last
+          match_found = values_found.any? do |codeable_concept|
+            if value.include? '|'
+              codeable_concept.coding.any? { |coding| coding.system == coding_system && coding.code == coding_value }
+            else
+              codeable_concept.coding.any? { |coding| coding.code == value }
+            end
+          end
           assert match_found, "category in CarePlan/#{resource.id} (#{values_found}) does not match category requested (#{value})"
 
         when 'date'
@@ -172,6 +179,11 @@ module Inferno
             save_delayed_sequence_references(resources_returned, USCore310CareplanSequenceDefinitions::DELAYED_REFERENCES)
             validate_reply_entries(resources_returned, search_params)
 
+            value_with_system = get_value_for_search_param(resolve_element_from_path(@care_plan_ary[patient], 'category'), true)
+            token_with_system_search_params = search_params.merge('category': value_with_system)
+            reply = get_resource_by_params(versioned_resource_class('CarePlan'), token_with_system_search_params)
+            validate_search_reply(versioned_resource_class('CarePlan'), reply, token_with_system_search_params)
+
             break
           end
         end
@@ -225,6 +237,11 @@ module Inferno
             reply = get_resource_by_params(versioned_resource_class('CarePlan'), comparator_search_params)
             validate_search_reply(versioned_resource_class('CarePlan'), reply, comparator_search_params)
           end
+
+          value_with_system = get_value_for_search_param(resolve_element_from_path(@care_plan_ary[patient], 'category'), true)
+          token_with_system_search_params = search_params.merge('category': value_with_system)
+          reply = get_resource_by_params(versioned_resource_class('CarePlan'), token_with_system_search_params)
+          validate_search_reply(versioned_resource_class('CarePlan'), reply, token_with_system_search_params)
         end
 
         skip 'Could not resolve all parameters (patient, category, date) in any resource.' unless resolved_one
@@ -276,6 +293,11 @@ module Inferno
             reply = get_resource_by_params(versioned_resource_class('CarePlan'), comparator_search_params)
             validate_search_reply(versioned_resource_class('CarePlan'), reply, comparator_search_params)
           end
+
+          value_with_system = get_value_for_search_param(resolve_element_from_path(@care_plan_ary[patient], 'category'), true)
+          token_with_system_search_params = search_params.merge('category': value_with_system)
+          reply = get_resource_by_params(versioned_resource_class('CarePlan'), token_with_system_search_params)
+          validate_search_reply(versioned_resource_class('CarePlan'), reply, token_with_system_search_params)
         end
 
         skip 'Could not resolve all parameters (patient, category, status, date) in any resource.' unless resolved_one
@@ -315,6 +337,11 @@ module Inferno
           reply = get_resource_by_params(versioned_resource_class('CarePlan'), search_params)
 
           validate_search_reply(versioned_resource_class('CarePlan'), reply, search_params)
+
+          value_with_system = get_value_for_search_param(resolve_element_from_path(@care_plan_ary[patient], 'category'), true)
+          token_with_system_search_params = search_params.merge('category': value_with_system)
+          reply = get_resource_by_params(versioned_resource_class('CarePlan'), token_with_system_search_params)
+          validate_search_reply(versioned_resource_class('CarePlan'), reply, token_with_system_search_params)
         end
 
         skip 'Could not resolve all parameters (patient, category, status) in any resource.' unless resolved_one

--- a/lib/modules/uscore_v3.1.0/us_core_diagnosticreport_lab_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_diagnosticreport_lab_sequence.rb
@@ -82,15 +82,29 @@ module Inferno
           assert match_found, "patient in DiagnosticReport/#{resource.id} (#{values_found}) does not match patient requested (#{value})"
 
         when 'category'
-          values_found = resolve_path(resource, 'category.coding.code')
-          values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
-          match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
+          values_found = resolve_path(resource, 'category')
+          coding_system = value.split('|').first.empty? ? nil : value.split('|').first
+          coding_value = value.split('|').last
+          match_found = values_found.any? do |codeable_concept|
+            if value.include? '|'
+              codeable_concept.coding.any? { |coding| coding.system == coding_system && coding.code == coding_value }
+            else
+              codeable_concept.coding.any? { |coding| coding.code == value }
+            end
+          end
           assert match_found, "category in DiagnosticReport/#{resource.id} (#{values_found}) does not match category requested (#{value})"
 
         when 'code'
-          values_found = resolve_path(resource, 'code.coding.code')
-          values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
-          match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
+          values_found = resolve_path(resource, 'code')
+          coding_system = value.split('|').first.empty? ? nil : value.split('|').first
+          coding_value = value.split('|').last
+          match_found = values_found.any? do |codeable_concept|
+            if value.include? '|'
+              codeable_concept.coding.any? { |coding| coding.system == coding_system && coding.code == coding_value }
+            else
+              codeable_concept.coding.any? { |coding| coding.code == value }
+            end
+          end
           assert match_found, "code in DiagnosticReport/#{resource.id} (#{values_found}) does not match code requested (#{value})"
 
         when 'date'
@@ -181,6 +195,11 @@ module Inferno
             save_delayed_sequence_references(resources_returned, USCore310DiagnosticreportLabSequenceDefinitions::DELAYED_REFERENCES)
             validate_reply_entries(resources_returned, search_params)
 
+            value_with_system = get_value_for_search_param(resolve_element_from_path(@diagnostic_report_ary[patient], 'category'), true)
+            token_with_system_search_params = search_params.merge('category': value_with_system)
+            reply = get_resource_by_params(versioned_resource_class('DiagnosticReport'), token_with_system_search_params)
+            validate_search_reply(versioned_resource_class('DiagnosticReport'), reply, token_with_system_search_params)
+
             break
           end
         end
@@ -251,6 +270,11 @@ module Inferno
           reply = perform_search_with_status(reply, search_params) if reply.code == 400
 
           validate_search_reply(versioned_resource_class('DiagnosticReport'), reply, search_params)
+
+          value_with_system = get_value_for_search_param(resolve_element_from_path(@diagnostic_report_ary[patient], 'code'), true)
+          token_with_system_search_params = search_params.merge('code': value_with_system)
+          reply = get_resource_by_params(versioned_resource_class('DiagnosticReport'), token_with_system_search_params)
+          validate_search_reply(versioned_resource_class('DiagnosticReport'), reply, token_with_system_search_params)
         end
 
         skip 'Could not resolve all parameters (patient, code) in any resource.' unless resolved_one
@@ -302,6 +326,11 @@ module Inferno
             reply = get_resource_by_params(versioned_resource_class('DiagnosticReport'), comparator_search_params)
             validate_search_reply(versioned_resource_class('DiagnosticReport'), reply, comparator_search_params)
           end
+
+          value_with_system = get_value_for_search_param(resolve_element_from_path(@diagnostic_report_ary[patient], 'category'), true)
+          token_with_system_search_params = search_params.merge('category': value_with_system)
+          reply = get_resource_by_params(versioned_resource_class('DiagnosticReport'), token_with_system_search_params)
+          validate_search_reply(versioned_resource_class('DiagnosticReport'), reply, token_with_system_search_params)
         end
 
         skip 'Could not resolve all parameters (patient, category, date) in any resource.' unless resolved_one
@@ -392,6 +421,11 @@ module Inferno
             reply = get_resource_by_params(versioned_resource_class('DiagnosticReport'), comparator_search_params)
             validate_search_reply(versioned_resource_class('DiagnosticReport'), reply, comparator_search_params)
           end
+
+          value_with_system = get_value_for_search_param(resolve_element_from_path(@diagnostic_report_ary[patient], 'code'), true)
+          token_with_system_search_params = search_params.merge('code': value_with_system)
+          reply = get_resource_by_params(versioned_resource_class('DiagnosticReport'), token_with_system_search_params)
+          validate_search_reply(versioned_resource_class('DiagnosticReport'), reply, token_with_system_search_params)
         end
 
         skip 'Could not resolve all parameters (patient, code, date) in any resource.' unless resolved_one

--- a/lib/modules/uscore_v3.1.0/us_core_diagnosticreport_note_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_diagnosticreport_note_sequence.rb
@@ -82,15 +82,29 @@ module Inferno
           assert match_found, "patient in DiagnosticReport/#{resource.id} (#{values_found}) does not match patient requested (#{value})"
 
         when 'category'
-          values_found = resolve_path(resource, 'category.coding.code')
-          values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
-          match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
+          values_found = resolve_path(resource, 'category')
+          coding_system = value.split('|').first.empty? ? nil : value.split('|').first
+          coding_value = value.split('|').last
+          match_found = values_found.any? do |codeable_concept|
+            if value.include? '|'
+              codeable_concept.coding.any? { |coding| coding.system == coding_system && coding.code == coding_value }
+            else
+              codeable_concept.coding.any? { |coding| coding.code == value }
+            end
+          end
           assert match_found, "category in DiagnosticReport/#{resource.id} (#{values_found}) does not match category requested (#{value})"
 
         when 'code'
-          values_found = resolve_path(resource, 'code.coding.code')
-          values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
-          match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
+          values_found = resolve_path(resource, 'code')
+          coding_system = value.split('|').first.empty? ? nil : value.split('|').first
+          coding_value = value.split('|').last
+          match_found = values_found.any? do |codeable_concept|
+            if value.include? '|'
+              codeable_concept.coding.any? { |coding| coding.system == coding_system && coding.code == coding_value }
+            else
+              codeable_concept.coding.any? { |coding| coding.code == value }
+            end
+          end
           assert match_found, "code in DiagnosticReport/#{resource.id} (#{values_found}) does not match code requested (#{value})"
 
         when 'date'
@@ -181,6 +195,11 @@ module Inferno
             save_delayed_sequence_references(resources_returned, USCore310DiagnosticreportNoteSequenceDefinitions::DELAYED_REFERENCES)
             validate_reply_entries(resources_returned, search_params)
 
+            value_with_system = get_value_for_search_param(resolve_element_from_path(@diagnostic_report_ary[patient], 'category'), true)
+            token_with_system_search_params = search_params.merge('category': value_with_system)
+            reply = get_resource_by_params(versioned_resource_class('DiagnosticReport'), token_with_system_search_params)
+            validate_search_reply(versioned_resource_class('DiagnosticReport'), reply, token_with_system_search_params)
+
             break
           end
         end
@@ -251,6 +270,11 @@ module Inferno
           reply = perform_search_with_status(reply, search_params) if reply.code == 400
 
           validate_search_reply(versioned_resource_class('DiagnosticReport'), reply, search_params)
+
+          value_with_system = get_value_for_search_param(resolve_element_from_path(@diagnostic_report_ary[patient], 'code'), true)
+          token_with_system_search_params = search_params.merge('code': value_with_system)
+          reply = get_resource_by_params(versioned_resource_class('DiagnosticReport'), token_with_system_search_params)
+          validate_search_reply(versioned_resource_class('DiagnosticReport'), reply, token_with_system_search_params)
         end
 
         skip 'Could not resolve all parameters (patient, code) in any resource.' unless resolved_one
@@ -302,6 +326,11 @@ module Inferno
             reply = get_resource_by_params(versioned_resource_class('DiagnosticReport'), comparator_search_params)
             validate_search_reply(versioned_resource_class('DiagnosticReport'), reply, comparator_search_params)
           end
+
+          value_with_system = get_value_for_search_param(resolve_element_from_path(@diagnostic_report_ary[patient], 'category'), true)
+          token_with_system_search_params = search_params.merge('category': value_with_system)
+          reply = get_resource_by_params(versioned_resource_class('DiagnosticReport'), token_with_system_search_params)
+          validate_search_reply(versioned_resource_class('DiagnosticReport'), reply, token_with_system_search_params)
         end
 
         skip 'Could not resolve all parameters (patient, category, date) in any resource.' unless resolved_one
@@ -392,6 +421,11 @@ module Inferno
             reply = get_resource_by_params(versioned_resource_class('DiagnosticReport'), comparator_search_params)
             validate_search_reply(versioned_resource_class('DiagnosticReport'), reply, comparator_search_params)
           end
+
+          value_with_system = get_value_for_search_param(resolve_element_from_path(@diagnostic_report_ary[patient], 'code'), true)
+          token_with_system_search_params = search_params.merge('code': value_with_system)
+          reply = get_resource_by_params(versioned_resource_class('DiagnosticReport'), token_with_system_search_params)
+          validate_search_reply(versioned_resource_class('DiagnosticReport'), reply, token_with_system_search_params)
         end
 
         skip 'Could not resolve all parameters (patient, code, date) in any resource.' unless resolved_one

--- a/lib/modules/uscore_v3.1.0/us_core_documentreference_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_documentreference_sequence.rb
@@ -89,15 +89,29 @@ module Inferno
           assert match_found, "patient in DocumentReference/#{resource.id} (#{values_found}) does not match patient requested (#{value})"
 
         when 'category'
-          values_found = resolve_path(resource, 'category.coding.code')
-          values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
-          match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
+          values_found = resolve_path(resource, 'category')
+          coding_system = value.split('|').first.empty? ? nil : value.split('|').first
+          coding_value = value.split('|').last
+          match_found = values_found.any? do |codeable_concept|
+            if value.include? '|'
+              codeable_concept.coding.any? { |coding| coding.system == coding_system && coding.code == coding_value }
+            else
+              codeable_concept.coding.any? { |coding| coding.code == value }
+            end
+          end
           assert match_found, "category in DocumentReference/#{resource.id} (#{values_found}) does not match category requested (#{value})"
 
         when 'type'
-          values_found = resolve_path(resource, 'type.coding.code')
-          values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
-          match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
+          values_found = resolve_path(resource, 'type')
+          coding_system = value.split('|').first.empty? ? nil : value.split('|').first
+          coding_value = value.split('|').last
+          match_found = values_found.any? do |codeable_concept|
+            if value.include? '|'
+              codeable_concept.coding.any? { |coding| coding.system == coding_system && coding.code == coding_value }
+            else
+              codeable_concept.coding.any? { |coding| coding.code == value }
+            end
+          end
           assert match_found, "type in DocumentReference/#{resource.id} (#{values_found}) does not match type requested (#{value})"
 
         when 'date'
@@ -271,6 +285,11 @@ module Inferno
           reply = perform_search_with_status(reply, search_params) if reply.code == 400
 
           validate_search_reply(versioned_resource_class('DocumentReference'), reply, search_params)
+
+          value_with_system = get_value_for_search_param(resolve_element_from_path(@document_reference_ary[patient], 'type'), true)
+          token_with_system_search_params = search_params.merge('type': value_with_system)
+          reply = get_resource_by_params(versioned_resource_class('DocumentReference'), token_with_system_search_params)
+          validate_search_reply(versioned_resource_class('DocumentReference'), reply, token_with_system_search_params)
         end
 
         skip 'Could not resolve all parameters (patient, type) in any resource.' unless resolved_one
@@ -315,6 +334,11 @@ module Inferno
           reply = perform_search_with_status(reply, search_params) if reply.code == 400
 
           validate_search_reply(versioned_resource_class('DocumentReference'), reply, search_params)
+
+          value_with_system = get_value_for_search_param(resolve_element_from_path(@document_reference_ary[patient], 'category'), true)
+          token_with_system_search_params = search_params.merge('category': value_with_system)
+          reply = get_resource_by_params(versioned_resource_class('DocumentReference'), token_with_system_search_params)
+          validate_search_reply(versioned_resource_class('DocumentReference'), reply, token_with_system_search_params)
         end
 
         skip 'Could not resolve all parameters (patient, category, date) in any resource.' unless resolved_one
@@ -354,6 +378,11 @@ module Inferno
           reply = perform_search_with_status(reply, search_params) if reply.code == 400
 
           validate_search_reply(versioned_resource_class('DocumentReference'), reply, search_params)
+
+          value_with_system = get_value_for_search_param(resolve_element_from_path(@document_reference_ary[patient], 'category'), true)
+          token_with_system_search_params = search_params.merge('category': value_with_system)
+          reply = get_resource_by_params(versioned_resource_class('DocumentReference'), token_with_system_search_params)
+          validate_search_reply(versioned_resource_class('DocumentReference'), reply, token_with_system_search_params)
         end
 
         skip 'Could not resolve all parameters (patient, category) in any resource.' unless resolved_one
@@ -406,6 +435,11 @@ module Inferno
             reply = get_resource_by_params(versioned_resource_class('DocumentReference'), comparator_search_params)
             validate_search_reply(versioned_resource_class('DocumentReference'), reply, comparator_search_params)
           end
+
+          value_with_system = get_value_for_search_param(resolve_element_from_path(@document_reference_ary[patient], 'type'), true)
+          token_with_system_search_params = search_params.merge('type': value_with_system)
+          reply = get_resource_by_params(versioned_resource_class('DocumentReference'), token_with_system_search_params)
+          validate_search_reply(versioned_resource_class('DocumentReference'), reply, token_with_system_search_params)
         end
 
         skip 'Could not resolve all parameters (patient, type, period) in any resource.' unless resolved_one

--- a/lib/modules/uscore_v3.1.0/us_core_medicationrequest_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_medicationrequest_sequence.rb
@@ -213,6 +213,7 @@ module Inferno
             save_resource_references(versioned_resource_class('MedicationRequest'), @medication_request_ary[patient])
             save_delayed_sequence_references(resources_returned, USCore310MedicationrequestSequenceDefinitions::DELAYED_REFERENCES)
             validate_reply_entries(resources_returned, search_params)
+
             test_medication_inclusion(@medication_request_ary[patient], search_params)
             break
           end

--- a/lib/modules/uscore_v3.1.0/us_core_observation_lab_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_observation_lab_sequence.rb
@@ -76,15 +76,29 @@ module Inferno
           assert match_found, "status in Observation/#{resource.id} (#{values_found}) does not match status requested (#{value})"
 
         when 'category'
-          values_found = resolve_path(resource, 'category.coding.code')
-          values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
-          match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
+          values_found = resolve_path(resource, 'category')
+          coding_system = value.split('|').first.empty? ? nil : value.split('|').first
+          coding_value = value.split('|').last
+          match_found = values_found.any? do |codeable_concept|
+            if value.include? '|'
+              codeable_concept.coding.any? { |coding| coding.system == coding_system && coding.code == coding_value }
+            else
+              codeable_concept.coding.any? { |coding| coding.code == value }
+            end
+          end
           assert match_found, "category in Observation/#{resource.id} (#{values_found}) does not match category requested (#{value})"
 
         when 'code'
-          values_found = resolve_path(resource, 'code.coding.code')
-          values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
-          match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
+          values_found = resolve_path(resource, 'code')
+          coding_system = value.split('|').first.empty? ? nil : value.split('|').first
+          coding_value = value.split('|').last
+          match_found = values_found.any? do |codeable_concept|
+            if value.include? '|'
+              codeable_concept.coding.any? { |coding| coding.system == coding_system && coding.code == coding_value }
+            else
+              codeable_concept.coding.any? { |coding| coding.code == value }
+            end
+          end
           assert match_found, "code in Observation/#{resource.id} (#{values_found}) does not match code requested (#{value})"
 
         when 'date'
@@ -180,6 +194,11 @@ module Inferno
             save_delayed_sequence_references(resources_returned, USCore310ObservationLabSequenceDefinitions::DELAYED_REFERENCES)
             validate_reply_entries(resources_returned, search_params)
 
+            value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category'), true)
+            token_with_system_search_params = search_params.merge('category': value_with_system)
+            reply = get_resource_by_params(versioned_resource_class('Observation'), token_with_system_search_params)
+            validate_search_reply(versioned_resource_class('Observation'), reply, token_with_system_search_params)
+
             break
           end
         end
@@ -220,6 +239,11 @@ module Inferno
           reply = perform_search_with_status(reply, search_params) if reply.code == 400
 
           validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
+
+          value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'code'), true)
+          token_with_system_search_params = search_params.merge('code': value_with_system)
+          reply = get_resource_by_params(versioned_resource_class('Observation'), token_with_system_search_params)
+          validate_search_reply(versioned_resource_class('Observation'), reply, token_with_system_search_params)
         end
 
         skip 'Could not resolve all parameters (patient, code) in any resource.' unless resolved_one
@@ -271,6 +295,11 @@ module Inferno
             reply = get_resource_by_params(versioned_resource_class('Observation'), comparator_search_params)
             validate_search_reply(versioned_resource_class('Observation'), reply, comparator_search_params)
           end
+
+          value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category'), true)
+          token_with_system_search_params = search_params.merge('category': value_with_system)
+          reply = get_resource_by_params(versioned_resource_class('Observation'), token_with_system_search_params)
+          validate_search_reply(versioned_resource_class('Observation'), reply, token_with_system_search_params)
         end
 
         skip 'Could not resolve all parameters (patient, category, date) in any resource.' unless resolved_one
@@ -323,6 +352,11 @@ module Inferno
             reply = get_resource_by_params(versioned_resource_class('Observation'), comparator_search_params)
             validate_search_reply(versioned_resource_class('Observation'), reply, comparator_search_params)
           end
+
+          value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'code'), true)
+          token_with_system_search_params = search_params.merge('code': value_with_system)
+          reply = get_resource_by_params(versioned_resource_class('Observation'), token_with_system_search_params)
+          validate_search_reply(versioned_resource_class('Observation'), reply, token_with_system_search_params)
         end
 
         skip 'Could not resolve all parameters (patient, code, date) in any resource.' unless resolved_one
@@ -362,6 +396,11 @@ module Inferno
           reply = get_resource_by_params(versioned_resource_class('Observation'), search_params)
 
           validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
+
+          value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category'), true)
+          token_with_system_search_params = search_params.merge('category': value_with_system)
+          reply = get_resource_by_params(versioned_resource_class('Observation'), token_with_system_search_params)
+          validate_search_reply(versioned_resource_class('Observation'), reply, token_with_system_search_params)
         end
 
         skip 'Could not resolve all parameters (patient, category, status) in any resource.' unless resolved_one

--- a/lib/modules/uscore_v3.1.0/us_core_practitioner_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_practitioner_sequence.rb
@@ -67,9 +67,12 @@ module Inferno
           assert match_found, "name in Practitioner/#{resource.id} (#{values_found}) does not match name requested (#{value})"
 
         when 'identifier'
-          values_found = resolve_path(resource, 'identifier.value')
-          values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
-          match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
+          values_found = resolve_path(resource, 'identifier')
+          identifier_system = value.split('|').first.empty? ? nil : value.split('|').first
+          identifier_value = value.split('|').last
+          match_found = values_found.any? do |identifier|
+            identifier.value == identifier_value && (!value.include?('|') || identifier.system == identifier_system)
+          end
           assert match_found, "identifier in Practitioner/#{resource.id} (#{values_found}) does not match identifier requested (#{value})"
 
         end

--- a/lib/modules/uscore_v3.1.0/us_core_practitionerrole_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_practitionerrole_sequence.rb
@@ -55,9 +55,16 @@ module Inferno
         case property
 
         when 'specialty'
-          values_found = resolve_path(resource, 'specialty.coding.code')
-          values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
-          match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
+          values_found = resolve_path(resource, 'specialty')
+          coding_system = value.split('|').first.empty? ? nil : value.split('|').first
+          coding_value = value.split('|').last
+          match_found = values_found.any? do |codeable_concept|
+            if value.include? '|'
+              codeable_concept.coding.any? { |coding| coding.system == coding_system && coding.code == coding_value }
+            else
+              codeable_concept.coding.any? { |coding| coding.code == value }
+            end
+          end
           assert match_found, "specialty in PractitionerRole/#{resource.id} (#{values_found}) does not match specialty requested (#{value})"
 
         when 'practitioner'

--- a/lib/modules/uscore_v3.1.0/us_core_pulse_oximetry_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_pulse_oximetry_sequence.rb
@@ -76,15 +76,29 @@ module Inferno
           assert match_found, "status in Observation/#{resource.id} (#{values_found}) does not match status requested (#{value})"
 
         when 'category'
-          values_found = resolve_path(resource, 'category.coding.code')
-          values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
-          match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
+          values_found = resolve_path(resource, 'category')
+          coding_system = value.split('|').first.empty? ? nil : value.split('|').first
+          coding_value = value.split('|').last
+          match_found = values_found.any? do |codeable_concept|
+            if value.include? '|'
+              codeable_concept.coding.any? { |coding| coding.system == coding_system && coding.code == coding_value }
+            else
+              codeable_concept.coding.any? { |coding| coding.code == value }
+            end
+          end
           assert match_found, "category in Observation/#{resource.id} (#{values_found}) does not match category requested (#{value})"
 
         when 'code'
-          values_found = resolve_path(resource, 'code.coding.code')
-          values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
-          match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
+          values_found = resolve_path(resource, 'code')
+          coding_system = value.split('|').first.empty? ? nil : value.split('|').first
+          coding_value = value.split('|').last
+          match_found = values_found.any? do |codeable_concept|
+            if value.include? '|'
+              codeable_concept.coding.any? { |coding| coding.system == coding_system && coding.code == coding_value }
+            else
+              codeable_concept.coding.any? { |coding| coding.code == value }
+            end
+          end
           assert match_found, "code in Observation/#{resource.id} (#{values_found}) does not match code requested (#{value})"
 
         when 'date'
@@ -180,6 +194,11 @@ module Inferno
             save_delayed_sequence_references(resources_returned, USCore310PulseOximetrySequenceDefinitions::DELAYED_REFERENCES)
             validate_reply_entries(resources_returned, search_params)
 
+            value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'code'), true)
+            token_with_system_search_params = search_params.merge('code': value_with_system)
+            reply = get_resource_by_params(versioned_resource_class('Observation'), token_with_system_search_params)
+            validate_search_reply(versioned_resource_class('Observation'), reply, token_with_system_search_params)
+
             break
           end
         end
@@ -232,6 +251,11 @@ module Inferno
             reply = get_resource_by_params(versioned_resource_class('Observation'), comparator_search_params)
             validate_search_reply(versioned_resource_class('Observation'), reply, comparator_search_params)
           end
+
+          value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category'), true)
+          token_with_system_search_params = search_params.merge('category': value_with_system)
+          reply = get_resource_by_params(versioned_resource_class('Observation'), token_with_system_search_params)
+          validate_search_reply(versioned_resource_class('Observation'), reply, token_with_system_search_params)
         end
 
         skip 'Could not resolve all parameters (patient, category, date) in any resource.' unless resolved_one
@@ -271,6 +295,11 @@ module Inferno
           reply = perform_search_with_status(reply, search_params) if reply.code == 400
 
           validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
+
+          value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category'), true)
+          token_with_system_search_params = search_params.merge('category': value_with_system)
+          reply = get_resource_by_params(versioned_resource_class('Observation'), token_with_system_search_params)
+          validate_search_reply(versioned_resource_class('Observation'), reply, token_with_system_search_params)
         end
 
         skip 'Could not resolve all parameters (patient, category) in any resource.' unless resolved_one
@@ -323,6 +352,11 @@ module Inferno
             reply = get_resource_by_params(versioned_resource_class('Observation'), comparator_search_params)
             validate_search_reply(versioned_resource_class('Observation'), reply, comparator_search_params)
           end
+
+          value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'code'), true)
+          token_with_system_search_params = search_params.merge('code': value_with_system)
+          reply = get_resource_by_params(versioned_resource_class('Observation'), token_with_system_search_params)
+          validate_search_reply(versioned_resource_class('Observation'), reply, token_with_system_search_params)
         end
 
         skip 'Could not resolve all parameters (patient, code, date) in any resource.' unless resolved_one
@@ -362,6 +396,11 @@ module Inferno
           reply = get_resource_by_params(versioned_resource_class('Observation'), search_params)
 
           validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
+
+          value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category'), true)
+          token_with_system_search_params = search_params.merge('category': value_with_system)
+          reply = get_resource_by_params(versioned_resource_class('Observation'), token_with_system_search_params)
+          validate_search_reply(versioned_resource_class('Observation'), reply, token_with_system_search_params)
         end
 
         skip 'Could not resolve all parameters (patient, category, status) in any resource.' unless resolved_one

--- a/lib/modules/uscore_v3.1.0/us_core_smokingstatus_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_smokingstatus_sequence.rb
@@ -76,15 +76,29 @@ module Inferno
           assert match_found, "status in Observation/#{resource.id} (#{values_found}) does not match status requested (#{value})"
 
         when 'category'
-          values_found = resolve_path(resource, 'category.coding.code')
-          values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
-          match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
+          values_found = resolve_path(resource, 'category')
+          coding_system = value.split('|').first.empty? ? nil : value.split('|').first
+          coding_value = value.split('|').last
+          match_found = values_found.any? do |codeable_concept|
+            if value.include? '|'
+              codeable_concept.coding.any? { |coding| coding.system == coding_system && coding.code == coding_value }
+            else
+              codeable_concept.coding.any? { |coding| coding.code == value }
+            end
+          end
           assert match_found, "category in Observation/#{resource.id} (#{values_found}) does not match category requested (#{value})"
 
         when 'code'
-          values_found = resolve_path(resource, 'code.coding.code')
-          values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
-          match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
+          values_found = resolve_path(resource, 'code')
+          coding_system = value.split('|').first.empty? ? nil : value.split('|').first
+          coding_value = value.split('|').last
+          match_found = values_found.any? do |codeable_concept|
+            if value.include? '|'
+              codeable_concept.coding.any? { |coding| coding.system == coding_system && coding.code == coding_value }
+            else
+              codeable_concept.coding.any? { |coding| coding.code == value }
+            end
+          end
           assert match_found, "code in Observation/#{resource.id} (#{values_found}) does not match code requested (#{value})"
 
         when 'date'
@@ -180,6 +194,11 @@ module Inferno
             save_delayed_sequence_references(resources_returned, USCore310SmokingstatusSequenceDefinitions::DELAYED_REFERENCES)
             validate_reply_entries(resources_returned, search_params)
 
+            value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'code'), true)
+            token_with_system_search_params = search_params.merge('code': value_with_system)
+            reply = get_resource_by_params(versioned_resource_class('Observation'), token_with_system_search_params)
+            validate_search_reply(versioned_resource_class('Observation'), reply, token_with_system_search_params)
+
             break
           end
         end
@@ -232,6 +251,11 @@ module Inferno
             reply = get_resource_by_params(versioned_resource_class('Observation'), comparator_search_params)
             validate_search_reply(versioned_resource_class('Observation'), reply, comparator_search_params)
           end
+
+          value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category'), true)
+          token_with_system_search_params = search_params.merge('category': value_with_system)
+          reply = get_resource_by_params(versioned_resource_class('Observation'), token_with_system_search_params)
+          validate_search_reply(versioned_resource_class('Observation'), reply, token_with_system_search_params)
         end
 
         skip 'Could not resolve all parameters (patient, category, date) in any resource.' unless resolved_one
@@ -271,6 +295,11 @@ module Inferno
           reply = perform_search_with_status(reply, search_params) if reply.code == 400
 
           validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
+
+          value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category'), true)
+          token_with_system_search_params = search_params.merge('category': value_with_system)
+          reply = get_resource_by_params(versioned_resource_class('Observation'), token_with_system_search_params)
+          validate_search_reply(versioned_resource_class('Observation'), reply, token_with_system_search_params)
         end
 
         skip 'Could not resolve all parameters (patient, category) in any resource.' unless resolved_one
@@ -323,6 +352,11 @@ module Inferno
             reply = get_resource_by_params(versioned_resource_class('Observation'), comparator_search_params)
             validate_search_reply(versioned_resource_class('Observation'), reply, comparator_search_params)
           end
+
+          value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'code'), true)
+          token_with_system_search_params = search_params.merge('code': value_with_system)
+          reply = get_resource_by_params(versioned_resource_class('Observation'), token_with_system_search_params)
+          validate_search_reply(versioned_resource_class('Observation'), reply, token_with_system_search_params)
         end
 
         skip 'Could not resolve all parameters (patient, code, date) in any resource.' unless resolved_one
@@ -362,6 +396,11 @@ module Inferno
           reply = get_resource_by_params(versioned_resource_class('Observation'), search_params)
 
           validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
+
+          value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category'), true)
+          token_with_system_search_params = search_params.merge('category': value_with_system)
+          reply = get_resource_by_params(versioned_resource_class('Observation'), token_with_system_search_params)
+          validate_search_reply(versioned_resource_class('Observation'), reply, token_with_system_search_params)
         end
 
         skip 'Could not resolve all parameters (patient, category, status) in any resource.' unless resolved_one

--- a/test/unit/sequence_base_test.rb
+++ b/test/unit/sequence_base_test.rb
@@ -56,8 +56,31 @@ class SequenceBaseTest < MiniTest::Test
           @sequence.validate_resource_item(@allergy_intolerance_resource, key.to_s, value)
         end
       end
-      expected_error_msg = 'clinical-status in AllergyIntolerance/SMART-AllergyIntolerance-28 (["active"]) does not match clinical-status requested (inactive)'
+      expected_error_msg = "clinical-status in AllergyIntolerance/SMART-AllergyIntolerance-28 (#{@sequence.resolve_path(@allergy_intolerance_resource, 'clinicalStatus')})"\
+        ' does not match clinical-status requested (inactive)'
       assert error.message == expected_error_msg, "expected: #{expected_error_msg}, actual: #{error.message}"
+    end
+
+    it 'passes when the correct system for clinical-status is searched' do
+      search_params = {
+        'patient': '1234',
+        'clinical-status': 'http://terminology.hl7.org/CodeSystem/allergyintolerance-clinical|active'
+      }
+      search_params.each do |key, value|
+        @sequence.validate_resource_item(@allergy_intolerance_resource, key.to_s, value)
+      end
+    end
+
+    it 'fails when the incorrect system is searched' do
+      search_params = {
+        'patient': '1234',
+        'clinical-status': 'http://terminology.hl7.org|active'
+      }
+      assert_raises(Inferno::AssertionException) do
+        search_params.each do |key, value|
+          @sequence.validate_resource_item(@allergy_intolerance_resource, key.to_s, value)
+        end
+      end
     end
   end
 


### PR DESCRIPTION
This PR creates a search that includes system for searches which include a parameter that's a CodeableConcept, Coding, or Identifier. It works by just grabbing whatever the system value was from the resources found in previous searches. The search validators have been updated to check for system values. 

**Submitter:**
- [X] This pull request describes why these changes were made
- [X] Internal ticket for this PR: https://oncprojectracking.healthit.gov/support/browse/FI-585
- [X] Internal ticket links to this PR
- [X] Internal ticket is properly labeled (Community/Program)
- [X] Internal ticket has a justification for its Community/Program label
- [X] Code diff has been reviewed for extraneous/missing code
- [X] Tests are included and test edge cases
- [X] Tests/code quality metrics have been run locally and pass


**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
