### PR TITLE
FI-196 Add invalid launches.

### DIFF
--- a/lib/app/endpoint/oauth2_endpoints.rb
+++ b/lib/app/endpoint/oauth2_endpoints.rb
@@ -115,7 +115,7 @@ module Inferno
                 next_test_case = submitted_test_cases.shift
                 finished = next_test_case.nil?
                 if sequence_result.redirect_to_url
-                  out << js_redirect_modal(sequence_result.redirect_to_url, sequence_result, @instance)
+                  out << js_redirect_modal(sequence_result.redirect_to_url, sequence_result.expect_redirect_failure, sequence_result, @instance)
                   next_test_case = nil
                   finished = false
                 elsif !submitted_test_cases.empty?
@@ -163,7 +163,7 @@ module Inferno
 
                   sequence_result.save!
                   if sequence_result.redirect_to_url
-                    out << js_redirect_modal(sequence_result.redirect_to_url, sequence_result, @instance)
+                    out << js_redirect_modal(sequence_result.redirect_to_url, sequence_result.expect_redirect_failure, sequence_result, @instance)
                     finished = false
                   elsif !submitted_test_cases.empty?
                     out << js_next_sequence(sequence_result.next_test_cases)

--- a/lib/app/endpoint/test_set_endpoints.rb
+++ b/lib/app/endpoint/test_set_endpoints.rb
@@ -200,10 +200,9 @@ module Inferno
 
                 all_test_cases << test_case.id
                 expanded_test_cases << test_case.id if sequence_result.fail? || sequence_result.skip?
-
                 sequence_result.save!
                 if sequence_result.redirect_to_url
-                  out << js_redirect_modal(sequence_result.redirect_to_url, sequence_result, instance)
+                  out << js_redirect_modal(sequence_result.redirect_to_url, sequence_result.expect_redirect_failure, sequence_result, instance)
                   next_test_case = nil
                   finished = false
                 elsif sequence_result.wait_at_endpoint

--- a/lib/app/helpers/browser_logic.rb
+++ b/lib/app/helpers/browser_logic.rb
@@ -40,9 +40,14 @@ module Inferno
           "<script>console.log('js_redirect'); window.location = '#{location}'</script>"
         end
 
-        def js_redirect_modal(location, _sequence, instance)
+        def js_redirect_modal(location, expect_redirect_failure, _sequence, instance)
           ok_button = "<a href=\"#{location}\" class=\"btn btn-primary\">Continue</a>"
           warning_text = "Inferno will now redirect you to an external website for user authorization.  For this test sequence to complete successfully, you will need to select a patient and authorize the Inferno client to access their data.  Once you authorize the Inferno client to access patient data, you should be redirected back to Inferno.  If something goes wrong, you can always return to Inferno at <a href=\"#{instance.base_url}#{base_path}/#{instance.id}\">#{instance.base_url}#{base_path}/#{instance.id}</a>.<br/><br/>"
+
+          if expect_redirect_failure
+            ok_button = "<a href=\"#{location}\" target=\"_blank\" class=\"btn btn-primary continue_to_confirm\">Perform Invalid Launch in New Window</a><a href=\"#{instance.redirect_uris}?state=#{instance.state}&confirm_fail=true\" class=\"btn btn-primary confirm_to_continue\">Attest Launch Failed</a>"
+            warning_text = 'Inferno will redirect you to an external website at the link below for user authorization in a new browser window.  <strong>It is expected this will fail</strong>.  If the server does not return to Inferno automatically, but does provide an error message, you may return to Inferno and confirm that an error was presented in this window.<br/><br/>'
+          end
 
           "<script>console.log('js_redirect_modal');$('#testsRunningModal').find('.modal-body').html('#{warning_text} <textarea readonly class=\"form-control\" rows=\"3\">#{location}</textarea>'); $('#testsRunningModal').find('.modal-footer').append('#{ok_button}');</script>"
         end

--- a/lib/app/models/sequence_result.rb
+++ b/lib/app/models/sequence_result.rb
@@ -16,6 +16,7 @@ module Inferno
 
       property :redirect_to_url, String, length: 500
       property :wait_at_endpoint, String
