### PR TITLE
Have limited access check request all scopes and expect tester to select subset in EHR interface

### DIFF
--- a/generator/uscore/templates/access_verify_sequence.rb.erb
+++ b/generator/uscore/templates/access_verify_sequence.rb.erb
@@ -108,7 +108,7 @@ module Inferno
 
         if access_allowed_scope.present?
           assert_response_ok reply
-          pass "Access expcted to be granted and request properly returned #{reply&.response&.dig(:code)}"
+          pass "Access expected to be granted and request properly returned #{reply&.response&.dig(:code)}"
         else
           assert_response_unauthorized reply
         end

--- a/generator/uscore/templates/access_verify_sequence.rb.erb
+++ b/generator/uscore/templates/access_verify_sequence.rb.erb
@@ -22,10 +22,22 @@ module Inferno
       
       )
 
-      requires :onc_sl_url, :token, :patient_id, :received_scopes
+      requires :onc_sl_url, :token, :patient_id, :received_scopes<% if access_verify_restriction == 'restricted' %>, :onc_sl_expected_resources<% end %>
 
       def scopes
-        @instance.received_scopes || <% if access_verify_restriction == 'restricted' %>@instance.onc_sl_restricted_scopes<% else %> @instance.onc_sl_scopes<% end %>
+        @instance.received_scopes || @instance.onc_sl_scopes
+      end
+
+      def resource_access_as_scope
+        <% if access_verify_restriction == 'restricted' %>
+        @instance.onc_sl_expected_resources&.split(',')&.map{|resource| "patient/#{resource.strip}.read"}&.join(' ')
+        <% else %>
+          all_resources = [
+          <%= non_delayed_sequences.group_by{|sequence| sequence[:resource]}.values.map(&:first).map{|resource| "'#{resource[:resource]}'"}.join(",\n") %>,
+          'Patient'
+          ]
+          all_resources.map{|resource| "patient/#{resource.strip}.read"}&.join(' ')
+        <% end %>
       end
 
       def url_property
@@ -41,27 +53,32 @@ module Inferno
       test :validate_right_scopes do
         metadata do
           id '01'
-          <% if access_verify_restriction == 'restricted' %>name 'Verify scope provided do not contain all resource types'
-          <% else %>name 'Verify scope enables access to all US Core resource types'
+          <% if access_verify_restriction == 'restricted' %>name 'Scope granted is limited to those chosen by user during authorization.'
+          <% else %>name 'Scope granted enables access to all US Core resource types.'
           <% end %>
           link 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient'
           description %(
-            This test checks if the resources returned from bulk data export conform to the US Core profiles. This includes checking for missing data elements and valueset verification.
+            This test confirms that the scopes received during authorization match those that
+            expected for this launch.
           )
         end
 
         skip_if @instance.received_scopes.nil?, 'No SMART scopes were provided to the test.'
 
         all_resources = [
-        <%= non_delayed_sequences.group_by{|sequence| sequence[:resource]}.values.map(&:first).map{|resource| "'#{resource[:resource]}'"}.join(",\n") %>
+        <%= non_delayed_sequences.group_by{|sequence| sequence[:resource]}.values.map(&:first).map{|resource| "'#{resource[:resource]}'"}.join(",\n") %>,
+        'Patient'
         ]
 
 
-       allowed_resources = all_resources.select {|resource| scope_granting_access(resource, scopes).present? }
+       allowed_resources = all_resources.select {|resource| scope_granting_access(resource, resource_access_as_scope)}
        denied_resources = all_resources - allowed_resources
 
        <% if access_verify_restriction == 'restricted' %>
-       assert denied_resources.present?, "This test requires at least one resource to be denied, but the received scope '#{@instance.received_scopes}' grants access to all resource types."
+       assert denied_resources.present?, "This test requires at least one resource to be denied, but the provided scope '#{@instance.received_scopes}' grants access to all resource types."
+       received_scope_resources = all_resources.select{|resource| scope_granting_access(resource, @instance.received_scopes)}
+       unexpected_resources = received_scope_resources - allowed_resources
+       assert unexpected_resources.empty?, "This test expected the user to deny access to the following resources that are present in scopes received during token exchange response: #{unexpected_resources.join(', ')}"
        pass "Resources to be denied: #{denied_resources.join(',')}"
        <% else %>
        assert denied_resources.empty?, "This test requires access to all US Core resources with patient information, but the received scope '#{@instance.received_scopes}' does not grant access to the '#{denied_resources.join(', ')}' resource type(s)."
