### PR TITLE
Handles empty lines in export file

### DIFF
--- a/lib/app/models/module/test_procedure.rb
+++ b/lib/app/models/module/test_procedure.rb
@@ -37,11 +37,12 @@ module Inferno
         attr_accessor :inferno_module
         attr_accessor :group
         attr_accessor :id
-        attr_accessor :SUT
-        attr_accessor :TLV
+        attr_accessor :s_u_t
+        attr_accessor :t_l_v
         attr_accessor :inferno_supported
         attr_accessor :inferno_notes
         attr_accessor :inferno_tests
+        attr_accessor :alternate_test
 
         def initialize(data, inferno_module)
           @group = data[:group]
@@ -50,6 +51,7 @@ module Inferno
           @t_l_v = data[:TLV]
           @inferno_supported = data[:inferno_supported]
           @inferno_notes = data[:inferno_notes]
+          @alternate_test = data[:alternate_test]
           @inferno_module = inferno_module
           @inferno_tests = expand_tests(data[:inferno_tests]).flatten
         end

--- a/lib/modules/onc_program/bulk_data_group_validation_sequence.rb
+++ b/lib/modules/onc_program/bulk_data_group_validation_sequence.rb
@@ -251,7 +251,7 @@ module Inferno
           # Skip process the last line since the it may not complete (still appending from stream)
           last_line = resource_list.pop
           # Skip if the last_line is empty
-          next_block = String.new last_line unless last_line.blank?
+          next_block = String.new last_line unless last_line.nil?
 
           resource_list.each do |resource|
             # NDJSON does not specify empty line is NOT allowed.

--- a/lib/modules/onc_program_procedure.yml
+++ b/lib/modules/onc_program_procedure.yml
@@ -4,47 +4,67 @@ procedure:
       - group: Application Registration
         id: APP-REGISTRATION-1
         SUT: |
-          The health IT developer demonstrates the Health IT Module
-          supports application registration with an authorization server for
-          the purposes of Electronic Health Information (EHI) access for
-          single patients, including support for application registration
-          functions to enable authentication and authorization in §
-          170.315(g)(10)(v).
+          The health IT developer demonstrates the Health IT Module supports
+          application registration with an authorization server for the purposes
+          of Electronic Health Information (EHI) access for single patients,
+          including support for application registration functions to enable
+          authentication and authorization in § 170.315(g)(10)(v).
         TLV: |
           The tester verifies the Health IT Module supports application
           registration with an authorization server for the purposes of EHI
           access for single patients, including support for application
-          registration functions to enable authentication and authorization in
-          § 170.315(g)(10)(v).
+          registration functions to enable authentication and authorization in §
+          170.315(g)(10)(v).
         inferno_supported: 'no'
         inferno_notes: |
-          Application registration is considered out of scope for Inferno
-          Program Edition because it cannot be done in an automated fashion.
-          Inferno Program Edition may in the future include Dynamic Registration
-          functionality for those systems that support that standard.  It may
-          also include an input field to allow the tester to document that this
-          has been performed.
+          Application registration is currently out of scope for automated
+          testing within Inferno Program Edition because there is no standard
+          being required.
+        alternate_test: |
+          Prior to executing the single patient tests, the health IT developer
+          must demonstrate the steps involved in registering Inferno as a client
+          application using registration information provided within the Inferno
+          interface (e.g. redirect url). During this process, the system under
+          test developer provides a client ID, client secret, and a list of
+          authorized scopes to Inferno.  By inputting this information into
+          Inferno, the tester verifies that a new client application can be
+          registered within the system under test. All tests within "Standalone
+          Patient App", "Limited Scope App", and "EHR Practitioner App" must use
+          clients registered at the time of testing.  Note that the "Standalone
+          Patient App" and "EHR Practioner App" can use separate client
+          registrations if necessary.
       - id: APP-REGISTRATION-2
         SUT: |