+      property :expect_redirect_failure, Boolean, default: false
 
       property :required_passed, Integer, default: 0
       property :required_total, Integer, default: 0

--- a/lib/app/models/test_result.rb
+++ b/lib/app/models/test_result.rb
@@ -25,6 +25,7 @@ module Inferno
 
       property :wait_at_endpoint, String
       property :redirect_to_url, String
+      property :expect_redirect_failure, Boolean, default: false
 
       has n, :request_responses, through: Resource, order: [:timestamp.asc]
       has n, :test_warnings

--- a/lib/app/sequence_base.rb
+++ b/lib/app/sequence_base.rb
@@ -208,6 +208,7 @@ module Inferno
           next unless result.wait?
 
           sequence_result.redirect_to_url = result.redirect_to_url
+          sequence_result.expect_redirect_failure = result.expect_redirect_failure
           sequence_result.wait_at_endpoint = result.wait_at_endpoint
           break
         end
@@ -469,8 +470,8 @@ module Inferno
         raise WaitException, endpoint
       end
 
-      def redirect(url, endpoint)
-        raise RedirectException.new url, endpoint
+      def redirect(url, endpoint, expect_failure = false)
+        raise RedirectException.new url, endpoint, expect_failure
       end
 
       def warning

--- a/lib/app/utils/exceptions.rb
+++ b/lib/app/utils/exceptions.rb
@@ -83,16 +83,19 @@ module Inferno
   class RedirectException < RuntimeError
     attr_accessor :endpoint
     attr_accessor :url
-    def initialize(url, endpoint)
+    attr_accessor :expect_failure
+    def initialize(url, endpoint, expect_failure = false)
       super("Redirecting to #{url} and waiting at endpoint #{endpoint}")
       @url = url
       @endpoint = endpoint
+      @expect_failure = expect_failure
     end
 
     def update_result(result)
       result.wait!
       result.wait_at_endpoint = endpoint
       result.redirect_to_url = url
+      result.expect_redirect_failure = expect_failure
     end
   end
 

--- a/lib/modules/onc_program/smart_invalid_aud_sequence.rb
+++ b/lib/modules/onc_program/smart_invalid_aud_sequence.rb
@@ -3,22 +3,135 @@
 module Inferno
   module Sequence
     class SMARTInvalidAudSequence < SequenceBase
-      title 'SMART App Launch Error Condition: Invalid AUD'
+      include Inferno::Sequence::SharedONCLaunchTests
+      title 'SMART App Launch Error: Invalid AUD Parameter'
       description 'Demonstrate that the server properly validates AUD parameter'
 
       test_id_prefix 'SIA'
 
-      requires :bulk_client_id, :bulk_jwks_url_auth, :bulk_encryption_method, :bulk_token_endpoint, :bulk_scope
-      defines :bulk_access_token
+      requires :onc_sl_client_id,
+               :onc_sl_confidential_client,
+               :onc_sl_client_secret,
+               :onc_sl_scopes,
+               :oauth_authorize_endpoint,
+               :oauth_token_endpoint,
+               :initiate_login_uri,
+               :redirect_uris
 
-      test 'Test to be implemented by v1.0' do
+      show_uris
+
+      INVALID_AUD_URL = 'https://inferno.healthit.gov/invalid_aud'
+
+      details %(
+        # Background
+
+        The Invalid AUD Sequence verifies that a SMART Launch Sequence,
+        specifically the [Standalone
+        Launch](http://hl7.org/fhir/smart-app-launch/#standalone-launch-sequence)
+        Sequence, does not work in the case where the client sends an invalid
+        FHIR server as the `aud` parameter during launch.  This must fail to ensure
+        that a genuine bearer token is not leaked to a counterfit resource server.
+
+        This test is not included as part of a regular SMART Launch Sequence
+        because it requires the browser of the user to be redirected to the authorization
+        service, and there is no expectation that the authorization service redirects
+        the user back to Inferno with an error message.  The only requirement is that
+        Inferno is not granted a code to exchange for a valid access token.  Since
+        this is a special case, it is tested independently in a separate sequence.
+
+        Note that this test will launch a new browser window.  The user is required to
+        'Attest' in the Inferno user interface after the launch does not succeed,
+        if the server does not return an error code.
+      )
+
+      def url_property
+        'onc_sl_url'
+      end
+
+      def instance_url
+        @instance.send(url_property)
+      end
+
+      def instance_client_id
+        @instance.onc_sl_client_id
+      end
+
+      def instance_confidential_client
+        @instance.onc_sl_confidential_client
+      end
+
+      def instance_client_secret
+        @instance.onc_sl_client_secret
+      end
+
+      def instance_scopes
+        @instance.onc_sl_scopes
+      end
+
+      test 'Inferno redirects client browser to authorization service and is redirected back to Inferno.' do
         metadata do
           id '01'
           link 'http://www.hl7.org/fhir/smart-app-launch/'
           description %(
-            Test description
-        )
+            Client browser redirected from OAuth server to redirect URI of
+            client app as described in SMART authorization sequence.
+          )
         end
