### PR TITLE
Handle Empty Line in NDJSON file

### DIFF
--- a/lib/modules/onc_program/bulk_data_group_validation_sequence.rb
+++ b/lib/modules/onc_program/bulk_data_group_validation_sequence.rb
@@ -251,7 +251,7 @@ module Inferno
           # Skip process the last line since the it may not complete (still appending from stream)
           last_line = resource_list.pop
           # Skip if the last_line is empty
-          next_block = String.new last_line unless last_line.blank?
+          next_block = String.new last_line unless last_line.nil?
 
           resource_list.each do |resource|
             # NDJSON does not specify empty line is NOT allowed.


### PR DESCRIPTION
The changes handles both empty line in NDJSON file and empty NDJSON file.
empty NDJSON file are reported the same as server has no resources to export.
empty NDJOSN line is ignored during process.

**Submitter:**
- [x] This pull request describes why these changes were made
- [x] Internal ticket for this PR:
- [x] Internal ticket links to this PR
- [x] Internal ticket is properly labeled (Community/Program)
- [x] Internal ticket has a justification for its Community/Program label
- [x] Code diff has been reviewed for extraneous/missing code
- [x] Tests are included and test edge cases
- [x] Tests/code quality metrics have been run locally and pass


**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