-          The health IT developer demonstrates the Health IT Module
-          supports application registration with an authorization server for
-          the purposes of EHI access for multiple patients, including support
-          for application registration functions to enable authentication and
-          authorization in § 170.315(g)(10)(v).
+          The health IT developer demonstrates the Health IT Module supports
+          application registration with an authorization server for the purposes
+          of EHI access for multiple patients, including support for application
+          registration functions to enable authentication and authorization in §
+          170.315(g)(10)(v).
         TLV: |
           The tester verifies the Health IT Module supports application
           registration with an authorization server for the purposes of EHI
           access for multiple patients including support for application
-          registration functions to enable authentication and authorization in
-          § 170.315(g)(10)(v).
+          registration functions to enable authentication and authorization in §
+          170.315(g)(10)(v).
         inferno_supported: 'no'
         inferno_notes: |
           Application registration is considered out of scope for Inferno
-          Program Edition because it cannot be accomplished using automation.
-          Inferno Program Edition may in the future include OAuth Dynamic Registration
-          functionality for those systems that support that standard.  It may
-          also include an input field to allow the tester to document that this
-          has been performed.
+          Program Edition because there are no requirements on how registration
+          can occur.
+        alternate_test: |
+          Prior to executing the 'Multi-Patient Data Query' tests, the health IT
+          developer must demonstrate the steps involved in registering Inferno
+          as a bulk client application using the JWKS URL provided within the
+          Inferno interface.  During this process, the health IT developer
+          provides a backend serives token endpoint, a bulk client ID, and a
+          list of authorized scopes for the application.  By inputting this
+          information into Inferno, the tester verifies that a new client
+          application can be registered within the system under test.
+          Registering client applications using the JWKS URL is strongly
+          recommended in the specification, but if this is not possible, the
+          tester can provide the keys directly by manually visiting Inferno's
+          JWKS URL and providing that to the health IT developer.
+          
   - section: Paragraph (g)(10)(iv) – Secure connection
     steps:
       - group: Secure connection
@@ -59,7 +79,7 @@ procedure:
           * Conformance to FHIR Communications Security requirements.
         TLV: |
           For all transmissions between the Health IT Module and the
-          application, the tester verifiesthe use of a secure and trusted
+          application, the tester verifies the use of a secure and trusted
           connection in accordance with the implementation specifications
           adopted in § 170.215(a)(2) and § 170.215(a)(3), including:
           * Using TLS version 1.2 or higher; and
@@ -71,9 +91,20 @@ procedure:
           - RPA-OSRLS-01
           - RPA-OSRLS-04
           - EHB-OELS-03
+          - EHB-OELS-06
           - USCCAP-01
           - BDA-01
           - BDE-01
+          - BDGV-01
+        inferno_notes: |
+          Inferno tests that all endpoints provided support at least TLS
+          version 1.2, and rejects all requests for TLS version 1.1 or below.
+          This includes all FHIR endpoints (if more than one is provided), as
+          well as authorization endpoints required by SMART. Inferno can be
+          configured to disable TLS testing if configuring TLS within a
+          lab environment is not possible.  Note that there are no SHALL
+          requirements within the "FHIR Communications Security Requirements" in
+          FHIR R4, and therefore there are no tests based on this requirement.
   - section: Paragraph (g)(10)(v)(A) – Authentication and authorization for patient and user scopes
     steps:
       - group: Authentication and Authorization for Patient and User Scopes
@@ -91,7 +122,7 @@ procedure:
           implementation specification adopted in § 170.215(a)(3).
         inferno_supported: 'yes'
         inferno_tests:
-          - SPA-OSD-01
+          - EHB-OELS-01 - EHB-OELS-02
           - SPB-OSLS-01
           - EHA-OSD-01
           - EHB-OELS-01
@@ -115,6 +146,7 @@ procedure:
         inferno_supported: 'yes'
         inferno_tests:
           - EHB-OELS-01 - EHB-OELS-02