@@ -87,11 +104,11 @@ module Inferno
 
         reply = @client.read(FHIR::Patient, @instance.patient_id)
 
-        access_allowed_scope = scope_granting_access('Patient', scopes)
+        access_allowed_scope = scope_granting_access('Patient', resource_access_as_scope)
 
         if access_allowed_scope.present?
           assert_response_ok reply
-          pass "Access granted by scope #{access_allowed_scope} and request properly returned #{reply&.response&.dig(:code)}"
+          pass "Access expcted to be granted and request properly returned #{reply&.response&.dig(:code)}"
         else
           assert_response_unauthorized reply
         end
@@ -125,7 +142,7 @@ module Inferno
           }
         }
         reply = @client.search('<%=sequence[:resource]%>', options)
-        access_allowed_scope = scope_granting_access('<%=sequence[:resource]%>', scopes)
+        access_allowed_scope = scope_granting_access('<%=sequence[:resource]%>', resource_access_as_scope)
 
         if access_allowed_scope.present?
           <% if access_verify_status_codes.key?(sequence[:resource].downcase.to_sym) %>
@@ -147,7 +164,7 @@ module Inferno
           end
           <% end %>
           assert_response_ok reply
-          pass "Access granted by scope #{access_allowed_scope} and request properly returned #{reply&.response&.dig(:code)}"
+          pass "Access expected to be granted and request properly returned #{reply&.response&.dig(:code)}"
     
         else
           assert_response_unauthorized reply

--- a/lib/app/views/onc_program.erb
+++ b/lib/app/views/onc_program.erb
@@ -423,11 +423,11 @@
               value: instance.onc_sl_scopes || 'launch/patient openid fhirUser offline_access patient/Medication.read patient/AllergyIntolerance.read patient/CarePlan.read patient/CareTeam.read patient/Condition.read patient/Device.read patient/DiagnosticReport.read patient/DocumentReference.read patient/Encounter.read patient/Goal.read patient/Immunization.read patient/Location.read patient/MedicationRequest.read patient/Observation.read patient/Organization.read patient/Patient.read patient/Practitioner.read patient/PractitionerRole.read patient/Procedure.read patient/Provenance.read'
                })%>
 