+
+        @instance.save
+        @instance.update(state: SecureRandom.uuid)
+
+        oauth2_params = {
+          'response_type' => 'code',
+          'client_id' => @instance.onc_sl_client_id,
+          'redirect_uri' => @instance.redirect_uris,
+          'scope' => instance_scopes,
+          'state' => @instance.state,
+          'aud' => INVALID_AUD_URL
+        }
+
+        oauth_authorize_endpoint = @instance.oauth_authorize_endpoint
+
+        assert_valid_http_uri oauth_authorize_endpoint, "OAuth2 Authorization Endpoint: \"#{oauth_authorize_endpoint}\" is not a valid URI"
+
+        oauth2_auth_query = oauth_authorize_endpoint
+
+        oauth2_auth_query += if oauth_authorize_endpoint.include? '?'
+                               '&'
+                             else
+                               '?'
+                             end
+
+        oauth2_params.each do |key, value|
+          oauth2_auth_query += "#{key}=#{CGI.escape(value)}&"
+        end
+
+        redirect oauth2_auth_query[0..-2], 'redirect', true
+      end
+
+      test :code_and_state_received do
+        metadata do
+          id '02'
+          name 'Inferno client app does not receive code parameter redirect URI'
+          link 'http://www.hl7.org/fhir/smart-app-launch/'
+          description %(
+            Inferno redirected the user to the authorization service with an invalid AUD.
+            Inferno expects that the authorization request will not succeed.  This can
+            either be from the server explicitely pass an error, or stopping and the
+            tester returns to Inferno to confirm that the server presented them a failure.
+          )
+        end
+
+        @client = FHIR::Client.for_testing_instance(@instance, url_property: url_property)
+        @client.set_bearer_token(@instance.token) unless @client.nil? || @instance.nil? || @instance.token.nil?
+        @client&.monitor_requests
+
+        skip_if @params.blank?, oauth_redirect_failed_message
+        pass 'Server redirected the user back to the app without an access code.' if @params.blank?
+
+        assert @params['code'].nil?, 'Authorization has incorrectly succeeded because access code provided to Inferno.'
+        pass 'Server redirected the user back to the app with an error.' if @params['error'].present?
+        pass 'Tester attested that the authorization service did not succeed due to invalid AUD parameter.' if @params['confirm_fail']
       end
     end
   end

--- a/lib/modules/onc_program/smart_invalid_launch_sequence.rb
+++ b/lib/modules/onc_program/smart_invalid_launch_sequence.rb
@@ -25,8 +25,8 @@ module Inferno
         # Background
 
         The Invalid Launch Parameter Sequence verifies that a SMART Launch Sequence,