+          - EHB-OELS-04
       - id: AUTH-PATIENT-3
         SUT: |
           [Standalone-Launch] The health IT developer demonstrates the
@@ -129,7 +161,7 @@ procedure:
           implementation specification adopted in § 170.215(a)(3).
         inferno_supported: 'yes'
         inferno_tests:
-          - SPB-OSLS-01 - SPB-OSLS-09
+          - SPB-OSLS-02
       - id: AUTH-PATIENT-4
         SUT: |
           [Both] The health IT developer demonstrates the ability of the
@@ -148,7 +180,9 @@ procedure:
         inferno_supported: 'yes'
         inferno_tests:
           - SPA-OSD-01 - SPA-OSD-02
+          - SPA-OSD-04
           - EHA-OSD-01 - EHA-OSD-02
+          - EHA-OSD-04
       - id: AUTH-PATIENT-5
         SUT: |
           [Both] The health IT developer demonstrates the ability of the
@@ -167,8 +201,14 @@ procedure:
           * “capabilities” (including support for all the “SMART on FHIR Core Capabilities”).
         inferno_supported: 'yes'
         inferno_tests:
-          - SPA-OSD-06
-          - EHA-OSD-06
+          - SPA-OSD-02
+          - SPA-OSD-05 - SPA-OSD-06
+          - EHA-OSD-02
+          - EHA-OSD-05 - EHA-OSD-06
+        inferno_notes: |
+          Inferno additionally checks that the "authorization endpoint" and the
+          "token endpoint" are consistent between the Capability Statement and
+          the well-known endpoint.
       - id: AUTH-PATIENT-6
         SUT: |
           [Both] The health IT developer demonstrates the ability of the
@@ -188,8 +228,12 @@ procedure:
           * “token”.
         inferno_supported: 'yes'
         inferno_tests:
-          - SPA-OSD-04
-          - EHA-OSD-04
+          - SPA-OSD-04 - SPA-OSD-05
+          - EHA-OSD-04 - EHA-OSD-05
+        inferno_notes: |
+          Inferno additionally checks that the "authorization endpoint" and the
+          "token endpoint" are consistent between the Capability Statement and
+          the well-known endpoint.
       - id: AUTH-PATIENT-7
         SUT: |
           [Both] The health IT developer demonstrates the ability of the
@@ -258,7 +302,7 @@ procedure:
           - EHB-OELS-09 - EHB-OELS-10
           - EHB-OELS-12
           - EHB-OELS-14 - EHB-OELS-16
-      - id: auth-patient-9
+      - id: AUTH-PATIENT-9
         SUT: |
           [Both] The health IT developer demonstrates the ability of the
           Health IT Module to evaluate the authorization request and
@@ -472,8 +516,8 @@ procedure:
           * “smart_style_url” (to support “context-style” “SMART on FHIR Core Capability” for EHR-Launch mode only).
         inferno_supported: 'yes'
         inferno_tests: 
-          - SPB-OSLS-08
-          - EHB-OELS-10
+          - SPB-OSLS-08 - SPB-OSLS-09
+          - EHB-OELS-10 - EHB-OELS-10
       - id: AUTH-PATIENT-16
         SUT: |
           [Both] The health IT developer demonstrates the ability of the
@@ -985,7 +1029,7 @@ procedure:
           * All data elements with required “ValueSet” bindings contain codes within the bound “ValueSet”;
           * All information is accurate and without omission; and
           * All references within the resources can be resolved and validated, as applicable, according to steps 2-6 of this section
-        inferno_supported: 'yes'
+        inferno_supported: 'partial'
         inferno_tests:
           - USCP-02
           - USCAI-02
@@ -1016,6 +1060,15 @@ procedure:
           - USCO-02
           - USCPROV-02
           - BDGV-01