-        <%= erb(:prerequisite_field,{},{prerequisite: :onc_sl_restricted_scopes,
-              label: 'Limited Standalone Patient Scope',
-              description: 'OAuth 2.0 scope to enable all or limited functionality',
+        <%= erb(:prerequisite_field,{},{prerequisite: :onc_sl_expected_resources,
+              label: 'Expected Resource Grant',
+              description: 'The user will only grant access to the following resources during authorization.',
               instance: instance,
-              value: instance.onc_sl_restricted_scopes || 'launch/patient patient/Patient.read patient/Condition.read patient/Observation.read',
+              value: instance.onc_sl_expected_resources || 'Patient, Condition, Observation',
               required: true,
               })%>
 

--- a/lib/modules/onc_program/onc_parameters.rb
+++ b/lib/modules/onc_program/onc_parameters.rb
@@ -8,7 +8,7 @@ module Inferno
       property :onc_sl_client_id, String
       property :onc_sl_client_secret, String
       property :onc_sl_scopes, String
-      property :onc_sl_restricted_scopes, String
+      property :onc_sl_expected_resources, String
 
       property :onc_patient_ids, String
 

--- a/lib/modules/onc_program/onc_standalone_launch_sequence.rb
+++ b/lib/modules/onc_program/onc_standalone_launch_sequence.rb
@@ -125,7 +125,7 @@ module Inferno
           'response_type' => 'code',
           'client_id' => @instance.onc_sl_client_id,
           'redirect_uri' => @instance.redirect_uris,
-          'scope' => @instance.onc_sl_scopes,
+          'scope' => instance_scopes,
           'state' => @instance.state,
           'aud' => @instance.onc_sl_url
         }

--- a/lib/modules/onc_program/onc_standalone_restricted_launch_sequence.rb
+++ b/lib/modules/onc_program/onc_standalone_restricted_launch_sequence.rb
@@ -17,7 +17,8 @@ module Inferno
                :onc_sl_client_id,
                :onc_sl_confidential_client,
                :onc_sl_client_secret,
-               :onc_sl_restricted_scopes,
+               :onc_sl_scopes,
+               :onc_sl_expected_resources,
                :oauth_authorize_endpoint,
                :oauth_token_endpoint,
                :initiate_login_uri,
@@ -102,7 +103,7 @@ module Inferno
       end
 
       def instance_scopes
-        @instance.onc_sl_restricted_scopes
+        @instance.onc_sl_scopes
       end
 
       auth_endpoint_tls_test(index: '01')
@@ -163,6 +164,58 @@ module Inferno
       token_response_headers_test(index: '09')
 
       patient_context_test(index: '10')
+
+      def scope_granting_access(resource, scopes)
+        scopes.split(' ').find do |scope|
+          scope.start_with?("patient/#{resource}", 'patient/*') && scope.end_with?('*', 'read')
+        end
+      end
+
+      test :onc_restricted_scopes do
+        metadata do
+          id '11'
+          name 'OAuth token exchange response grants scope that is limited to those selected by user'
+          link 'http://www.hl7.org/fhir/smart-app-launch/scopes-and-launch-context/index.html#quick-start'
+          description %(
+            The ONC certification criteria requires that patients are capable of choosing which
+            FHIR resources to authorize to the application, and patients must be
+            given the choice to grant `offline_access`.  For this test, the tester specifies
+            which resources will be selected during authorization, and this verifies that only
+            those resources are granted according to the scopes returned during the access token
+            response.
+          )
+        end
+
+        skip_if_auth_failed
+
+        received_scopes = @instance.received_scopes || ''
+
+        all_resources = [
+          'AllergyIntolerance',
+          'CarePlan',
+          'CareTeam',
+          'Condition',
+          'Device',
+          'DiagnosticReport',
+          'DocumentReference',
+          'Goal',
+          'Immunization',
+          'MedicationRequest',
+          'Observation',
+          'Procedure',
+          'Patient'
+        ]
+
+        expected_resources = all_resources.select { |resource| @instance.onc_sl_expected_resources.split(',').map(&:strip).map(&:downcase).include?(resource.downcase) }
+        expected_denied_resources = all_resources - expected_resources
+
+        improperly_granted_resources = expected_denied_resources.select { |resource| scope_granting_access(resource, received_scopes).present? }
+
+        assert improperly_granted_resources.empty?, "User expected to deny the following resources that were granted: #{improperly_granted_resources.join(', ')}"
+
+        assert !received_scopes.split(' ').include?('offline_access'), 'Scopes returned in access token response contained offline_access.  User must deny this scope to pass this test.'
+
+      end
     end
   end
 end

--- a/lib/modules/onc_program/onc_standalone_restricted_launch_sequence.rb
+++ b/lib/modules/onc_program/onc_standalone_restricted_launch_sequence.rb
@@ -214,7 +214,6 @@ module Inferno
         assert improperly_granted_resources.empty?, "User expected to deny the following resources that were granted: #{improperly_granted_resources.join(', ')}"
 
         assert !received_scopes.split(' ').include?('offline_access'), 'Scopes returned in access token response contained offline_access.  User must deny this scope to pass this test.'
-
       end
     end
   end

--- a/lib/modules/onc_program/shared_onc_launch_tests.rb
+++ b/lib/modules/onc_program/shared_onc_launch_tests.rb
@@ -295,7 +295,7 @@ module Inferno
           test :token_response_contents do
             metadata do
               id index
-              name 'Token exchange response body contains required information encoded in JSON'
+              name 'OAuth token exchange response body contains required information encoded in JSON'
               link 'http://www.hl7.org/fhir/smart-app-launch/'
               description %(
                 The EHR authorization server shall return a JSON structure that
@@ -317,7 +317,7 @@ module Inferno
           test :token_response_headers do
             metadata do
               id index
-              name 'Response includes correct HTTP Cache-Control and Pragma headers'
+              name 'OAuth Token exchange response includes correct HTTP Cache-Control and Pragma headers'
               link 'http://www.hl7.org/fhir/smart-app-launch/'
               description %(
                 The authorization servers response must include the HTTP
@@ -341,7 +341,8 @@ module Inferno
               name "#{patient_or_user.capitalize}-level access with OpenID Connect and Refresh Token scopes used."
               link 'http://www.hl7.org/fhir/smart-app-launch/scopes-and-launch-context/index.html#quick-start'
               description %(
-                The scopes being input must follow the guidelines specified in the smart-app-launch guide
+                The scopes being input must follow the guidelines specified in the smart-app-launch guide.
+                All scopes requested are expected to be granted.
               )
             end
 
@@ -395,7 +396,7 @@ module Inferno
           test :patient_context do
             metadata do
               id index
-              name 'Patient context provided during token exchange and patient resource can be retrieved'
+              name 'OAuth token exchange response body contains patient context and patient resource can be retrieved'
               link 'http://www.hl7.org/fhir/smart-app-launch/scopes-and-launch-context/index.html#scopes-for-requesting-context-data'
               description %(
                 The `patient` field is a String value with a patient id,

--- a/lib/modules/onc_program_module.yml
+++ b/lib/modules/onc_program_module.yml
@@ -44,16 +44,24 @@ test_sets:
         short_label: Limited App
         run_all: true
         overview: |
-          This scenario demonstrates the ability to perform a Patient Standalone Launch to a [SMART on FHIR](http://www.hl7.org/fhir/smart-app-launch/) client 
-          with limited access granted to the application.  The tester is expected to grant the application access to a subset of the relevant resource
-          types, and Inferno verifies that the application is granted access consistent with that subset.
+          This scenario demonstrates the ability to perform a Patient Standalone
+          Launch to a [SMART on FHIR](http://www.hl7.org/fhir/smart-app-launch/)
+          client with limited access granted to the app based on user input.
+          The tester is expected to grant the application access to a subset of
+          desired resource types, and to deny requests for "offline_access"
+          refresh tokens.
         input_instructions: |
-          The purpose of this test is to demonstrate that an app can be restricted to a subset of scopes.  This can either be done by having the app
-          request a subset of resource type scopes to be read, or by having the user select a subset of resources to grant an app access to during launch.
-          This uses the same app that was registered and used in the standalone patient app launch.  This test requires a patient context to be granted.
+          The purpose of this test is to demonstrate that users can restrict
+          access granted to apps to a limited number of resources and does
+          not force the user to have offline_access refresh tokens.  Enter
+          which resources the user will grant access to below, and during
+          the launch process only grant access to those resources. Additionally,
+          do not grant access to offline_access refresh tokens.  Inferno
+          will verify that access granted matches these expectations.
         lock_variables: 
           - redirect_uris
           - onc_sl_url
+          - onc_sl_scopes
           - oauth_authorize_endpoint
           - oauth_token_endpoint
           - onc_sl_confidential_client

--- a/lib/modules/uscore_v3.1.0/access_verify_restricted_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/access_verify_restricted_sequence.rb
@@ -121,7 +121,7 @@ module Inferno
 
         if access_allowed_scope.present?
           assert_response_ok reply
-          pass "Access expcted to be granted and request properly returned #{reply&.response&.dig(:code)}"
+          pass "Access expected to be granted and request properly returned #{reply&.response&.dig(:code)}"
         else
           assert_response_unauthorized reply
         end

--- a/lib/modules/uscore_v3.1.0/access_verify_unrestricted_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/access_verify_unrestricted_sequence.rb
@@ -133,7 +133,7 @@ module Inferno
 
         if access_allowed_scope.present?
           assert_response_ok reply
-          pass "Access expcted to be granted and request properly returned #{reply&.response&.dig(:code)}"
+          pass "Access expected to be granted and request properly returned #{reply&.response&.dig(:code)}"
         else
           assert_response_unauthorized reply
         end

--- a/lib/modules/uscore_v3.1.0/access_verify_unrestricted_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/access_verify_unrestricted_sequence.rb
@@ -42,7 +42,26 @@ module Inferno
       requires :onc_sl_url, :token, :patient_id, :received_scopes
 
       def scopes
-        @instance.received_scopes ||  @instance.onc_sl_scopes
+        @instance.received_scopes || @instance.onc_sl_scopes
+      end
+
+      def resource_access_as_scope
+        all_resources = [
+          'AllergyIntolerance',
+          'CarePlan',
+          'CareTeam',
+          'Condition',
+          'Device',
+          'DiagnosticReport',
+          'DocumentReference',
+          'Goal',
+          'Immunization',
+          'MedicationRequest',
+          'Observation',
+          'Procedure',
+          'Patient'
+        ]
+        all_resources.map { |resource| "patient/#{resource.strip}.read" }&.join(' ')
       end
 
       def url_property
@@ -58,11 +77,12 @@ module Inferno
       test :validate_right_scopes do
         metadata do
           id '01'
-          name 'Verify scope enables access to all US Core resource types'
+          name 'Scope granted enables access to all US Core resource types.'
 
           link 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient'
           description %(
-            This test checks if the resources returned from bulk data export conform to the US Core profiles. This includes checking for missing data elements and valueset verification.
+            This test confirms that the scopes received during authorization match those that
+            expected for this launch.
           )
         end
 
@@ -80,10 +100,11 @@ module Inferno
           'Immunization',
           'MedicationRequest',
           'Observation',
-          'Procedure'
+          'Procedure',
+          'Patient'
         ]
 
-        allowed_resources = all_resources.select { |resource| scope_granting_access(resource, scopes).present? }
+        allowed_resources = all_resources.select { |resource| scope_granting_access(resource, resource_access_as_scope) }
         denied_resources = all_resources - allowed_resources
 
         assert denied_resources.empty?, "This test requires access to all US Core resources with patient information, but the received scope '#{@instance.received_scopes}' does not grant access to the '#{denied_resources.join(', ')}' resource type(s)."
@@ -108,11 +129,11 @@ module Inferno
 
         reply = @client.read(FHIR::Patient, @instance.patient_id)
 
-        access_allowed_scope = scope_granting_access('Patient', scopes)
+        access_allowed_scope = scope_granting_access('Patient', resource_access_as_scope)
 
         if access_allowed_scope.present?
           assert_response_ok reply
-          pass "Access granted by scope #{access_allowed_scope} and request properly returned #{reply&.response&.dig(:code)}"
+          pass "Access expcted to be granted and request properly returned #{reply&.response&.dig(:code)}"
         else
           assert_response_unauthorized reply
         end
@@ -142,7 +163,7 @@ module Inferno
           }
         }
         reply = @client.search('AllergyIntolerance', options)
-        access_allowed_scope = scope_granting_access('AllergyIntolerance', scopes)
+        access_allowed_scope = scope_granting_access('AllergyIntolerance', resource_access_as_scope)
 
         if access_allowed_scope.present?
 
@@ -161,7 +182,7 @@ module Inferno
           end
 
           assert_response_ok reply
-          pass "Access granted by scope #{access_allowed_scope} and request properly returned #{reply&.response&.dig(:code)}"
+          pass "Access expected to be granted and request properly returned #{reply&.response&.dig(:code)}"
 
         else
           assert_response_unauthorized reply
@@ -193,7 +214,7 @@ module Inferno
           }
         }
         reply = @client.search('CarePlan', options)
-        access_allowed_scope = scope_granting_access('CarePlan', scopes)
+        access_allowed_scope = scope_granting_access('CarePlan', resource_access_as_scope)
 
         if access_allowed_scope.present?
 
@@ -212,7 +233,7 @@ module Inferno
           end
 
           assert_response_ok reply
-          pass "Access granted by scope #{access_allowed_scope} and request properly returned #{reply&.response&.dig(:code)}"
+          pass "Access expected to be granted and request properly returned #{reply&.response&.dig(:code)}"
 
         else
           assert_response_unauthorized reply
@@ -244,7 +265,7 @@ module Inferno
           }
         }
         reply = @client.search('CareTeam', options)
