### PR TITLE
FI-817 multi patient test

### DIFF
--- a/lib/modules/onc_program/bulk_data_group_validation_sequence.rb
+++ b/lib/modules/onc_program/bulk_data_group_validation_sequence.rb
@@ -374,7 +374,7 @@ module Inferno
           )
         end
 
-        skip 'Bulk Data Server export did not provide any Patient resources.' if @patient_ids_seen.empty?
+        skip 'Bulk Data Server export did not provide any Patient resources.' unless @patient_ids_seen.present?
 
         assert @patient_ids_seen.length >= MIN_RESOURCE_COUNT, 'Bulk Data Server export did not have multple Patient resources.'
       end

--- a/lib/modules/onc_program/bulk_data_group_validation_sequence.rb
+++ b/lib/modules/onc_program/bulk_data_group_validation_sequence.rb
@@ -47,11 +47,7 @@ module Inferno
 
         file_list = output.find_all { |item| item['type'] == klass }
 
-        if file_list.empty?
-          omit 'No Medication resources provided, and Medication resources are optional.' if klass == 'Medication'
-
-          skip "Bulk Data Server export did not provide any #{klass} resources."
-        end
+        omit_or_skip_empty_resources(klass) if file_list.empty?
 
         validate_all = lines_to_validate_parameter[:validate_all]
         lines_to_validate = lines_to_validate_parameter[:lines_to_validate]
@@ -64,13 +60,14 @@ module Inferno
           success_count += check_file_request(file, klass, validate_all, lines_to_validate, must_supports)
         end
 
-        if success_count.zero? && (validate_all || lines_to_validate.positive?)
-          omit 'No Medication resources provided, and Medication resources are optional.' if klass == 'Medication'
-
-          skip "Bulk Data Server export did not provide any #{klass} resources."
-        end
+        omit_or_skip_empty_resources(klass) if success_count.zero? && (validate_all || lines_to_validate.positive?)
 
         pass "Successfully validated #{success_count} resource(s)."
+      end
+
+      def omit_or_skip_empty_resources(klass)
+        omit 'No Medication resources provided, and Medication resources are optional.' if klass == 'Medication'
+        skip "Bulk Data Server export did not provide any #{klass} resources."
       end
 
       def get_lines_to_validate(input)
@@ -377,7 +374,9 @@ module Inferno
           )
         end
 
-        assert @patient_ids_seen.length >= MIN_RESOURCE_COUNT, 'Group export did not have multple patients.'
+        skip 'Bulk Data Server export did not provide any Patient resources.' if @patient_ids_seen.empty?
+
+        assert @patient_ids_seen.length >= MIN_RESOURCE_COUNT, 'Bulk Data Server export did not have multple Patient resources.'
       end
 
       test :validate_patient_ids_in_group do

--- a/lib/modules/onc_program/test/bulk_group_validation_sequence_test.rb
+++ b/lib/modules/onc_program/test/bulk_group_validation_sequence_test.rb
@@ -214,6 +214,30 @@ describe Inferno::Sequence::BulkDataGroupExportValidationSequence do
     end
   end
 
+  describe 'validate two patients tests' do
+    before do
+      @sequence = @sequence_class.new(@instance, @client)
+      @test = @sequence_class[:validate_two_patients]
+    end
+
+    it 'success when 2 patients in output' do
+      @sequence.patient_ids_seen = Set.new(['1', '2'])
+      @sequence.run_test(@test)
+    end
+
+    it 'fails when 1 patients in output' do
+      @sequence.patient_ids_seen = Set.new(['1'])
+      error = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+      assert error.message, 'Bulk Data Server export did not have multple Patient resources.'
+    end
+
+    it 'skips when 0 patients in output' do
+      @sequence.patient_ids_seen = Set.new
+      error = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+      assert error.message, 'Bulk Data Server export did not provide any Patient resources.'
+    end
+  end
+
   describe 'get lines-to-validate' do
     before do
       @sequence = @sequence_class.new(@instance, @client)

--- a/lib/modules/onc_program/test/bulk_group_validation_sequence_test.rb
+++ b/lib/modules/onc_program/test/bulk_group_validation_sequence_test.rb
@@ -236,6 +236,12 @@ describe Inferno::Sequence::BulkDataGroupExportValidationSequence do
       error = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
       assert error.message, 'Bulk Data Server export did not provide any Patient resources.'
     end
+
+    it 'skips when patients in output is nil' do
+      @sequence.patient_ids_seen = nil
+      error = assert_raises(Inferno::SkipException) { @sequence.run_test(@test) }
+      assert error.message, 'Bulk Data Server export did not provide any Patient resources.'
+    end
   end
 
   describe 'get lines-to-validate' do


### PR DESCRIPTION
Changes in this pull request:
1) Skip BDGV-04 validate-two-patients test when the patients output is empty


**Submitter:**
- [x] This pull request describes why these changes were made
- [x] Internal ticket for this PR:
- [x] Internal ticket links to this PR
- [x] Internal ticket is properly labeled (Community/Program)
- [x] Internal ticket has a justification for its Community/Program label
- [x] Code diff has been reviewed for extraneous/missing code
- [x] Tests are included and test edge cases
- [x] Tests/code quality metrics have been run locally and pass


**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