+        inferno_notes: |
+          The requirement "all information is accurate and without omission" cannot be verified automatically by Inferno,
+          as Inferno only has visibility into the data being returned in the API.  Inferno also does not require
+          a specific set of data to be loaded.  Because of this, omissions are not possible to detect.
+        alternate_test: |
+          Inferno provides full logs of responses provided by the server.  Through this, the tester can manually
+          'spot check' data that is returned to match it up with the information on display in the EHR interface.
+          Future versions of Inferno could improve this experience, by adding search capabilities or automated matching
+          based on expected output.
       - id: RESPONSE-3
         SUT: |
           The health IT developer demonstrates the ability of the Health IT

--- a/lib/tasks/tasks.rake
+++ b/lib/tasks/tasks.rake
@@ -314,129 +314,223 @@ namespace :inferno do |_argv|
     args.with_defaults(filename: "#{args.module}_matrix.xlsx")
 
     workbook = RubyXL::Workbook.new
-    worksheet = workbook.worksheets[0]
-
-    # columns.each_with_index do |row_name, index|
-    #   cell = worksheet.add_cell(0, index, row_name.first)
-    #   cell.change_text_wrap(true)
-    # end
-
-    # worksheet.change_row_bold(0, true)
-    # worksheet.change_row_fill(0, 'BBBBBB')
-    # worksheet.change_row_height(0, 40)
 
     test_module = Inferno::Module.get(args.module)
     test_set = test_module.test_sets[args.test_set.to_sym]
+
+    ########################
+    # MATRIX WORKSHEET
+    ########################
+
+    matrix_worksheet = workbook.worksheets[0]
+    matrix_worksheet.sheet_name = 'Matrix'
+
     col = 2
-    cell = worksheet.add_cell(0, 1, "Inferno Program Tests (v#{Inferno::VERSION})")
-    worksheet.change_row_height(0, 20)
-    worksheet.change_row_vertical_alignment(0, 'distributed')
+    cell = matrix_worksheet.add_cell(0, 1, "Inferno Program Tests (v#{Inferno::VERSION})")
+    matrix_worksheet.change_row_height(0, 20)
+    matrix_worksheet.change_row_vertical_alignment(0, 'distributed')
     tests = []
     column_map = {}
-    worksheet.change_column_width(1, 25)
-    worksheet.change_row_height(1, 20)
-    worksheet.change_row_horizontal_alignment(1, 'center')
-    worksheet.change_row_vertical_alignment(1, 'distributed')
+    inferno_to_procedure_map = Hash.new { |h, k| h[k] = [] }
+    matrix_worksheet.change_column_width(1, 25)
+    matrix_worksheet.change_row_height(1, 20)
+    matrix_worksheet.change_row_horizontal_alignment(1, 'center')
+    matrix_worksheet.change_row_vertical_alignment(1, 'distributed')
     column_borders = []
 
     test_set.groups.each do |group|
-      cell = worksheet.add_cell(1, col, group.name)
-      worksheet.merge_cells(1, col, 1, col + group.test_cases.length - 1)
+      cell = matrix_worksheet.add_cell(1, col, group.name)
+      matrix_worksheet.merge_cells(1, col, 1, col + group.test_cases.length - 1)
       cell.change_text_wrap(true)
-      worksheet.change_column_border(col, :left, 'medium')
-      worksheet.change_column_border_color(col, :left, '000000')
+      matrix_worksheet.change_column_border(col, :left, 'medium')
+      matrix_worksheet.change_column_border_color(col, :left, '000000')
       column_borders << col
-      # worksheet.change_row_fill(row, 'EEEEEE')
-      # worksheet.change_row_height(row, 25)
-      # row += 1
+
       group.test_cases.each do |test_case|
-        worksheet.change_column_width(col, 4.2)
+        matrix_worksheet.change_column_width(col, 4.2)
 
         test_case_id = test_case.sequence.tests.first.id.split('-').first
         test_case_id = "#{test_case.prefix}#{test_case_id}" unless test_case.prefix.nil?