-        access_allowed_scope = scope_granting_access('CareTeam', scopes)
+        access_allowed_scope = scope_granting_access('CareTeam', resource_access_as_scope)
 
         if access_allowed_scope.present?
 
@@ -263,7 +284,7 @@ module Inferno
           end
 
           assert_response_ok reply
-          pass "Access granted by scope #{access_allowed_scope} and request properly returned #{reply&.response&.dig(:code)}"
+          pass "Access expected to be granted and request properly returned #{reply&.response&.dig(:code)}"
 
         else
           assert_response_unauthorized reply
@@ -294,7 +315,7 @@ module Inferno
           }
         }
         reply = @client.search('Condition', options)
-        access_allowed_scope = scope_granting_access('Condition', scopes)
+        access_allowed_scope = scope_granting_access('Condition', resource_access_as_scope)
 
         if access_allowed_scope.present?
 
@@ -313,7 +334,7 @@ module Inferno
           end
 
           assert_response_ok reply
-          pass "Access granted by scope #{access_allowed_scope} and request properly returned #{reply&.response&.dig(:code)}"
+          pass "Access expected to be granted and request properly returned #{reply&.response&.dig(:code)}"
 
         else
           assert_response_unauthorized reply
@@ -344,12 +365,12 @@ module Inferno
           }
         }
         reply = @client.search('Device', options)