-        specifically the [Standalone
-        Launch](http://hl7.org/fhir/smart-app-launch/#standalone-launch-sequence)
+        specifically the [EHR
+        Launch](http://www.hl7.org/fhir/smart-app-launch/#ehr-launch-sequence)
         Sequence, does not work in the case where the client sends an invalid
         FHIR server as the `launch` parameter during launch.  This must fail to ensure
         that a genuine bearer token is not leaked to a counterfit resource server.

--- a/lib/modules/onc_program/smart_invalid_launch_sequence.rb
+++ b/lib/modules/onc_program/smart_invalid_launch_sequence.rb
@@ -3,22 +3,171 @@
 module Inferno
   module Sequence
     class SMARTInvalidLaunchSequence < SequenceBase
-      title 'SMART App Launch Error Condition: Invalid Launch Parameter'
-      description 'Demonstrate that the server properly validates Launch parameter'
+      include Inferno::Sequence::SharedONCLaunchTests
+      title 'SMART App Launch Error: Invalid Launch Parameter'
+      description 'Demonstrate that the server properly validates LAUNCH parameter'
 
       test_id_prefix 'SIL'
 
-      requires :bulk_client_id, :bulk_jwks_url_auth, :bulk_encryption_method, :bulk_token_endpoint, :bulk_scope
-      defines :bulk_access_token
+      requires :url,
+               :client_id,
+               :confidential_client,
+               :client_secret,
+               :scopes,
+               :oauth_authorize_endpoint,
+               :oauth_token_endpoint,
+               :initiate_login_uri,
+               :redirect_uris
 
-      test 'Test to be implemented by v1.0' do
+      show_uris
+
+      details %(
+        # Background
+
+        The Invalid Launch Parameter Sequence verifies that a SMART Launch Sequence,
+        specifically the [Standalone
+        Launch](http://hl7.org/fhir/smart-app-launch/#standalone-launch-sequence)
+        Sequence, does not work in the case where the client sends an invalid
+        FHIR server as the `launch` parameter during launch.  This must fail to ensure
+        that a genuine bearer token is not leaked to a counterfit resource server.
+
+        This test is not included as part of a regular SMART Launch Sequence
+        because it requires the browser of the user to be redirected to the authorization
+        service, and there is no expectation that the authorization service redirects
+        the user back to Inferno with an error message.  The only requirement is that
+        Inferno is not granted a code to exchange for a valid access token.  Since
+        this is a special case, it is tested independently in a separate sequence.
+
+        Note that this test will launch a new browser window.  The user is required to
+        'Attest' in the Inferno user interface after the launch does not succeed,
+        if the server does not return an error code.
+      )
+
+      def url_property
+        'url'
+      end
+
+      def instance_url
+        @instance.send(url_property)
+      end
+
+      def instance_client_id
+        @instance.client_id
+      end
+
+      def instance_confidential_client
+        @instance.confidential_client
+      end
+
+      def instance_client_secret
+        @instance.client_secret
+      end
+
+      def instance_scopes
+        @instance.scopes
+      end
+
+      test 'EHR server redirects client browser to Inferno app launch URI' do
         metadata do
           id '01'
           link 'http://www.hl7.org/fhir/smart-app-launch/'
           description %(
-              Test description
+            Client browser sent from EHR server to app launch URI of client app
+            as described in SMART EHR Launch Sequence.
           )
         end
+
+        wait_at_endpoint 'launch'
+      end
+
+      test 'EHR provides iss and launch parameter to the Inferno app launch URI via the client browser querystring' do
+        metadata do
+          id '02'
+          link 'http://www.hl7.org/fhir/smart-app-launch/'
+          description %(
+            The EHR is required to provide a reference to the EHR FHIR endpoint
+            in the iss queystring parameter, and an opaque identifier for the
+            launch in the launch querystring parameter.
+          )
+        end
+
+        @client = FHIR::Client.for_testing_instance(@instance, url_property: 'url')
+        @client.set_bearer_token(@instance.token) unless @client.nil? || @instance.nil? || @instance.token.nil?
+        @client&.monitor_requests
+
+        assert @params['iss'].present?, 'Expecting "iss" as a querystring parameter.'
+        assert @params['launch'].present?, 'Expecting "launch" as a querystring parameter.'
+
+        warning do
+          assert @params['iss'] == @instance.url, "'iss' param [#{@params['iss']}] does not match url of testing instance [#{@instance.url}]"
+        end
+      end
+
+      test 'Inferno redirects client browser to authorization service and is redirected back to Inferno.' do
+        metadata do
+          id '03'
+          link 'http://www.hl7.org/fhir/smart-app-launch/'
+          description %(
+            Client browser redirected from OAuth server to redirect URI of
+            client app as described in SMART authorization sequence.
+          )
+        end
+
+        @instance.save
+        @instance.update(state: SecureRandom.uuid)
+
+        oauth2_params = {
+          'response_type' => 'code',
+          'client_id' => @instance.client_id,
+          'redirect_uri' => @instance.redirect_uris,
+          'scope' => @instance.scopes,
+          'launch' => SecureRandom.uuid, # overwrite with an invalid launch parameter
+          'state' => @instance.state,
+          'aud' => @params['iss']
+        }
+
+        oauth_authorize_endpoint = @instance.oauth_authorize_endpoint
+
+        assert_valid_http_uri oauth_authorize_endpoint, "OAuth2 Authorization Endpoint: \"#{oauth_authorize_endpoint}\" is not a valid URI"
+
+        oauth2_auth_query = oauth_authorize_endpoint
+
+        oauth2_auth_query += if oauth_authorize_endpoint.include? '?'
+                               '&'
+                             else
+                               '?'
+                             end
+
+        oauth2_params.each do |key, value|
+          oauth2_auth_query += "#{key}=#{CGI.escape(value)}&"
+        end
+
+        redirect oauth2_auth_query[0..-2], 'redirect', true
+      end
+
+      test :code_and_state_received do
+        metadata do
+          id '04'
+          name 'Inferno client app does not receive code parameter redirect URI'
+          link 'http://www.hl7.org/fhir/smart-app-launch/'
+          description %(
+            Inferno redirected the user to the authorization service with an invalid launch parameter.
+            Inferno expects that the authorization request will not succeed.  This can
+            either be from the server explicitely pass an error, or stopping and the
+            tester returns to Inferno to confirm that the server presented them a failure.
+          )
+        end
+
+        @client = FHIR::Client.for_testing_instance(@instance, url_property: url_property)
+        @client.set_bearer_token(@instance.token) unless @client.nil? || @instance.nil? || @instance.token.nil?
+        @client&.monitor_requests
+
+        skip_if @params.blank?, oauth_redirect_failed_message
+        pass 'Server redirected the user back to the app without an access code.' if @params.blank?
+
+        assert @params['code'].nil?, 'Authorization has incorrectly succeeded because access code provided to Inferno.'
+        pass 'Server redirected the user back to the app with an error.' if @params['error'].present?
+        pass 'Tester attested that the authorization did not succeed due to invalid LAUNCH parameter.' if @params['confirm_fail']
       end
     end
   end

--- a/lib/modules/onc_program_module.yml
+++ b/lib/modules/onc_program_module.yml
@@ -178,8 +178,12 @@ test_sets:
 
           Note: additional tests are expected to be added to this preview version of Inferno prior to rule effective date.
         sequences:
+          - sequence: SMARTInvalidAudSequence
+            variable_defaults:
+              confidential_client: 'true'
+          - sequence: SMARTInvalidLaunchSequence
+            variable_defaults:
+              confidential_client: 'true'
           - ONCVisualInspectionSequence
-          # - SMARTInvalidAudSequence
-          # - SMARTInvalidLaunchSequence
           # - TokenRevocationSequence
           # - BulkCacheCheckSequence


### PR DESCRIPTION
Add two new negative launch tests.  One test is for standalone launches and tests that the server fails if an invalid AUD parameter is passed.  The other is for EHR launches and tests that if Inferno changes the launch parameter received during the launch then the authorization fails.

I suspect this will need a lot more documentation / explanation in the app to describe how it works.

Pull requests into Inferno require the following items to be completed. Submitter and reviewer 
should check the relevant check boxes when the associated item is done. For items that are not 
applicable, note it's not applicable ("N/A") and check the box. For example, external Pull 
Requests do not require ticket links.

**Submitter:**
- [x] This pull request describes why these changes were made
- [x] Internal ticket for this PR:
- [x] Internal ticket links to this PR
- [x] Internal ticket is properly labeled (Community/Program)
- [x] Internal ticket has a justification for its Community/Program label
- [x] Code diff has been reviewed for extraneous/missing code
- [x] Tests are included and test edge cases
- [ ] Tests/code quality metrics have been run locally and pass


**Reviewer 1:**

Name:
- [x] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