-        cell = worksheet.add_cell(2, col, test_case_id)
+        cell = matrix_worksheet.add_cell(2, col, test_case_id)
         cell.change_text_rotation(90)
         cell.change_border_color(:bottom, '000000')
         cell.change_border(:bottom, 'medium')
-        worksheet.change_column_border(col, :right, 'thin')
-        worksheet.change_column_border_color(col, :right, '666666')
+        matrix_worksheet.change_column_border(col, :right, 'thin')
+        matrix_worksheet.change_column_border_color(col, :right, '666666')
+
         test_case.sequence.tests.each do |test|
           tests << { test_case: test_case, test: test }
           full_test_id = "#{test_case.prefix}#{test.id}"
           column_map[full_test_id] = col
-
-          # next if test_case.sequence.optional? || test.optional?
-
-          # this_row = columns.map do |col|
-          #   col[2].call(group, test_case, test)
-          # end
-
-          # this_row.each_with_index do |value, index|
-          #   cell = worksheet.add_cell(row, index, value)
-          #   cell.change_text_wrap(true)
-          # end
-          # worksheet.change_row_height(row, 30)
-          # worksheet.change_row_vertical_alignment(row, 'top')
-          # worksheet.change_row_font_color(row, '666666') unless !test_case.sequence.optional? && !test.optional?
         end
         col += 1
       end
     end
 
     total_width = col - 1
-    worksheet.merge_cells(0, 1, 0, total_width)
-    worksheet.change_row_horizontal_alignment(0, 'center')
+    matrix_worksheet.merge_cells(0, 1, 0, total_width)
+    matrix_worksheet.change_row_horizontal_alignment(0, 'center')
 
-    cell = worksheet.add_cell(2, total_width + 2, 'Supported?')
+    cell = matrix_worksheet.add_cell(2, total_width + 2, 'Supported?')
     row = 3
 
     test_module.test_procedure.sections.each do |section|
       section.steps.each do |step|
-        cell = worksheet.add_cell(row, 1, "#{step.id.upcase} ")
-        worksheet.change_row_height(row, 13)
-        worksheet.change_row_vertical_alignment(row, 'distributed')
+        cell = matrix_worksheet.add_cell(row, 1, "#{step.id.upcase} ")
+        matrix_worksheet.change_row_height(row, 13)
+        matrix_worksheet.change_row_vertical_alignment(row, 'distributed')
 
         (2..total_width).each do |column|
-          cell = worksheet.add_cell(row, column, '')
+          cell = matrix_worksheet.add_cell(row, column, '')
         end
 
         step.inferno_tests.each do |test|
           column = column_map[test]
+          inferno_to_procedure_map[test].push(step.id.upcase)
           if column.nil?
             puts "No such test found: #{test}"
             next
           end
 
-          cell = worksheet.add_cell(row, column, '')
+          cell = matrix_worksheet.add_cell(row, column, '')
           cell.change_fill('3C63FF')
         end
 
-        cell = worksheet.add_cell(row, total_width + 2, step.inferno_supported.upcase)
+        cell = matrix_worksheet.add_cell(row, total_width + 2, step.inferno_supported.upcase)
 
         row += 1
       end
     end
-    worksheet.change_column_horizontal_alignment(1, 'right')
-    worksheet.change_row_horizontal_alignment(0, 'center')
+    matrix_worksheet.change_column_horizontal_alignment(1, 'right')
+    matrix_worksheet.change_row_horizontal_alignment(0, 'center')
 
     column_borders.each do |column|
-      worksheet.change_column_border(column, :left, 'medium')
-      worksheet.change_column_border_color(column, :left, '000000')
+      matrix_worksheet.change_column_border(column, :left, 'medium')
+      matrix_worksheet.change_column_border_color(column, :left, '000000')
     end