-        access_allowed_scope = scope_granting_access('Device', scopes)
+        access_allowed_scope = scope_granting_access('Device', resource_access_as_scope)
 
         if access_allowed_scope.present?
 
           assert_response_ok reply
-          pass "Access granted by scope #{access_allowed_scope} and request properly returned #{reply&.response&.dig(:code)}"
+          pass "Access expected to be granted and request properly returned #{reply&.response&.dig(:code)}"
 
         else
           assert_response_unauthorized reply
@@ -381,7 +402,7 @@ module Inferno
           }
         }
         reply = @client.search('DiagnosticReport', options)
-        access_allowed_scope = scope_granting_access('DiagnosticReport', scopes)
+        access_allowed_scope = scope_granting_access('DiagnosticReport', resource_access_as_scope)
 
         if access_allowed_scope.present?
 
@@ -400,7 +421,7 @@ module Inferno
           end
 
           assert_response_ok reply
-          pass "Access granted by scope #{access_allowed_scope} and request properly returned #{reply&.response&.dig(:code)}"
+          pass "Access expected to be granted and request properly returned #{reply&.response&.dig(:code)}"
 
         else
           assert_response_unauthorized reply
@@ -431,7 +452,7 @@ module Inferno
           }
         }
         reply = @client.search('DocumentReference', options)
