### PR TITLE
FI-814 observation profile

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -39,7 +39,7 @@ badge_text: PROGRAM EDITION
 
 # Resource validator options: must be one of "internal" or "external". external_resource_validator_url is only used if resource_validator is set to external.
 resource_validator: external
-external_resource_validator_url: http://localhost:8888
+external_resource_validator_url: http://validator_service:4567
 
 # module options: one or more must be set.  The first option in the list will be checked by default
 modules:

--- a/config.yml
+++ b/config.yml
@@ -39,7 +39,7 @@ badge_text: PROGRAM EDITION
 
 # Resource validator options: must be one of "internal" or "external". external_resource_validator_url is only used if resource_validator is set to external.
 resource_validator: external
-external_resource_validator_url: http://validator_service:4567
+external_resource_validator_url: http://localhost:8888
 
 # module options: one or more must be set.  The first option in the list will be checked by default
 modules:

--- a/lib/app/utils/validation.rb
+++ b/lib/app/utils/validation.rb
@@ -179,14 +179,11 @@ module Inferno
         return DEFINITIONS[US_CORE_R4_URIS[:body_temperature]] if observation_contains_code(resource, '8310-5')
 
         # if none of the US Core profile matches, use FHIR base profile
-        return 
+        return
       elsif resource.resourceType == 'DiagnosticReport'
         return DEFINITIONS[US_CORE_R4_URIS[:diagnostic_report_lab]] if resource&.category&.first&.coding&.any? { |coding| coding&.code == 'LAB' }
 
         return DEFINITIONS[US_CORE_R4_URIS[:diagnostic_report_note]]
-
-        # if none of the US Core profile matches, use FHIR base profile
-        return 
       end
 
       candidates.first

--- a/lib/app/utils/validation.rb
+++ b/lib/app/utils/validation.rb
@@ -177,10 +177,16 @@ module Inferno
         return DEFINITIONS[US_CORE_R4_URIS[:heart_rate]] if observation_contains_code(resource, '8867-4')
 
         return DEFINITIONS[US_CORE_R4_URIS[:body_temperature]] if observation_contains_code(resource, '8310-5')
+
+        # if none of the US Core profile matches, use FHIR base profile
+        return 
       elsif resource.resourceType == 'DiagnosticReport'
         return DEFINITIONS[US_CORE_R4_URIS[:diagnostic_report_lab]] if resource&.category&.first&.coding&.any? { |coding| coding&.code == 'LAB' }
 
         return DEFINITIONS[US_CORE_R4_URIS[:diagnostic_report_note]]
+
+        # if none of the US Core profile matches, use FHIR base profile
+        return 
       end
 
       candidates.first

--- a/lib/modules/onc_program/test/bulk_group_validation_sequence_test.rb
+++ b/lib/modules/onc_program/test/bulk_group_validation_sequence_test.rb
@@ -634,14 +634,9 @@ describe Inferno::Sequence::BulkDataGroupExportValidationSequence do
         )
     end
 
-    it 'fails with vital-signs observation' do
+    it 'succeeds with vital-signs observation' do
       must_supports = []
-
-      error = assert_raises(Inferno::AssertionException) do
-        @sequence.check_file_request(@file, 'Observation', true, 1, must_supports)
-      end
-
-      assert_match(%r{^2 / 2 Observation resources failed profile validation}, error.message)
+      @sequence.check_file_request(@file, 'Observation', true, 1, must_supports)
     end
   end
 


### PR DESCRIPTION
Changes in this PR:
1) return nil when Observation resource does not match any predefined US core profile

**Submitter:**
- [x] This pull request describes why these changes were made
- [x] Internal ticket for this PR:
- [x] Internal ticket links to this PR
- [x] Internal ticket is properly labeled (Community/Program)
- [x] Internal ticket has a justification for its Community/Program label
- [x] Code diff has been reviewed for extraneous/missing code
- [x] Tests are included and test edge cases
- [x] Tests/code quality metrics have been run locally and pass


**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