-    worksheet.change_column_border_color(total_width, :right, '000000')
-    worksheet.change_column_border(total_width, :right, 'medium')
-    worksheet.change_column_width(total_width + 1, 3)
+    matrix_worksheet.change_column_border_color(total_width, :right, '000000')
+    matrix_worksheet.change_column_border(total_width, :right, 'medium')
+    matrix_worksheet.change_column_width(total_width + 1, 3)
 
-    # worksheet.change_row_border(row-1, :bottom, 'medium')
-    # worksheet.change_row_border_color(row-1, :bottom, '000000')
+    matrix_worksheet.change_column_width(total_width + 3, 6)
+    matrix_worksheet.change_column_width(total_width + 4, 2)
+    matrix_worksheet.change_column_width(total_width + 5, 60)
+    matrix_worksheet.add_cell(1, total_width + 3, '').change_fill('3C63FF')
+    matrix_worksheet.add_cell(1, total_width + 5, 'Blue boxes indicate that the Inferno test (top) covers this test procedure step (left).').change_text_wrap(true)
+    matrix_worksheet.change_column_horizontal_alignment(total_width + 5, :left)
+
+    ########################
+    # TEST PROCEDURE WORKSHEET
+    ########################
+
+    workbook.add_worksheet('Test Procedure')
+    tp_worksheet = workbook.worksheets[1]
+
+    [3, 3, 22, 65, 65, 3, 15, 30, 65, 65].each_with_index { |width, index| tp_worksheet.change_column_width(index, width) }
+    ['',
+     '',
+     'ID',
+     'System Under Test',
+     'Test Lab Verifies',
+     '',
+     'Inferno Supports?',
+     'Inferno Tests',
+     'Inferno Notes',
+     'Alternate Test Methodology'].each_with_index { |text, index| tp_worksheet.add_cell(0, index, text) }
+
+    row = 2
+
+    test_module.test_procedure.sections.each do |section|
+      cell = tp_worksheet.add_cell(row, 0, section.name)
+      row += 1
+      section.steps.group_by(&:group).each do |group_name, steps|
+        cell = tp_worksheet.add_cell(row, 1, group_name)
+        row += 1
+        steps.each do |step|
+          longest_line = [step.s_u_t, step.t_l_v, step.inferno_notes, step.alternate_test].map { |text| text&.lines&.count || 0 }.max
+          tp_worksheet.change_row_height(row, longest_line * 10 + 10)
+          tp_worksheet.change_row_vertical_alignment(row, 'top')
+          cell = tp_worksheet.add_cell(row, 2, "#{step.id.upcase} ")
+          cell = tp_worksheet.add_cell(row, 3, step.s_u_t).change_text_wrap(true)
+          cell = tp_worksheet.add_cell(row, 4, step.t_l_v).change_text_wrap(true)
+          cell = tp_worksheet.add_cell(row, 5, '')
+          cell = tp_worksheet.add_cell(row, 6, step.inferno_supported)
+          cell = tp_worksheet.add_cell(row, 7, step.inferno_tests.join(', ')).change_text_wrap(true)
+          cell = tp_worksheet.add_cell(row, 8, step.inferno_notes).change_text_wrap(true)
+          cell = tp_worksheet.add_cell(row, 9, step.alternate_test).change_text_wrap(true)
+          row += 1
+        end
+      end
+      row += 1
+    end
+
+    ########################
+    # INFERNO TESTS WORKSHEET
+    ########################
+
+    workbook.add_worksheet('Inferno Tests')
+    inferno_worksheet = workbook.worksheets[2]
+
+    columns = [
+      ['', 3, ->(_group, _test_case, _test) { '' }],
+      ['', 3, ->(_group, _test_case, _test) { '' }],
+      ['Inferno Test ID', 22, ->(_group, test_case, test) { "#{test_case.prefix}#{test.id}" }],
+      ['Inferno Test Name', 65, ->(_group, _test_case, test) { test.name }],
+      ['Inferno Test Description', 65, lambda do |_group, _test_case, test|
+        natural_indent = test.description.lines.collect { |l| l.index(/[^ ]/) }.select { |l| !l.nil? && l.positive? }.min || 0
+        test.description.lines.map { |l| l[natural_indent..-1] || "\n" }.join.strip
+      end],
+      ['Reference', 65, ->(_group, _test_case, test) { test.link }],
+      ['Test Procedure Steps', 30, ->(_group, test_case, test) { inferno_to_procedure_map["#{test_case.prefix}#{test.id}"].join(', ') }]
+    ]
+
+    columns.each_with_index do |row_name, index|
+      cell = inferno_worksheet.add_cell(0, index, row_name.first)
+    end
+
+    test_module = Inferno::Module.get(args.module)
+    test_set = test_module.test_sets[args.test_set.to_sym]
+    row = 1
+
+    test_set.groups.each do |group|
+      row += 1
+      cell = inferno_worksheet.add_cell(row, 0, group.name)
+      row += 1
+      group.test_cases.each do |test_case|
+        cell = inferno_worksheet.add_cell(row, 1, "#{test_case.prefix}#{test_case.sequence.tests.first.id.split('-').first}: #{test_case.title}: #{test_case.description}")
+        row += 1
+        test_case.sequence.tests.each do |test|
+          next if test_case.sequence.optional? || test.optional?
+
+          this_row = columns.map do |column|
+            column[2].call(group, test_case, test)
+          end
+
+          this_row.each_with_index do |value, index|
+            cell = inferno_worksheet.add_cell(row, index, value)
+            cell.change_text_wrap(true)
+          end
+          inferno_worksheet.change_row_height(row, [26, test.description.strip.lines.count * 10 + 10].max)
+          inferno_worksheet.change_row_vertical_alignment(row, 'top')
+          row += 1
+        end
+      end
+    end
+
+    columns.each_with_index do |column, index|
+      inferno_worksheet.change_column_width(index, column[1])
+    end
+
+    # inferno_worksheet.change_row_border(row-1, :bottom, 'medium')
+    # inferno_worksheet.change_row_border_color(row-1, :bottom, '000000')
 
     # test_set.groups.each do |group|