-        access_allowed_scope = scope_granting_access('DocumentReference', scopes)
+        access_allowed_scope = scope_granting_access('DocumentReference', resource_access_as_scope)
 
         if access_allowed_scope.present?
 
@@ -450,7 +471,7 @@ module Inferno
           end
 
           assert_response_ok reply
-          pass "Access granted by scope #{access_allowed_scope} and request properly returned #{reply&.response&.dig(:code)}"
+          pass "Access expected to be granted and request properly returned #{reply&.response&.dig(:code)}"
 
         else
           assert_response_unauthorized reply
@@ -481,7 +502,7 @@ module Inferno
           }
         }
         reply = @client.search('Goal', options)
-        access_allowed_scope = scope_granting_access('Goal', scopes)
+        access_allowed_scope = scope_granting_access('Goal', resource_access_as_scope)
 
         if access_allowed_scope.present?
 
@@ -500,7 +521,7 @@ module Inferno
           end
 
           assert_response_ok reply
-          pass "Access granted by scope #{access_allowed_scope} and request properly returned #{reply&.response&.dig(:code)}"
+          pass "Access expected to be granted and request properly returned #{reply&.response&.dig(:code)}"
 
         else
           assert_response_unauthorized reply
@@ -531,7 +552,7 @@ module Inferno
           }
         }
         reply = @client.search('Immunization', options)
