### PR TITLE
FI-750: Support canonical urls in capabilities test

### DIFF
--- a/lib/app/models/server_capabilities.rb
+++ b/lib/app/models/server_capabilities.rb
@@ -32,9 +32,10 @@ module Inferno
       end
 
       def supported_profiles
-        statement.rest.flat_map(&:resource)
+        profile_urls = statement.rest.flat_map(&:resource)
           &.flat_map { |resource| resource.supportedProfile + [resource.profile] }
           &.compact || []
+        profile_urls.map { |profile_url| profile_url.split('|').first }
       end
 
       def operation_supported?(operation_name)

--- a/lib/modules/us_core_guidance/us_core_r4_capability_statement_sequence.rb
+++ b/lib/modules/us_core_guidance/us_core_r4_capability_statement_sequence.rb
@@ -77,7 +77,13 @@ module Inferno
           'http://hl7.org/fhir/us/core/StructureDefinition/pediatric-weight-for-height',
           'http://hl7.org/fhir/us/core/StructureDefinition/us-core-pulse-oximetry',
           'http://hl7.org/fhir/us/core/StructureDefinition/us-core-smokingstatus',
-          'http://hl7.org/fhir/StructureDefinition/vitalsigns'
+          'http://hl7.org/fhir/StructureDefinition/bp',
+          'http://hl7.org/fhir/StructureDefinition/bodyheight',
+          'http://hl7.org/fhir/StructureDefinition/bodyweight',
+          'http://hl7.org/fhir/StructureDefinition/heartrate',
+          'http://hl7.org/fhir/StructureDefinition/resprate',
+          'http://hl7.org/fhir/StructureDefinition/bodytemp',
+          'http://hl7.org/fhir/StructureDefinition/headcircum'
         ],
         'Organization' => ['http://hl7.org/fhir/us/core/StructureDefinition/us-core-organization'],
         'Patient' => ['http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient'],

--- a/test/unit/server_capabilities_test.rb
+++ b/test/unit/server_capabilities_test.rb
@@ -36,7 +36,7 @@ class ServerCapabilitiesTest < MiniTest::Test
             },
             {
               type: 'Condition',
-              profile: 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-condition',
+              profile: 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-condition|3.1.0',
               interaction: [
                 { code: 'delete' },
                 { code: 'update' },
@@ -51,7 +51,7 @@ class ServerCapabilitiesTest < MiniTest::Test
             {
               type: 'Observation',
               supportedProfile: [
-                'http://hl7.org/fhir/us/core/StructureDefinition/pediatric-bmi-for-age',
+                'http://hl7.org/fhir/us/core/StructureDefinition/pediatric-bmi-for-age|3.1.0',
                 'http://hl7.org/fhir/us/core/StructureDefinition/pediatric-weight-for-height'
               ]
             }


### PR DESCRIPTION
This fixes a problem where warnings were being given for unsupported profiles because canonical urls weren't being recognized.

**Submitter:**
- [x] This pull request describes why these changes were made
- [x] Internal ticket links to this PR
- [x] Internal ticket is properly labeled (Community/Program)
- [x] Internal ticket has a justification for its Community/Program label
- [x] Code diff has been reviewed for extraneous/missing code
- [x] Tests are included and test edge cases
- [x] Tests/code quality metrics have been run locally and pass


**Reviewer 1:**

Name:
- [x] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code

**Reviewer 2:**

Name:
- [x] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code