-    #   cell = worksheet.add_cell(row, 0, group.name)
+    #   cell = inferno_worksheet.add_cell(row, 0, group.name)
     #   cell.change_text_wrap(true)
-    #   worksheet.merge_cells(row, 0, row, columns.length)
-    #   worksheet.change_row_fill(row, 'EEEEEE')
-    #   worksheet.change_row_height(row, 25)
-    #   worksheet.change_row_vertical_alignment(row, 'distributed')
+    #   inferno_worksheet.merge_cells(row, 0, row, columns.length)
+    #   inferno_worksheet.change_row_fill(row, 'EEEEEE')
+    #   inferno_worksheet.change_row_height(row, 25)
+    #   inferno_worksheet.change_row_vertical_alignment(row, 'distributed')
     #   row += 1
     #   group.test_cases.each do |test_case|
     #     test_case.sequence.tests.each do |test|


### PR DESCRIPTION
Ignore empty lines in NDJSON export in streamed_ndjson_get() function 
Add check in test_output_against_profile() function to check if the returned file is empty. Such check is ignored if tester turns off validation (with lines_to_validate = '0')

**Submitter:**
- [x] This pull request describes why these changes were made
- [x] Internal ticket for this PR:
- [x] Internal ticket links to this PR
- [x] Internal ticket is properly labeled (Community/Program)
- [x] Internal ticket has a justification for its Community/Program label
- [x] Code diff has been reviewed for extraneous/missing code
- [x] Tests are included and test edge cases
- [x] Tests/code quality metrics have been run locally and pass


**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