-        access_allowed_scope = scope_granting_access('Immunization', scopes)
+        access_allowed_scope = scope_granting_access('Immunization', resource_access_as_scope)
 
         if access_allowed_scope.present?
 
@@ -550,7 +571,7 @@ module Inferno
           end
 
           assert_response_ok reply
-          pass "Access granted by scope #{access_allowed_scope} and request properly returned #{reply&.response&.dig(:code)}"
+          pass "Access expected to be granted and request properly returned #{reply&.response&.dig(:code)}"
 
         else
           assert_response_unauthorized reply
@@ -582,7 +603,7 @@ module Inferno
           }
         }
         reply = @client.search('MedicationRequest', options)
-        access_allowed_scope = scope_granting_access('MedicationRequest', scopes)
+        access_allowed_scope = scope_granting_access('MedicationRequest', resource_access_as_scope)
 
         if access_allowed_scope.present?
 
@@ -601,7 +622,7 @@ module Inferno
           end
 
           assert_response_ok reply
-          pass "Access granted by scope #{access_allowed_scope} and request properly returned #{reply&.response&.dig(:code)}"
+          pass "Access expected to be granted and request properly returned #{reply&.response&.dig(:code)}"
 
         else
           assert_response_unauthorized reply
@@ -633,7 +654,7 @@ module Inferno
           }
         }
         reply = @client.search('Observation', options)
-        access_allowed_scope = scope_granting_access('Observation', scopes)
+        access_allowed_scope = scope_granting_access('Observation', resource_access_as_scope)
 
         if access_allowed_scope.present?
 
@@ -652,7 +673,7 @@ module Inferno
           end
 
           assert_response_ok reply
-          pass "Access granted by scope #{access_allowed_scope} and request properly returned #{reply&.response&.dig(:code)}"
+          pass "Access expected to be granted and request properly returned #{reply&.response&.dig(:code)}"
 
         else
           assert_response_unauthorized reply
@@ -683,7 +704,7 @@ module Inferno
           }
         }
         reply = @client.search('Procedure', options)
-        access_allowed_scope = scope_granting_access('Procedure', scopes)
+        access_allowed_scope = scope_granting_access('Procedure', resource_access_as_scope)
 
         if access_allowed_scope.present?
 
@@ -702,7 +723,7 @@ module Inferno
           end
 
           assert_response_ok reply
-          pass "Access granted by scope #{access_allowed_scope} and request properly returned #{reply&.response&.dig(:code)}"
+          pass "Access expected to be granted and request properly returned #{reply&.response&.dig(:code)}"
 
         else
           assert_response_unauthorized reply


### PR DESCRIPTION
This updates the limited access test so that Inferno (as an app) requests full permissions again, but then expects the user to select a subset consistent with the resources that the tester entered in the UI.  Additionally, the tester is expected to NOT select 'offline_access', to prove that the server does not blindly accept the app's request for that level of permission.

Testing this is a challenge, because our reference server currently does not provide a modal to select a subset of resources.  Logica health can do this though.

Pull requests into Inferno require the following items to be completed. Submitter and reviewer 
should check the relevant check boxes when the associated item is done. For items that are not 
applicable, note it's not applicable ("N/A") and check the box. For example, external Pull 
Requests do not require ticket links.

**Submitter:**
- [x] This pull request describes why these changes were made
- [x] Internal ticket for this PR:
- [x] Internal ticket links to this PR
- [x] Internal ticket is properly labeled (Community/Program)
- [x] Internal ticket has a justification for its Community/Program label
- [x] Code diff has been reviewed for extraneous/missing code
- n/a Tests are included and test edge cases
- [x] Tests/code quality metrics have been run locally and pass


**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
