### PR TITLE
fi-840 Fix error when cannot find codeableconcept search value

### DIFF
--- a/lib/app/sequence_base.rb
+++ b/lib/app/sequence_base.rb
@@ -808,7 +808,7 @@ module Inferno
                        when FHIR::CodeableConcept
                          if include_system
                            coding_with_code = resolve_element_from_path(element, 'coding') { |coding| coding.code.present? }
-                           "#{coding_with_code.system}|#{coding_with_code.code}"
+                           coding_with_code.present? ? "#{coding_with_code.system}|#{coding_with_code.code}" : nil
                          else
                            resolve_element_from_path(element, 'coding.code')
                          end


### PR DESCRIPTION
This fixes an issue where we give an error when trying to perform a search with system for a codeableconcept that cannot be found. 

**Submitter:**
- [X] This pull request describes why these changes were made
- [X] Internal ticket for this PR: https://oncprojectracking.healthit.gov/support/browse/FI-840
- [X] Internal ticket links to this PR
- [X] Internal ticket is properly labeled (Community/Program)
- [X] Internal ticket has a justification for its Community/Program label
- [X] Code diff has been reviewed for extraneous/missing code
- [ ] Tests are included and test edge cases
- [ ] Tests/code quality metrics have been run locally and pass


**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
