### PR TITLE
FI 849 add more reference searches

### DIFF
--- a/generator/uscore/templates/unit_tests/search_unit_test.rb.erb
+++ b/generator/uscore/templates/unit_tests/search_unit_test.rb.erb
@@ -159,11 +159,21 @@ describe '<%= resource_type %> search by <%= search_params.keys.join('+') %> tes
       stub_request(:get, "#{@base_url}/<%= resource_type %>")
         .with(query: query_params, headers: @auth_header)
         .to_return(status: 200, body: body)
+      reference_with_type_params = query_params.merge('patient': 'Patient/' + query_params[:patient])
+      stub_request(:get, "#{@base_url}/<%= resource_type %>")
+        .with(query: reference_with_type_params, headers: @auth_header)
+        .to_return(status: 200, body: body)
     end
   <% else %>
     stub_request(:get, "#{@base_url}/<%= resource_type %>")
       .with(query: @query, headers: @auth_header)
       .to_return(status: 200, body: wrap_resources_in_bundle(@<%= resource_var_name %>_ary<%='.values.flatten' unless delayed_sequence %>).to_json)
+    <% if is_first_search  && resource_type != 'Patient'%> 
+      reference_with_type_params = @query.merge('patient': 'Patient/' + @query[:patient])
+      stub_request(:get, "#{@base_url}/<%= resource_type %>")
+        .with(query: reference_with_type_params, headers: @auth_header)
+      .to_return(status: 200, body: wrap_resources_in_bundle(@<%= resource_var_name %>_ary<%='.values.flatten' unless delayed_sequence %>).to_json)
+    <% end %>
   <% end %>
   <% if token_param %>
     stub_request(:get, "#{@base_url}/<%= resource_type %>")
@@ -188,6 +198,9 @@ describe '<%= resource_type %> search by <%= search_params.keys.join('+') %> tes
           end
         stub_request(:get, "#{@base_url}/MedicationRequest")
           .with(query: query_params, headers: @auth_header)
+          .to_return(status: 200, body: body)
+        stub_request(:get, "#{@base_url}/MedicationRequest")
+          .with(query: query_params.merge('patient': 'Patient/' + query_params[:patient]), headers: @auth_header)
           .to_return(status: 200, body: body)
       end
 
@@ -318,6 +331,9 @@ describe '<%= resource_type %> search by <%= search_params.keys.join('+') %> tes
         stub_request(:get, "#{@base_url}/<%= resource_type %>")
           .with(query: query_params.merge(<%= status_param[:param] %>: [<%= status_param[:value] %>].first), headers: @auth_header)
           .to_return(status: 200, body: wrap_resources_in_bundle([@<%= resource_var_name %>]).to_json)
+        stub_request(:get, "#{@base_url}/<%= resource_type %>")
+          .with(query: query_params.merge('patient': 'Patient/' + query_params[:patient], <%= status_param[:param] %>: [<%= status_param[:value] %>].first), headers: @auth_header)
+          .to_return(status: 200, body: wrap_resources_in_bundle([@<%= resource_var_name %>]).to_json)
       end
     <% else %>
       stub_request(:get, "#{@base_url}/<%= resource_type %>")
@@ -326,6 +342,11 @@ describe '<%= resource_type %> search by <%= search_params.keys.join('+') %> tes
       stub_request(:get, "#{@base_url}/<%= resource_type %>")
         .with(query: @query.merge(<%= status_param[:param] %>: [<%= status_param[:value] %>].first), headers: @auth_header)
         .to_return(status: 200, body: wrap_resources_in_bundle([@<%= resource_var_name %>]).to_json)
+      <% if is_first_search %>
+      stub_request(:get, "#{@base_url}/<%= resource_type %>")
+          .with(query: @query.merge('patient': 'Patient/' + @query[:patient], <%= status_param[:param] %>: [<%= status_param[:value] %>].first), headers: @auth_header)
+          .to_return(status: 200, body: wrap_resources_in_bundle([@<%= resource_var_name %>]).to_json)
+      <% end %>
     <% end %>
     <% if token_param %>
     stub_request(:get, "#{@base_url}/<%= resource_type %>")

--- a/generator/uscore/uscore_generator.rb
+++ b/generator/uscore/uscore_generator.rb
@@ -1026,14 +1026,6 @@ module Inferno
             assert_bundle_response(reply)
             search_with_type = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
             assert search_with_type.length == @#{sequence[:resource].underscore}_ary[patient].length, 'Expected search by Patient/ID to have the same results as search by ID'
-
-            search_params = search_params.merge('patient': "\#{@instance.url}/Patient/\#{patient}")
-            reply = get_resource_by_params(versioned_resource_class('#{sequence[:resource]}'), search_params)
-            assert_response_ok(reply)
-            assert_bundle_response(reply)
-            search_with_url = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
-            assert search_with_url.length == @#{sequence[:resource].underscore}_ary[patient].length, 'Expected search by url to have the same results as search by ID'
-
           )
 
           first_search + %(
@@ -1111,14 +1103,6 @@ module Inferno
               assert_bundle_response(reply)
               search_with_type = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
               assert search_with_type.length == resources_returned.length, 'Expected search by Patient/ID to have the same results as search by ID'
-
-              search_params_with_url = search_params.merge('patient': "\#{@instance.url}/Patient/\#{patient}")
-              reply = get_resource_by_params(versioned_resource_class('#{sequence[:resource]}'), search_params_with_url)
-              #{status_search_code(sequence, search_parameters)}
-              assert_response_ok(reply)
-              assert_bundle_response(reply)
-              search_with_url = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
-              assert search_with_url.length == resources_returned.length, 'Expected search by url to have the same results as search by ID'
 
               #{'test_medication_inclusion(@medication_request_ary[patient], search_params)' if sequence[:resource] == 'MedicationRequest'}
               break#{' if values_found == 2' if find_two_values}

--- a/generator/uscore/uscore_generator.rb
+++ b/generator/uscore/uscore_generator.rb
@@ -1019,6 +1019,23 @@ module Inferno
             )
           end
 
+          search_with_reference_types = %(
+            search_params = search_params.merge('patient': "Patient/\#{patient}")
+            reply = get_resource_by_params(versioned_resource_class('#{sequence[:resource]}'), search_params)
+            assert_response_ok(reply)
+            assert_bundle_response(reply)
+            search_with_type = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
+            assert search_with_type.length == @#{sequence[:resource].underscore}_ary[patient].length, 'Expected search by Patient/ID to have the same results as search by ID'
+
+            search_params = search_params.merge('patient': "\#{@instance.url}/Patient/\#{patient}")
+            reply = get_resource_by_params(versioned_resource_class('#{sequence[:resource]}'), search_params)
+            assert_response_ok(reply)
+            assert_bundle_response(reply)
+            search_with_url = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
+            assert search_with_url.length == @#{sequence[:resource].underscore}_ary[patient].length, 'Expected search by url to have the same results as search by ID'
+
+          )
+
           first_search + %(
               @#{sequence[:resource].underscore} = @#{sequence[:resource].underscore}_ary[patient]
                 .find { |resource| resource.resourceType == '#{sequence[:resource]}' }
@@ -1027,6 +1044,7 @@ module Inferno
               save_resource_references(#{save_resource_references_arguments})
               save_delayed_sequence_references(@#{sequence[:resource].underscore}_ary[patient], #{sequence[:class_name]}Definitions::DELAYED_REFERENCES)
               validate_reply_entries(@#{sequence[:resource].underscore}_ary[patient], search_params)
+              #{search_with_reference_types unless sequence[:resource] == 'Patient'}
             end
 
             #{skip_if_not_found_code(sequence)}
@@ -1085,6 +1103,23 @@ module Inferno
               save_delayed_sequence_references(resources_returned, #{sequence[:class_name]}Definitions::DELAYED_REFERENCES)
               validate_reply_entries(resources_returned, search_params)
               #{get_token_system_search_code(search_parameters, sequence)}
+
+              search_params_with_type = search_params.merge('patient': "Patient/\#{patient}")
+              reply = get_resource_by_params(versioned_resource_class('#{sequence[:resource]}'), search_params_with_type)
+              #{status_search_code(sequence, search_parameters)}
+              assert_response_ok(reply)
+              assert_bundle_response(reply)
+              search_with_type = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
+              assert search_with_type.length == resources_returned.length, 'Expected search by Patient/ID to have the same results as search by ID'
+
+              search_params_with_url = search_params.merge('patient': "\#{@instance.url}/Patient/\#{patient}")
+              reply = get_resource_by_params(versioned_resource_class('#{sequence[:resource]}'), search_params_with_url)
+              #{status_search_code(sequence, search_parameters)}
+              assert_response_ok(reply)
+              assert_bundle_response(reply)
+              search_with_url = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
+              assert search_with_url.length == resources_returned.length, 'Expected search by url to have the same results as search by ID'
+
               #{'test_medication_inclusion(@medication_request_ary[patient], search_params)' if sequence[:resource] == 'MedicationRequest'}
               break#{' if values_found == 2' if find_two_values}
             end
@@ -1279,7 +1314,8 @@ module Inferno
           # searching by patient requires special case because we are searching by a resource identifier
           # references can also be URL's, so we made need to resolve those url's
           if ['subject', 'patient'].include? element.to_s
-            %(match_found = values_found.any? { |reference| [value, 'Patient/' + value].include? reference })
+            %(value = value.split('Patient/').last
+              match_found = values_found.any? { |reference| [value, 'Patient/' + value, "\#{@instance.url}/Patient/\#{value}"].include? reference })
           else
             %(values = value.split(/(?<!\\\\),/).each { |str| str.gsub!('\\,', ',') }
               match_found = values_found.any? { |value_in_resource| values.include? value_in_resource })

--- a/lib/modules/uscore_v3.1.0/bodyheight_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/bodyheight_sequence.rb
@@ -212,16 +212,6 @@ module Inferno
             search_with_type = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
             assert search_with_type.length == resources_returned.length, 'Expected search by Patient/ID to have the same results as search by ID'
 
-            search_params_with_url = search_params.merge('patient': "#{@instance.url}/Patient/#{patient}")
-            reply = get_resource_by_params(versioned_resource_class('Observation'), search_params_with_url)
-
-            reply = perform_search_with_status(reply, search_params) if reply.code == 400
-
-            assert_response_ok(reply)
-            assert_bundle_response(reply)
-            search_with_url = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
-            assert search_with_url.length == resources_returned.length, 'Expected search by url to have the same results as search by ID'
-
             break
           end
         end

--- a/lib/modules/uscore_v3.1.0/bodyheight_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/bodyheight_sequence.rb
@@ -110,7 +110,8 @@ module Inferno
 
         when 'patient'
           values_found = resolve_path(resource, 'subject.reference')
-          match_found = values_found.any? { |reference| [value, 'Patient/' + value].include? reference }
+          value = value.split('Patient/').last
+          match_found = values_found.any? { |reference| [value, 'Patient/' + value, "#{@instance.url}/Patient/#{value}"].include? reference }
           assert match_found, "patient in Observation/#{resource.id} (#{values_found}) does not match patient requested (#{value})"
 
         end
@@ -200,6 +201,26 @@ module Inferno
             token_with_system_search_params = search_params.merge('code': value_with_system)
             reply = get_resource_by_params(versioned_resource_class('Observation'), token_with_system_search_params)
             validate_search_reply(versioned_resource_class('Observation'), reply, token_with_system_search_params)
+
+            search_params_with_type = search_params.merge('patient': "Patient/#{patient}")
+            reply = get_resource_by_params(versioned_resource_class('Observation'), search_params_with_type)
+
+            reply = perform_search_with_status(reply, search_params) if reply.code == 400
+
+            assert_response_ok(reply)
+            assert_bundle_response(reply)
+            search_with_type = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
+            assert search_with_type.length == resources_returned.length, 'Expected search by Patient/ID to have the same results as search by ID'
+
+            search_params_with_url = search_params.merge('patient': "#{@instance.url}/Patient/#{patient}")
+            reply = get_resource_by_params(versioned_resource_class('Observation'), search_params_with_url)
+
+            reply = perform_search_with_status(reply, search_params) if reply.code == 400
+
+            assert_response_ok(reply)
+            assert_bundle_response(reply)
+            search_with_url = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
+            assert search_with_url.length == resources_returned.length, 'Expected search by url to have the same results as search by ID'
 
             break
           end

--- a/lib/modules/uscore_v3.1.0/bodytemp_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/bodytemp_sequence.rb
@@ -212,16 +212,6 @@ module Inferno
             search_with_type = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
             assert search_with_type.length == resources_returned.length, 'Expected search by Patient/ID to have the same results as search by ID'
 
-            search_params_with_url = search_params.merge('patient': "#{@instance.url}/Patient/#{patient}")
-            reply = get_resource_by_params(versioned_resource_class('Observation'), search_params_with_url)
-
-            reply = perform_search_with_status(reply, search_params) if reply.code == 400
-
-            assert_response_ok(reply)
-            assert_bundle_response(reply)
-            search_with_url = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
-            assert search_with_url.length == resources_returned.length, 'Expected search by url to have the same results as search by ID'
-
             break
           end
         end

--- a/lib/modules/uscore_v3.1.0/bodytemp_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/bodytemp_sequence.rb
@@ -110,7 +110,8 @@ module Inferno
 
         when 'patient'
           values_found = resolve_path(resource, 'subject.reference')
-          match_found = values_found.any? { |reference| [value, 'Patient/' + value].include? reference }
+          value = value.split('Patient/').last
+          match_found = values_found.any? { |reference| [value, 'Patient/' + value, "#{@instance.url}/Patient/#{value}"].include? reference }
           assert match_found, "patient in Observation/#{resource.id} (#{values_found}) does not match patient requested (#{value})"
 
         end
@@ -200,6 +201,26 @@ module Inferno
             token_with_system_search_params = search_params.merge('code': value_with_system)
             reply = get_resource_by_params(versioned_resource_class('Observation'), token_with_system_search_params)
             validate_search_reply(versioned_resource_class('Observation'), reply, token_with_system_search_params)
+
+            search_params_with_type = search_params.merge('patient': "Patient/#{patient}")
+            reply = get_resource_by_params(versioned_resource_class('Observation'), search_params_with_type)
+
+            reply = perform_search_with_status(reply, search_params) if reply.code == 400
+
+            assert_response_ok(reply)
+            assert_bundle_response(reply)
+            search_with_type = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
+            assert search_with_type.length == resources_returned.length, 'Expected search by Patient/ID to have the same results as search by ID'
+
+            search_params_with_url = search_params.merge('patient': "#{@instance.url}/Patient/#{patient}")
+            reply = get_resource_by_params(versioned_resource_class('Observation'), search_params_with_url)
+
+            reply = perform_search_with_status(reply, search_params) if reply.code == 400
+
+            assert_response_ok(reply)
+            assert_bundle_response(reply)
+            search_with_url = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
+            assert search_with_url.length == resources_returned.length, 'Expected search by url to have the same results as search by ID'
 
             break
           end

--- a/lib/modules/uscore_v3.1.0/bodyweight_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/bodyweight_sequence.rb
@@ -212,16 +212,6 @@ module Inferno
             search_with_type = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
             assert search_with_type.length == resources_returned.length, 'Expected search by Patient/ID to have the same results as search by ID'
 
-            search_params_with_url = search_params.merge('patient': "#{@instance.url}/Patient/#{patient}")
-            reply = get_resource_by_params(versioned_resource_class('Observation'), search_params_with_url)
-
-            reply = perform_search_with_status(reply, search_params) if reply.code == 400
-
-            assert_response_ok(reply)
-            assert_bundle_response(reply)
-            search_with_url = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
-            assert search_with_url.length == resources_returned.length, 'Expected search by url to have the same results as search by ID'
-
             break
           end
         end

--- a/lib/modules/uscore_v3.1.0/bodyweight_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/bodyweight_sequence.rb
@@ -110,7 +110,8 @@ module Inferno
 
         when 'patient'
           values_found = resolve_path(resource, 'subject.reference')
-          match_found = values_found.any? { |reference| [value, 'Patient/' + value].include? reference }
+          value = value.split('Patient/').last
+          match_found = values_found.any? { |reference| [value, 'Patient/' + value, "#{@instance.url}/Patient/#{value}"].include? reference }
           assert match_found, "patient in Observation/#{resource.id} (#{values_found}) does not match patient requested (#{value})"
 
         end
@@ -200,6 +201,26 @@ module Inferno
             token_with_system_search_params = search_params.merge('code': value_with_system)
             reply = get_resource_by_params(versioned_resource_class('Observation'), token_with_system_search_params)
             validate_search_reply(versioned_resource_class('Observation'), reply, token_with_system_search_params)
+
+            search_params_with_type = search_params.merge('patient': "Patient/#{patient}")
+            reply = get_resource_by_params(versioned_resource_class('Observation'), search_params_with_type)
+
+            reply = perform_search_with_status(reply, search_params) if reply.code == 400
+
+            assert_response_ok(reply)
+            assert_bundle_response(reply)
+            search_with_type = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
+            assert search_with_type.length == resources_returned.length, 'Expected search by Patient/ID to have the same results as search by ID'
+
+            search_params_with_url = search_params.merge('patient': "#{@instance.url}/Patient/#{patient}")
+            reply = get_resource_by_params(versioned_resource_class('Observation'), search_params_with_url)
+
+            reply = perform_search_with_status(reply, search_params) if reply.code == 400
+
+            assert_response_ok(reply)
+            assert_bundle_response(reply)
+            search_with_url = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
+            assert search_with_url.length == resources_returned.length, 'Expected search by url to have the same results as search by ID'
 
             break
           end

--- a/lib/modules/uscore_v3.1.0/bp_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/bp_sequence.rb
@@ -212,16 +212,6 @@ module Inferno
             search_with_type = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
             assert search_with_type.length == resources_returned.length, 'Expected search by Patient/ID to have the same results as search by ID'
 
-            search_params_with_url = search_params.merge('patient': "#{@instance.url}/Patient/#{patient}")
-            reply = get_resource_by_params(versioned_resource_class('Observation'), search_params_with_url)
-
-            reply = perform_search_with_status(reply, search_params) if reply.code == 400
-
-            assert_response_ok(reply)
-            assert_bundle_response(reply)
-            search_with_url = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
-            assert search_with_url.length == resources_returned.length, 'Expected search by url to have the same results as search by ID'
-
             break
           end
         end

--- a/lib/modules/uscore_v3.1.0/bp_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/bp_sequence.rb
@@ -110,7 +110,8 @@ module Inferno
 
         when 'patient'
           values_found = resolve_path(resource, 'subject.reference')
-          match_found = values_found.any? { |reference| [value, 'Patient/' + value].include? reference }
+          value = value.split('Patient/').last
+          match_found = values_found.any? { |reference| [value, 'Patient/' + value, "#{@instance.url}/Patient/#{value}"].include? reference }
           assert match_found, "patient in Observation/#{resource.id} (#{values_found}) does not match patient requested (#{value})"
 
         end
@@ -200,6 +201,26 @@ module Inferno
             token_with_system_search_params = search_params.merge('code': value_with_system)
             reply = get_resource_by_params(versioned_resource_class('Observation'), token_with_system_search_params)
             validate_search_reply(versioned_resource_class('Observation'), reply, token_with_system_search_params)
+
+            search_params_with_type = search_params.merge('patient': "Patient/#{patient}")
+            reply = get_resource_by_params(versioned_resource_class('Observation'), search_params_with_type)
+
+            reply = perform_search_with_status(reply, search_params) if reply.code == 400
+
+            assert_response_ok(reply)
+            assert_bundle_response(reply)
+            search_with_type = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
+            assert search_with_type.length == resources_returned.length, 'Expected search by Patient/ID to have the same results as search by ID'
+
+            search_params_with_url = search_params.merge('patient': "#{@instance.url}/Patient/#{patient}")
+            reply = get_resource_by_params(versioned_resource_class('Observation'), search_params_with_url)
+
+            reply = perform_search_with_status(reply, search_params) if reply.code == 400
+
+            assert_response_ok(reply)
+            assert_bundle_response(reply)
+            search_with_url = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
+            assert search_with_url.length == resources_returned.length, 'Expected search by url to have the same results as search by ID'
 
             break
           end

--- a/lib/modules/uscore_v3.1.0/headcircum_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/headcircum_sequence.rb
@@ -212,16 +212,6 @@ module Inferno
             search_with_type = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
             assert search_with_type.length == resources_returned.length, 'Expected search by Patient/ID to have the same results as search by ID'
 
-            search_params_with_url = search_params.merge('patient': "#{@instance.url}/Patient/#{patient}")
-            reply = get_resource_by_params(versioned_resource_class('Observation'), search_params_with_url)
-
-            reply = perform_search_with_status(reply, search_params) if reply.code == 400
-
-            assert_response_ok(reply)
-            assert_bundle_response(reply)
-            search_with_url = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
-            assert search_with_url.length == resources_returned.length, 'Expected search by url to have the same results as search by ID'
-
             break
           end
         end

--- a/lib/modules/uscore_v3.1.0/headcircum_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/headcircum_sequence.rb
@@ -110,7 +110,8 @@ module Inferno
 
         when 'patient'
           values_found = resolve_path(resource, 'subject.reference')
-          match_found = values_found.any? { |reference| [value, 'Patient/' + value].include? reference }
+          value = value.split('Patient/').last
+          match_found = values_found.any? { |reference| [value, 'Patient/' + value, "#{@instance.url}/Patient/#{value}"].include? reference }
           assert match_found, "patient in Observation/#{resource.id} (#{values_found}) does not match patient requested (#{value})"
 
         end
@@ -200,6 +201,26 @@ module Inferno
             token_with_system_search_params = search_params.merge('code': value_with_system)
             reply = get_resource_by_params(versioned_resource_class('Observation'), token_with_system_search_params)
             validate_search_reply(versioned_resource_class('Observation'), reply, token_with_system_search_params)
+
+            search_params_with_type = search_params.merge('patient': "Patient/#{patient}")
+            reply = get_resource_by_params(versioned_resource_class('Observation'), search_params_with_type)
+
+            reply = perform_search_with_status(reply, search_params) if reply.code == 400
+
+            assert_response_ok(reply)
+            assert_bundle_response(reply)
+            search_with_type = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
+            assert search_with_type.length == resources_returned.length, 'Expected search by Patient/ID to have the same results as search by ID'
+
+            search_params_with_url = search_params.merge('patient': "#{@instance.url}/Patient/#{patient}")
+            reply = get_resource_by_params(versioned_resource_class('Observation'), search_params_with_url)
+
+            reply = perform_search_with_status(reply, search_params) if reply.code == 400
+
+            assert_response_ok(reply)
+            assert_bundle_response(reply)
+            search_with_url = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
+            assert search_with_url.length == resources_returned.length, 'Expected search by url to have the same results as search by ID'
 
             break
           end

--- a/lib/modules/uscore_v3.1.0/heartrate_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/heartrate_sequence.rb
@@ -212,16 +212,6 @@ module Inferno
             search_with_type = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
             assert search_with_type.length == resources_returned.length, 'Expected search by Patient/ID to have the same results as search by ID'
 
-            search_params_with_url = search_params.merge('patient': "#{@instance.url}/Patient/#{patient}")
-            reply = get_resource_by_params(versioned_resource_class('Observation'), search_params_with_url)
-
-            reply = perform_search_with_status(reply, search_params) if reply.code == 400
-
-            assert_response_ok(reply)
-            assert_bundle_response(reply)
-            search_with_url = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
-            assert search_with_url.length == resources_returned.length, 'Expected search by url to have the same results as search by ID'
-
             break
           end
         end

--- a/lib/modules/uscore_v3.1.0/heartrate_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/heartrate_sequence.rb
@@ -110,7 +110,8 @@ module Inferno
 
         when 'patient'
           values_found = resolve_path(resource, 'subject.reference')
-          match_found = values_found.any? { |reference| [value, 'Patient/' + value].include? reference }
+          value = value.split('Patient/').last
+          match_found = values_found.any? { |reference| [value, 'Patient/' + value, "#{@instance.url}/Patient/#{value}"].include? reference }
           assert match_found, "patient in Observation/#{resource.id} (#{values_found}) does not match patient requested (#{value})"
 
         end
@@ -200,6 +201,26 @@ module Inferno
             token_with_system_search_params = search_params.merge('code': value_with_system)
             reply = get_resource_by_params(versioned_resource_class('Observation'), token_with_system_search_params)
             validate_search_reply(versioned_resource_class('Observation'), reply, token_with_system_search_params)
+
+            search_params_with_type = search_params.merge('patient': "Patient/#{patient}")
+            reply = get_resource_by_params(versioned_resource_class('Observation'), search_params_with_type)
+
+            reply = perform_search_with_status(reply, search_params) if reply.code == 400
+
+            assert_response_ok(reply)
+            assert_bundle_response(reply)
+            search_with_type = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
+            assert search_with_type.length == resources_returned.length, 'Expected search by Patient/ID to have the same results as search by ID'
+
+            search_params_with_url = search_params.merge('patient': "#{@instance.url}/Patient/#{patient}")
+            reply = get_resource_by_params(versioned_resource_class('Observation'), search_params_with_url)
+
+            reply = perform_search_with_status(reply, search_params) if reply.code == 400
+
+            assert_response_ok(reply)
+            assert_bundle_response(reply)
+            search_with_url = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
+            assert search_with_url.length == resources_returned.length, 'Expected search by url to have the same results as search by ID'
 
             break
           end

--- a/lib/modules/uscore_v3.1.0/pediatric_bmi_for_age_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/pediatric_bmi_for_age_sequence.rb
@@ -212,16 +212,6 @@ module Inferno
             search_with_type = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
             assert search_with_type.length == resources_returned.length, 'Expected search by Patient/ID to have the same results as search by ID'
 
-            search_params_with_url = search_params.merge('patient': "#{@instance.url}/Patient/#{patient}")
-            reply = get_resource_by_params(versioned_resource_class('Observation'), search_params_with_url)
-
-            reply = perform_search_with_status(reply, search_params) if reply.code == 400
-
-            assert_response_ok(reply)
-            assert_bundle_response(reply)
-            search_with_url = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
-            assert search_with_url.length == resources_returned.length, 'Expected search by url to have the same results as search by ID'
-
             break
           end
         end

--- a/lib/modules/uscore_v3.1.0/pediatric_bmi_for_age_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/pediatric_bmi_for_age_sequence.rb
@@ -110,7 +110,8 @@ module Inferno
 
         when 'patient'
           values_found = resolve_path(resource, 'subject.reference')
-          match_found = values_found.any? { |reference| [value, 'Patient/' + value].include? reference }
+          value = value.split('Patient/').last
+          match_found = values_found.any? { |reference| [value, 'Patient/' + value, "#{@instance.url}/Patient/#{value}"].include? reference }
           assert match_found, "patient in Observation/#{resource.id} (#{values_found}) does not match patient requested (#{value})"
 
         end
@@ -200,6 +201,26 @@ module Inferno
             token_with_system_search_params = search_params.merge('code': value_with_system)
             reply = get_resource_by_params(versioned_resource_class('Observation'), token_with_system_search_params)
             validate_search_reply(versioned_resource_class('Observation'), reply, token_with_system_search_params)
+
+            search_params_with_type = search_params.merge('patient': "Patient/#{patient}")
+            reply = get_resource_by_params(versioned_resource_class('Observation'), search_params_with_type)
+
+            reply = perform_search_with_status(reply, search_params) if reply.code == 400
+
+            assert_response_ok(reply)
+            assert_bundle_response(reply)
+            search_with_type = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
+            assert search_with_type.length == resources_returned.length, 'Expected search by Patient/ID to have the same results as search by ID'
+
+            search_params_with_url = search_params.merge('patient': "#{@instance.url}/Patient/#{patient}")
+            reply = get_resource_by_params(versioned_resource_class('Observation'), search_params_with_url)
+
+            reply = perform_search_with_status(reply, search_params) if reply.code == 400
+
+            assert_response_ok(reply)
+            assert_bundle_response(reply)
+            search_with_url = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
+            assert search_with_url.length == resources_returned.length, 'Expected search by url to have the same results as search by ID'
 
             break
           end

--- a/lib/modules/uscore_v3.1.0/pediatric_weight_for_height_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/pediatric_weight_for_height_sequence.rb
@@ -212,16 +212,6 @@ module Inferno
             search_with_type = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
             assert search_with_type.length == resources_returned.length, 'Expected search by Patient/ID to have the same results as search by ID'
 
-            search_params_with_url = search_params.merge('patient': "#{@instance.url}/Patient/#{patient}")
-            reply = get_resource_by_params(versioned_resource_class('Observation'), search_params_with_url)
-
-            reply = perform_search_with_status(reply, search_params) if reply.code == 400
-
-            assert_response_ok(reply)
-            assert_bundle_response(reply)
-            search_with_url = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
-            assert search_with_url.length == resources_returned.length, 'Expected search by url to have the same results as search by ID'
-
             break
           end
         end

--- a/lib/modules/uscore_v3.1.0/pediatric_weight_for_height_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/pediatric_weight_for_height_sequence.rb
@@ -110,7 +110,8 @@ module Inferno
 
         when 'patient'
           values_found = resolve_path(resource, 'subject.reference')
-          match_found = values_found.any? { |reference| [value, 'Patient/' + value].include? reference }
+          value = value.split('Patient/').last
+          match_found = values_found.any? { |reference| [value, 'Patient/' + value, "#{@instance.url}/Patient/#{value}"].include? reference }
           assert match_found, "patient in Observation/#{resource.id} (#{values_found}) does not match patient requested (#{value})"
 
         end
@@ -200,6 +201,26 @@ module Inferno
             token_with_system_search_params = search_params.merge('code': value_with_system)
             reply = get_resource_by_params(versioned_resource_class('Observation'), token_with_system_search_params)
             validate_search_reply(versioned_resource_class('Observation'), reply, token_with_system_search_params)
+
+            search_params_with_type = search_params.merge('patient': "Patient/#{patient}")
+            reply = get_resource_by_params(versioned_resource_class('Observation'), search_params_with_type)
+
+            reply = perform_search_with_status(reply, search_params) if reply.code == 400
+
+            assert_response_ok(reply)
+            assert_bundle_response(reply)
+            search_with_type = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
+            assert search_with_type.length == resources_returned.length, 'Expected search by Patient/ID to have the same results as search by ID'
+
+            search_params_with_url = search_params.merge('patient': "#{@instance.url}/Patient/#{patient}")
+            reply = get_resource_by_params(versioned_resource_class('Observation'), search_params_with_url)
+
+            reply = perform_search_with_status(reply, search_params) if reply.code == 400
+
+            assert_response_ok(reply)
+            assert_bundle_response(reply)
+            search_with_url = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
+            assert search_with_url.length == resources_returned.length, 'Expected search by url to have the same results as search by ID'
 
             break
           end

--- a/lib/modules/uscore_v3.1.0/resprate_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/resprate_sequence.rb
@@ -212,16 +212,6 @@ module Inferno
             search_with_type = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
             assert search_with_type.length == resources_returned.length, 'Expected search by Patient/ID to have the same results as search by ID'
 
-            search_params_with_url = search_params.merge('patient': "#{@instance.url}/Patient/#{patient}")
-            reply = get_resource_by_params(versioned_resource_class('Observation'), search_params_with_url)
-
-            reply = perform_search_with_status(reply, search_params) if reply.code == 400
-
-            assert_response_ok(reply)
-            assert_bundle_response(reply)
-            search_with_url = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
-            assert search_with_url.length == resources_returned.length, 'Expected search by url to have the same results as search by ID'
-
             break
           end
         end

--- a/lib/modules/uscore_v3.1.0/resprate_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/resprate_sequence.rb
@@ -110,7 +110,8 @@ module Inferno
 
         when 'patient'
           values_found = resolve_path(resource, 'subject.reference')
-          match_found = values_found.any? { |reference| [value, 'Patient/' + value].include? reference }
+          value = value.split('Patient/').last
+          match_found = values_found.any? { |reference| [value, 'Patient/' + value, "#{@instance.url}/Patient/#{value}"].include? reference }
           assert match_found, "patient in Observation/#{resource.id} (#{values_found}) does not match patient requested (#{value})"
 
         end
@@ -200,6 +201,26 @@ module Inferno
             token_with_system_search_params = search_params.merge('code': value_with_system)
             reply = get_resource_by_params(versioned_resource_class('Observation'), token_with_system_search_params)
             validate_search_reply(versioned_resource_class('Observation'), reply, token_with_system_search_params)
+
+            search_params_with_type = search_params.merge('patient': "Patient/#{patient}")
+            reply = get_resource_by_params(versioned_resource_class('Observation'), search_params_with_type)
+
+            reply = perform_search_with_status(reply, search_params) if reply.code == 400
+
+            assert_response_ok(reply)
+            assert_bundle_response(reply)
+            search_with_type = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
+            assert search_with_type.length == resources_returned.length, 'Expected search by Patient/ID to have the same results as search by ID'
+
+            search_params_with_url = search_params.merge('patient': "#{@instance.url}/Patient/#{patient}")
+            reply = get_resource_by_params(versioned_resource_class('Observation'), search_params_with_url)
+
+            reply = perform_search_with_status(reply, search_params) if reply.code == 400
+
+            assert_response_ok(reply)
+            assert_bundle_response(reply)
+            search_with_url = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
+            assert search_with_url.length == resources_returned.length, 'Expected search by url to have the same results as search by ID'
 
             break
           end

--- a/lib/modules/uscore_v3.1.0/test/bodyheight_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/bodyheight_test.rb
@@ -128,6 +128,10 @@ describe Inferno::Sequence::USCore310BodyheightSequence do
         stub_request(:get, "#{@base_url}/Observation")
           .with(query: query_params, headers: @auth_header)
           .to_return(status: 200, body: body)
+        reference_with_type_params = query_params.merge('patient': 'Patient/' + query_params[:patient])
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: reference_with_type_params, headers: @auth_header)
+          .to_return(status: 200, body: body)
       end
 
       stub_request(:get, "#{@base_url}/Observation")
@@ -223,6 +227,9 @@ describe Inferno::Sequence::USCore310BodyheightSequence do
             .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
           stub_request(:get, "#{@base_url}/Observation")
             .with(query: query_params.merge('status': ['registered,preliminary,final,amended,corrected,cancelled,entered-in-error,unknown'].first), headers: @auth_header)
+            .to_return(status: 200, body: wrap_resources_in_bundle([@observation]).to_json)
+          stub_request(:get, "#{@base_url}/Observation")
+            .with(query: query_params.merge('patient': 'Patient/' + query_params[:patient], 'status': ['registered,preliminary,final,amended,corrected,cancelled,entered-in-error,unknown'].first), headers: @auth_header)
             .to_return(status: 200, body: wrap_resources_in_bundle([@observation]).to_json)
         end
 

--- a/lib/modules/uscore_v3.1.0/test/bodytemp_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/bodytemp_test.rb
@@ -128,6 +128,10 @@ describe Inferno::Sequence::USCore310BodytempSequence do
         stub_request(:get, "#{@base_url}/Observation")
           .with(query: query_params, headers: @auth_header)
           .to_return(status: 200, body: body)
+        reference_with_type_params = query_params.merge('patient': 'Patient/' + query_params[:patient])
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: reference_with_type_params, headers: @auth_header)
+          .to_return(status: 200, body: body)
       end
 
       stub_request(:get, "#{@base_url}/Observation")
@@ -223,6 +227,9 @@ describe Inferno::Sequence::USCore310BodytempSequence do
             .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
           stub_request(:get, "#{@base_url}/Observation")
             .with(query: query_params.merge('status': ['registered,preliminary,final,amended,corrected,cancelled,entered-in-error,unknown'].first), headers: @auth_header)
+            .to_return(status: 200, body: wrap_resources_in_bundle([@observation]).to_json)
+          stub_request(:get, "#{@base_url}/Observation")
+            .with(query: query_params.merge('patient': 'Patient/' + query_params[:patient], 'status': ['registered,preliminary,final,amended,corrected,cancelled,entered-in-error,unknown'].first), headers: @auth_header)
             .to_return(status: 200, body: wrap_resources_in_bundle([@observation]).to_json)
         end
 

--- a/lib/modules/uscore_v3.1.0/test/bodyweight_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/bodyweight_test.rb
@@ -128,6 +128,10 @@ describe Inferno::Sequence::USCore310BodyweightSequence do
         stub_request(:get, "#{@base_url}/Observation")
           .with(query: query_params, headers: @auth_header)
           .to_return(status: 200, body: body)
+        reference_with_type_params = query_params.merge('patient': 'Patient/' + query_params[:patient])
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: reference_with_type_params, headers: @auth_header)
+          .to_return(status: 200, body: body)
       end
 
       stub_request(:get, "#{@base_url}/Observation")
@@ -223,6 +227,9 @@ describe Inferno::Sequence::USCore310BodyweightSequence do
             .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
           stub_request(:get, "#{@base_url}/Observation")
             .with(query: query_params.merge('status': ['registered,preliminary,final,amended,corrected,cancelled,entered-in-error,unknown'].first), headers: @auth_header)
+            .to_return(status: 200, body: wrap_resources_in_bundle([@observation]).to_json)
+          stub_request(:get, "#{@base_url}/Observation")
+            .with(query: query_params.merge('patient': 'Patient/' + query_params[:patient], 'status': ['registered,preliminary,final,amended,corrected,cancelled,entered-in-error,unknown'].first), headers: @auth_header)
             .to_return(status: 200, body: wrap_resources_in_bundle([@observation]).to_json)
         end
 

--- a/lib/modules/uscore_v3.1.0/test/bp_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/bp_test.rb
@@ -128,6 +128,10 @@ describe Inferno::Sequence::USCore310BpSequence do
         stub_request(:get, "#{@base_url}/Observation")
           .with(query: query_params, headers: @auth_header)
           .to_return(status: 200, body: body)
+        reference_with_type_params = query_params.merge('patient': 'Patient/' + query_params[:patient])
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: reference_with_type_params, headers: @auth_header)
+          .to_return(status: 200, body: body)
       end
 
       stub_request(:get, "#{@base_url}/Observation")
@@ -223,6 +227,9 @@ describe Inferno::Sequence::USCore310BpSequence do
             .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
           stub_request(:get, "#{@base_url}/Observation")
             .with(query: query_params.merge('status': ['registered,preliminary,final,amended,corrected,cancelled,entered-in-error,unknown'].first), headers: @auth_header)
+            .to_return(status: 200, body: wrap_resources_in_bundle([@observation]).to_json)
+          stub_request(:get, "#{@base_url}/Observation")
+            .with(query: query_params.merge('patient': 'Patient/' + query_params[:patient], 'status': ['registered,preliminary,final,amended,corrected,cancelled,entered-in-error,unknown'].first), headers: @auth_header)
             .to_return(status: 200, body: wrap_resources_in_bundle([@observation]).to_json)
         end
 

--- a/lib/modules/uscore_v3.1.0/test/headcircum_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/headcircum_test.rb
@@ -128,6 +128,10 @@ describe Inferno::Sequence::USCore310HeadcircumSequence do
         stub_request(:get, "#{@base_url}/Observation")
           .with(query: query_params, headers: @auth_header)
           .to_return(status: 200, body: body)
+        reference_with_type_params = query_params.merge('patient': 'Patient/' + query_params[:patient])
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: reference_with_type_params, headers: @auth_header)
+          .to_return(status: 200, body: body)
       end
 
       stub_request(:get, "#{@base_url}/Observation")
@@ -223,6 +227,9 @@ describe Inferno::Sequence::USCore310HeadcircumSequence do
             .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
           stub_request(:get, "#{@base_url}/Observation")
             .with(query: query_params.merge('status': ['registered,preliminary,final,amended,corrected,cancelled,entered-in-error,unknown'].first), headers: @auth_header)
+            .to_return(status: 200, body: wrap_resources_in_bundle([@observation]).to_json)
+          stub_request(:get, "#{@base_url}/Observation")
+            .with(query: query_params.merge('patient': 'Patient/' + query_params[:patient], 'status': ['registered,preliminary,final,amended,corrected,cancelled,entered-in-error,unknown'].first), headers: @auth_header)
             .to_return(status: 200, body: wrap_resources_in_bundle([@observation]).to_json)
         end
 

--- a/lib/modules/uscore_v3.1.0/test/heartrate_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/heartrate_test.rb
@@ -128,6 +128,10 @@ describe Inferno::Sequence::USCore310HeartrateSequence do
         stub_request(:get, "#{@base_url}/Observation")
           .with(query: query_params, headers: @auth_header)
           .to_return(status: 200, body: body)
+        reference_with_type_params = query_params.merge('patient': 'Patient/' + query_params[:patient])
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: reference_with_type_params, headers: @auth_header)
+          .to_return(status: 200, body: body)
       end
 
       stub_request(:get, "#{@base_url}/Observation")
@@ -223,6 +227,9 @@ describe Inferno::Sequence::USCore310HeartrateSequence do
             .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
           stub_request(:get, "#{@base_url}/Observation")
             .with(query: query_params.merge('status': ['registered,preliminary,final,amended,corrected,cancelled,entered-in-error,unknown'].first), headers: @auth_header)
+            .to_return(status: 200, body: wrap_resources_in_bundle([@observation]).to_json)
+          stub_request(:get, "#{@base_url}/Observation")
+            .with(query: query_params.merge('patient': 'Patient/' + query_params[:patient], 'status': ['registered,preliminary,final,amended,corrected,cancelled,entered-in-error,unknown'].first), headers: @auth_header)
             .to_return(status: 200, body: wrap_resources_in_bundle([@observation]).to_json)
         end
 

--- a/lib/modules/uscore_v3.1.0/test/pediatric_bmi_for_age_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/pediatric_bmi_for_age_test.rb
@@ -128,6 +128,10 @@ describe Inferno::Sequence::USCore310PediatricBmiForAgeSequence do
         stub_request(:get, "#{@base_url}/Observation")
           .with(query: query_params, headers: @auth_header)
           .to_return(status: 200, body: body)
+        reference_with_type_params = query_params.merge('patient': 'Patient/' + query_params[:patient])
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: reference_with_type_params, headers: @auth_header)
+          .to_return(status: 200, body: body)
       end
 
       stub_request(:get, "#{@base_url}/Observation")
@@ -223,6 +227,9 @@ describe Inferno::Sequence::USCore310PediatricBmiForAgeSequence do
             .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
           stub_request(:get, "#{@base_url}/Observation")
             .with(query: query_params.merge('status': ['registered,preliminary,final,amended,corrected,cancelled,entered-in-error,unknown'].first), headers: @auth_header)
+            .to_return(status: 200, body: wrap_resources_in_bundle([@observation]).to_json)
+          stub_request(:get, "#{@base_url}/Observation")
+            .with(query: query_params.merge('patient': 'Patient/' + query_params[:patient], 'status': ['registered,preliminary,final,amended,corrected,cancelled,entered-in-error,unknown'].first), headers: @auth_header)
             .to_return(status: 200, body: wrap_resources_in_bundle([@observation]).to_json)
         end
 

--- a/lib/modules/uscore_v3.1.0/test/pediatric_weight_for_height_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/pediatric_weight_for_height_test.rb
@@ -128,6 +128,10 @@ describe Inferno::Sequence::USCore310PediatricWeightForHeightSequence do
         stub_request(:get, "#{@base_url}/Observation")
           .with(query: query_params, headers: @auth_header)
           .to_return(status: 200, body: body)
+        reference_with_type_params = query_params.merge('patient': 'Patient/' + query_params[:patient])
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: reference_with_type_params, headers: @auth_header)
+          .to_return(status: 200, body: body)
       end
 
       stub_request(:get, "#{@base_url}/Observation")
@@ -223,6 +227,9 @@ describe Inferno::Sequence::USCore310PediatricWeightForHeightSequence do
             .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
           stub_request(:get, "#{@base_url}/Observation")
             .with(query: query_params.merge('status': ['registered,preliminary,final,amended,corrected,cancelled,entered-in-error,unknown'].first), headers: @auth_header)
+            .to_return(status: 200, body: wrap_resources_in_bundle([@observation]).to_json)
+          stub_request(:get, "#{@base_url}/Observation")
+            .with(query: query_params.merge('patient': 'Patient/' + query_params[:patient], 'status': ['registered,preliminary,final,amended,corrected,cancelled,entered-in-error,unknown'].first), headers: @auth_header)
             .to_return(status: 200, body: wrap_resources_in_bundle([@observation]).to_json)
         end
 

--- a/lib/modules/uscore_v3.1.0/test/resprate_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/resprate_test.rb
@@ -128,6 +128,10 @@ describe Inferno::Sequence::USCore310ResprateSequence do
         stub_request(:get, "#{@base_url}/Observation")
           .with(query: query_params, headers: @auth_header)
           .to_return(status: 200, body: body)
+        reference_with_type_params = query_params.merge('patient': 'Patient/' + query_params[:patient])
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: reference_with_type_params, headers: @auth_header)
+          .to_return(status: 200, body: body)
       end
 
       stub_request(:get, "#{@base_url}/Observation")
@@ -223,6 +227,9 @@ describe Inferno::Sequence::USCore310ResprateSequence do
             .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
           stub_request(:get, "#{@base_url}/Observation")
             .with(query: query_params.merge('status': ['registered,preliminary,final,amended,corrected,cancelled,entered-in-error,unknown'].first), headers: @auth_header)
+            .to_return(status: 200, body: wrap_resources_in_bundle([@observation]).to_json)
+          stub_request(:get, "#{@base_url}/Observation")
+            .with(query: query_params.merge('patient': 'Patient/' + query_params[:patient], 'status': ['registered,preliminary,final,amended,corrected,cancelled,entered-in-error,unknown'].first), headers: @auth_header)
             .to_return(status: 200, body: wrap_resources_in_bundle([@observation]).to_json)
         end
 

--- a/lib/modules/uscore_v3.1.0/test/us_core_allergyintolerance_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_allergyintolerance_test.rb
@@ -88,6 +88,11 @@ describe Inferno::Sequence::USCore310AllergyintoleranceSequence do
         .with(query: @query, headers: @auth_header)
         .to_return(status: 200, body: wrap_resources_in_bundle(@allergy_intolerance_ary.values.flatten).to_json)
 
+      reference_with_type_params = @query.merge('patient': 'Patient/' + @query[:patient])
+      stub_request(:get, "#{@base_url}/AllergyIntolerance")
+        .with(query: reference_with_type_params, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@allergy_intolerance_ary.values.flatten).to_json)
+
       @sequence.run_test(@test)
     end
 
@@ -148,6 +153,10 @@ describe Inferno::Sequence::USCore310AllergyintoleranceSequence do
           .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
         stub_request(:get, "#{@base_url}/AllergyIntolerance")
           .with(query: @query.merge('clinical-status': ['active', 'inactive', 'resolved'].first), headers: @auth_header)
+          .to_return(status: 200, body: wrap_resources_in_bundle([@allergy_intolerance]).to_json)
+
+        stub_request(:get, "#{@base_url}/AllergyIntolerance")
+          .with(query: @query.merge('patient': 'Patient/' + @query[:patient], 'clinical-status': ['active', 'inactive', 'resolved'].first), headers: @auth_header)
           .to_return(status: 200, body: wrap_resources_in_bundle([@allergy_intolerance]).to_json)
 
         @sequence.run_test(@test)

--- a/lib/modules/uscore_v3.1.0/test/us_core_careplan_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_careplan_test.rb
@@ -128,6 +128,10 @@ describe Inferno::Sequence::USCore310CareplanSequence do
         stub_request(:get, "#{@base_url}/CarePlan")
           .with(query: query_params, headers: @auth_header)
           .to_return(status: 200, body: body)
+        reference_with_type_params = query_params.merge('patient': 'Patient/' + query_params[:patient])
+        stub_request(:get, "#{@base_url}/CarePlan")
+          .with(query: reference_with_type_params, headers: @auth_header)
+          .to_return(status: 200, body: body)
       end
 
       stub_request(:get, "#{@base_url}/CarePlan")
@@ -223,6 +227,9 @@ describe Inferno::Sequence::USCore310CareplanSequence do
             .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
           stub_request(:get, "#{@base_url}/CarePlan")
             .with(query: query_params.merge('status': ['draft,active,on-hold,revoked,completed,entered-in-error,unknown'].first), headers: @auth_header)
+            .to_return(status: 200, body: wrap_resources_in_bundle([@care_plan]).to_json)
+          stub_request(:get, "#{@base_url}/CarePlan")
+            .with(query: query_params.merge('patient': 'Patient/' + query_params[:patient], 'status': ['draft,active,on-hold,revoked,completed,entered-in-error,unknown'].first), headers: @auth_header)
             .to_return(status: 200, body: wrap_resources_in_bundle([@care_plan]).to_json)
         end
 

--- a/lib/modules/uscore_v3.1.0/test/us_core_careteam_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_careteam_test.rb
@@ -123,6 +123,10 @@ describe Inferno::Sequence::USCore310CareteamSequence do
         stub_request(:get, "#{@base_url}/CareTeam")
           .with(query: query_params, headers: @auth_header)
           .to_return(status: 200, body: body)
+        reference_with_type_params = query_params.merge('patient': 'Patient/' + query_params[:patient])
+        stub_request(:get, "#{@base_url}/CareTeam")
+          .with(query: reference_with_type_params, headers: @auth_header)
+          .to_return(status: 200, body: body)
       end
 
       @sequence.run_test(@test)

--- a/lib/modules/uscore_v3.1.0/test/us_core_condition_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_condition_test.rb
@@ -88,6 +88,11 @@ describe Inferno::Sequence::USCore310ConditionSequence do
         .with(query: @query, headers: @auth_header)
         .to_return(status: 200, body: wrap_resources_in_bundle(@condition_ary.values.flatten).to_json)
 
+      reference_with_type_params = @query.merge('patient': 'Patient/' + @query[:patient])
+      stub_request(:get, "#{@base_url}/Condition")
+        .with(query: reference_with_type_params, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@condition_ary.values.flatten).to_json)
+
       @sequence.run_test(@test)
     end
 
@@ -148,6 +153,10 @@ describe Inferno::Sequence::USCore310ConditionSequence do
           .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
         stub_request(:get, "#{@base_url}/Condition")
           .with(query: @query.merge('clinical-status': ['active', 'recurrence', 'relapse', 'inactive', 'remission', 'resolved'].first), headers: @auth_header)
+          .to_return(status: 200, body: wrap_resources_in_bundle([@condition]).to_json)
+
+        stub_request(:get, "#{@base_url}/Condition")
+          .with(query: @query.merge('patient': 'Patient/' + @query[:patient], 'clinical-status': ['active', 'recurrence', 'relapse', 'inactive', 'remission', 'resolved'].first), headers: @auth_header)
           .to_return(status: 200, body: wrap_resources_in_bundle([@condition]).to_json)
 
         @sequence.run_test(@test)

--- a/lib/modules/uscore_v3.1.0/test/us_core_diagnosticreport_lab_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_diagnosticreport_lab_test.rb
@@ -128,6 +128,10 @@ describe Inferno::Sequence::USCore310DiagnosticreportLabSequence do
         stub_request(:get, "#{@base_url}/DiagnosticReport")
           .with(query: query_params, headers: @auth_header)
           .to_return(status: 200, body: body)
+        reference_with_type_params = query_params.merge('patient': 'Patient/' + query_params[:patient])
+        stub_request(:get, "#{@base_url}/DiagnosticReport")
+          .with(query: reference_with_type_params, headers: @auth_header)
+          .to_return(status: 200, body: body)
       end
 
       stub_request(:get, "#{@base_url}/DiagnosticReport")
@@ -223,6 +227,9 @@ describe Inferno::Sequence::USCore310DiagnosticreportLabSequence do
             .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
           stub_request(:get, "#{@base_url}/DiagnosticReport")
             .with(query: query_params.merge('status': ['registered,partial,preliminary,final,amended,corrected,appended,cancelled,entered-in-error,unknown'].first), headers: @auth_header)
+            .to_return(status: 200, body: wrap_resources_in_bundle([@diagnostic_report]).to_json)
+          stub_request(:get, "#{@base_url}/DiagnosticReport")
+            .with(query: query_params.merge('patient': 'Patient/' + query_params[:patient], 'status': ['registered,partial,preliminary,final,amended,corrected,appended,cancelled,entered-in-error,unknown'].first), headers: @auth_header)
             .to_return(status: 200, body: wrap_resources_in_bundle([@diagnostic_report]).to_json)
         end
 

--- a/lib/modules/uscore_v3.1.0/test/us_core_diagnosticreport_note_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_diagnosticreport_note_test.rb
@@ -128,6 +128,10 @@ describe Inferno::Sequence::USCore310DiagnosticreportNoteSequence do
         stub_request(:get, "#{@base_url}/DiagnosticReport")
           .with(query: query_params, headers: @auth_header)
           .to_return(status: 200, body: body)
+        reference_with_type_params = query_params.merge('patient': 'Patient/' + query_params[:patient])
+        stub_request(:get, "#{@base_url}/DiagnosticReport")
+          .with(query: reference_with_type_params, headers: @auth_header)
+          .to_return(status: 200, body: body)
       end
 
       stub_request(:get, "#{@base_url}/DiagnosticReport")
@@ -223,6 +227,9 @@ describe Inferno::Sequence::USCore310DiagnosticreportNoteSequence do
             .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
           stub_request(:get, "#{@base_url}/DiagnosticReport")
             .with(query: query_params.merge('status': ['registered,partial,preliminary,final,amended,corrected,appended,cancelled,entered-in-error,unknown'].first), headers: @auth_header)
+            .to_return(status: 200, body: wrap_resources_in_bundle([@diagnostic_report]).to_json)
+          stub_request(:get, "#{@base_url}/DiagnosticReport")
+            .with(query: query_params.merge('patient': 'Patient/' + query_params[:patient], 'status': ['registered,partial,preliminary,final,amended,corrected,appended,cancelled,entered-in-error,unknown'].first), headers: @auth_header)
             .to_return(status: 200, body: wrap_resources_in_bundle([@diagnostic_report]).to_json)
         end
 

--- a/lib/modules/uscore_v3.1.0/test/us_core_documentreference_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_documentreference_test.rb
@@ -88,6 +88,11 @@ describe Inferno::Sequence::USCore310DocumentreferenceSequence do
         .with(query: @query, headers: @auth_header)
         .to_return(status: 200, body: wrap_resources_in_bundle(@document_reference_ary.values.flatten).to_json)
 
+      reference_with_type_params = @query.merge('patient': 'Patient/' + @query[:patient])
+      stub_request(:get, "#{@base_url}/DocumentReference")
+        .with(query: reference_with_type_params, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@document_reference_ary.values.flatten).to_json)
+
       @sequence.run_test(@test)
     end
 
@@ -148,6 +153,10 @@ describe Inferno::Sequence::USCore310DocumentreferenceSequence do
           .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
         stub_request(:get, "#{@base_url}/DocumentReference")
           .with(query: @query.merge('status': ['current,superseded,entered-in-error'].first), headers: @auth_header)
+          .to_return(status: 200, body: wrap_resources_in_bundle([@document_reference]).to_json)
+
+        stub_request(:get, "#{@base_url}/DocumentReference")
+          .with(query: @query.merge('patient': 'Patient/' + @query[:patient], 'status': ['current,superseded,entered-in-error'].first), headers: @auth_header)
           .to_return(status: 200, body: wrap_resources_in_bundle([@document_reference]).to_json)
 
         @sequence.run_test(@test)

--- a/lib/modules/uscore_v3.1.0/test/us_core_goal_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_goal_test.rb
@@ -88,6 +88,11 @@ describe Inferno::Sequence::USCore310GoalSequence do
         .with(query: @query, headers: @auth_header)
         .to_return(status: 200, body: wrap_resources_in_bundle(@goal_ary.values.flatten).to_json)
 
+      reference_with_type_params = @query.merge('patient': 'Patient/' + @query[:patient])
+      stub_request(:get, "#{@base_url}/Goal")
+        .with(query: reference_with_type_params, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@goal_ary.values.flatten).to_json)
+
       @sequence.run_test(@test)
     end
 
@@ -148,6 +153,10 @@ describe Inferno::Sequence::USCore310GoalSequence do
           .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
         stub_request(:get, "#{@base_url}/Goal")
           .with(query: @query.merge('lifecycle-status': ['proposed', 'planned', 'accepted', 'active', 'on-hold', 'completed', 'cancelled', 'entered-in-error', 'rejected'].first), headers: @auth_header)
+          .to_return(status: 200, body: wrap_resources_in_bundle([@goal]).to_json)
+
+        stub_request(:get, "#{@base_url}/Goal")
+          .with(query: @query.merge('patient': 'Patient/' + @query[:patient], 'lifecycle-status': ['proposed', 'planned', 'accepted', 'active', 'on-hold', 'completed', 'cancelled', 'entered-in-error', 'rejected'].first), headers: @auth_header)
           .to_return(status: 200, body: wrap_resources_in_bundle([@goal]).to_json)
 
         @sequence.run_test(@test)

--- a/lib/modules/uscore_v3.1.0/test/us_core_immunization_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_immunization_test.rb
@@ -88,6 +88,11 @@ describe Inferno::Sequence::USCore310ImmunizationSequence do
         .with(query: @query, headers: @auth_header)
         .to_return(status: 200, body: wrap_resources_in_bundle(@immunization_ary.values.flatten).to_json)
 
+      reference_with_type_params = @query.merge('patient': 'Patient/' + @query[:patient])
+      stub_request(:get, "#{@base_url}/Immunization")
+        .with(query: reference_with_type_params, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@immunization_ary.values.flatten).to_json)
+
       @sequence.run_test(@test)
     end
 
@@ -148,6 +153,10 @@ describe Inferno::Sequence::USCore310ImmunizationSequence do
           .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
         stub_request(:get, "#{@base_url}/Immunization")
           .with(query: @query.merge('status': ['completed', 'entered-in-error', 'not-done', 'preparation', 'in-progress', 'on-hold', 'stopped', 'unknown'].first), headers: @auth_header)
+          .to_return(status: 200, body: wrap_resources_in_bundle([@immunization]).to_json)
+
+        stub_request(:get, "#{@base_url}/Immunization")
+          .with(query: @query.merge('patient': 'Patient/' + @query[:patient], 'status': ['completed', 'entered-in-error', 'not-done', 'preparation', 'in-progress', 'on-hold', 'stopped', 'unknown'].first), headers: @auth_header)
           .to_return(status: 200, body: wrap_resources_in_bundle([@immunization]).to_json)
 
         @sequence.run_test(@test)

--- a/lib/modules/uscore_v3.1.0/test/us_core_implantable_device_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_implantable_device_test.rb
@@ -88,6 +88,11 @@ describe Inferno::Sequence::USCore310ImplantableDeviceSequence do
         .with(query: @query, headers: @auth_header)
         .to_return(status: 200, body: wrap_resources_in_bundle(@device_ary.values.flatten).to_json)
 
+      reference_with_type_params = @query.merge('patient': 'Patient/' + @query[:patient])
+      stub_request(:get, "#{@base_url}/Device")
+        .with(query: reference_with_type_params, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@device_ary.values.flatten).to_json)
+
       @sequence.run_test(@test)
     end
   end

--- a/lib/modules/uscore_v3.1.0/test/us_core_medicationrequest_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_medicationrequest_test.rb
@@ -123,6 +123,10 @@ describe Inferno::Sequence::USCore310MedicationrequestSequence do
         stub_request(:get, "#{@base_url}/MedicationRequest")
           .with(query: query_params, headers: @auth_header)
           .to_return(status: 200, body: body)
+        reference_with_type_params = query_params.merge('patient': 'Patient/' + query_params[:patient])
+        stub_request(:get, "#{@base_url}/MedicationRequest")
+          .with(query: reference_with_type_params, headers: @auth_header)
+          .to_return(status: 200, body: body)
       end
 
       @sequence.run_test(@test)
@@ -141,6 +145,9 @@ describe Inferno::Sequence::USCore310MedicationrequestSequence do
           end
         stub_request(:get, "#{@base_url}/MedicationRequest")
           .with(query: query_params, headers: @auth_header)
+          .to_return(status: 200, body: body)
+        stub_request(:get, "#{@base_url}/MedicationRequest")
+          .with(query: query_params.merge('patient': 'Patient/' + query_params[:patient]), headers: @auth_header)
           .to_return(status: 200, body: body)
       end
 
@@ -237,6 +244,9 @@ describe Inferno::Sequence::USCore310MedicationrequestSequence do
             .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
           stub_request(:get, "#{@base_url}/MedicationRequest")
             .with(query: query_params.merge('status': ['active,on-hold,cancelled,completed,entered-in-error,stopped,draft,unknown'].first), headers: @auth_header)
+            .to_return(status: 200, body: wrap_resources_in_bundle([@medication_request]).to_json)
+          stub_request(:get, "#{@base_url}/MedicationRequest")
+            .with(query: query_params.merge('patient': 'Patient/' + query_params[:patient], 'status': ['active,on-hold,cancelled,completed,entered-in-error,stopped,draft,unknown'].first), headers: @auth_header)
             .to_return(status: 200, body: wrap_resources_in_bundle([@medication_request]).to_json)
         end
 
@@ -342,6 +352,9 @@ describe Inferno::Sequence::USCore310MedicationrequestSequence do
           end
         stub_request(:get, "#{@base_url}/MedicationRequest")
           .with(query: query_params, headers: @auth_header)
+          .to_return(status: 200, body: body)
+        stub_request(:get, "#{@base_url}/MedicationRequest")
+          .with(query: query_params.merge('patient': 'Patient/' + query_params[:patient]), headers: @auth_header)
           .to_return(status: 200, body: body)
       end
 
@@ -450,6 +463,9 @@ describe Inferno::Sequence::USCore310MedicationrequestSequence do
           end
         stub_request(:get, "#{@base_url}/MedicationRequest")
           .with(query: query_params, headers: @auth_header)
+          .to_return(status: 200, body: body)
+        stub_request(:get, "#{@base_url}/MedicationRequest")
+          .with(query: query_params.merge('patient': 'Patient/' + query_params[:patient]), headers: @auth_header)
           .to_return(status: 200, body: body)
       end
 
@@ -621,6 +637,9 @@ describe Inferno::Sequence::USCore310MedicationrequestSequence do
           end
         stub_request(:get, "#{@base_url}/MedicationRequest")
           .with(query: query_params, headers: @auth_header)
+          .to_return(status: 200, body: body)
+        stub_request(:get, "#{@base_url}/MedicationRequest")
+          .with(query: query_params.merge('patient': 'Patient/' + query_params[:patient]), headers: @auth_header)
           .to_return(status: 200, body: body)
       end
 

--- a/lib/modules/uscore_v3.1.0/test/us_core_observation_lab_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_observation_lab_test.rb
@@ -128,6 +128,10 @@ describe Inferno::Sequence::USCore310ObservationLabSequence do
         stub_request(:get, "#{@base_url}/Observation")
           .with(query: query_params, headers: @auth_header)
           .to_return(status: 200, body: body)
+        reference_with_type_params = query_params.merge('patient': 'Patient/' + query_params[:patient])
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: reference_with_type_params, headers: @auth_header)
+          .to_return(status: 200, body: body)
       end
 
       stub_request(:get, "#{@base_url}/Observation")
@@ -223,6 +227,9 @@ describe Inferno::Sequence::USCore310ObservationLabSequence do
             .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
           stub_request(:get, "#{@base_url}/Observation")
             .with(query: query_params.merge('status': ['registered,preliminary,final,amended,corrected,cancelled,entered-in-error,unknown'].first), headers: @auth_header)
+            .to_return(status: 200, body: wrap_resources_in_bundle([@observation]).to_json)
+          stub_request(:get, "#{@base_url}/Observation")
+            .with(query: query_params.merge('patient': 'Patient/' + query_params[:patient], 'status': ['registered,preliminary,final,amended,corrected,cancelled,entered-in-error,unknown'].first), headers: @auth_header)
             .to_return(status: 200, body: wrap_resources_in_bundle([@observation]).to_json)
         end
 

--- a/lib/modules/uscore_v3.1.0/test/us_core_procedure_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_procedure_test.rb
@@ -88,6 +88,11 @@ describe Inferno::Sequence::USCore310ProcedureSequence do
         .with(query: @query, headers: @auth_header)
         .to_return(status: 200, body: wrap_resources_in_bundle(@procedure_ary.values.flatten).to_json)
 
+      reference_with_type_params = @query.merge('patient': 'Patient/' + @query[:patient])
+      stub_request(:get, "#{@base_url}/Procedure")
+        .with(query: reference_with_type_params, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@procedure_ary.values.flatten).to_json)
+
       @sequence.run_test(@test)
     end
 
@@ -148,6 +153,10 @@ describe Inferno::Sequence::USCore310ProcedureSequence do
           .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
         stub_request(:get, "#{@base_url}/Procedure")
           .with(query: @query.merge('status': ['preparation,in-progress,not-done,on-hold,stopped,completed,entered-in-error,unknown'].first), headers: @auth_header)
+          .to_return(status: 200, body: wrap_resources_in_bundle([@procedure]).to_json)
+
+        stub_request(:get, "#{@base_url}/Procedure")
+          .with(query: @query.merge('patient': 'Patient/' + @query[:patient], 'status': ['preparation,in-progress,not-done,on-hold,stopped,completed,entered-in-error,unknown'].first), headers: @auth_header)
           .to_return(status: 200, body: wrap_resources_in_bundle([@procedure]).to_json)
 
         @sequence.run_test(@test)

--- a/lib/modules/uscore_v3.1.0/test/us_core_pulse_oximetry_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_pulse_oximetry_test.rb
@@ -128,6 +128,10 @@ describe Inferno::Sequence::USCore310PulseOximetrySequence do
         stub_request(:get, "#{@base_url}/Observation")
           .with(query: query_params, headers: @auth_header)
           .to_return(status: 200, body: body)
+        reference_with_type_params = query_params.merge('patient': 'Patient/' + query_params[:patient])
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: reference_with_type_params, headers: @auth_header)
+          .to_return(status: 200, body: body)
       end
 
       stub_request(:get, "#{@base_url}/Observation")
@@ -223,6 +227,9 @@ describe Inferno::Sequence::USCore310PulseOximetrySequence do
             .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
           stub_request(:get, "#{@base_url}/Observation")
             .with(query: query_params.merge('status': ['registered,preliminary,final,amended,corrected,cancelled,entered-in-error,unknown'].first), headers: @auth_header)
+            .to_return(status: 200, body: wrap_resources_in_bundle([@observation]).to_json)
+          stub_request(:get, "#{@base_url}/Observation")
+            .with(query: query_params.merge('patient': 'Patient/' + query_params[:patient], 'status': ['registered,preliminary,final,amended,corrected,cancelled,entered-in-error,unknown'].first), headers: @auth_header)
             .to_return(status: 200, body: wrap_resources_in_bundle([@observation]).to_json)
         end
 

--- a/lib/modules/uscore_v3.1.0/test/us_core_smokingstatus_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/us_core_smokingstatus_test.rb
@@ -128,6 +128,10 @@ describe Inferno::Sequence::USCore310SmokingstatusSequence do
         stub_request(:get, "#{@base_url}/Observation")
           .with(query: query_params, headers: @auth_header)
           .to_return(status: 200, body: body)
+        reference_with_type_params = query_params.merge('patient': 'Patient/' + query_params[:patient])
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: reference_with_type_params, headers: @auth_header)
+          .to_return(status: 200, body: body)
       end
 
       stub_request(:get, "#{@base_url}/Observation")
@@ -223,6 +227,9 @@ describe Inferno::Sequence::USCore310SmokingstatusSequence do
             .to_return(status: 400, body: FHIR::OperationOutcome.new.to_json)
           stub_request(:get, "#{@base_url}/Observation")
             .with(query: query_params.merge('status': ['final,entered-in-error'].first), headers: @auth_header)
+            .to_return(status: 200, body: wrap_resources_in_bundle([@observation]).to_json)
+          stub_request(:get, "#{@base_url}/Observation")
+            .with(query: query_params.merge('patient': 'Patient/' + query_params[:patient], 'status': ['final,entered-in-error'].first), headers: @auth_header)
             .to_return(status: 200, body: wrap_resources_in_bundle([@observation]).to_json)
         end
 

--- a/lib/modules/uscore_v3.1.0/us_core_allergyintolerance_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_allergyintolerance_sequence.rb
@@ -84,7 +84,8 @@ module Inferno
 
         when 'patient'
           values_found = resolve_path(resource, 'patient.reference')
-          match_found = values_found.any? { |reference| [value, 'Patient/' + value].include? reference }
+          value = value.split('Patient/').last
+          match_found = values_found.any? { |reference| [value, 'Patient/' + value, "#{@instance.url}/Patient/#{value}"].include? reference }
           assert match_found, "patient in AllergyIntolerance/#{resource.id} (#{values_found}) does not match patient requested (#{value})"
 
         end
@@ -170,6 +171,20 @@ module Inferno
           save_resource_references(versioned_resource_class('AllergyIntolerance'), @allergy_intolerance_ary[patient])
           save_delayed_sequence_references(@allergy_intolerance_ary[patient], USCore310AllergyintoleranceSequenceDefinitions::DELAYED_REFERENCES)
           validate_reply_entries(@allergy_intolerance_ary[patient], search_params)
+
+          search_params = search_params.merge('patient': "Patient/#{patient}")
+          reply = get_resource_by_params(versioned_resource_class('AllergyIntolerance'), search_params)
+          assert_response_ok(reply)
+          assert_bundle_response(reply)
+          search_with_type = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
+          assert search_with_type.length == @allergy_intolerance_ary[patient].length, 'Expected search by Patient/ID to have the same results as search by ID'
+
+          search_params = search_params.merge('patient': "#{@instance.url}/Patient/#{patient}")
+          reply = get_resource_by_params(versioned_resource_class('AllergyIntolerance'), search_params)
+          assert_response_ok(reply)
+          assert_bundle_response(reply)
+          search_with_url = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
+          assert search_with_url.length == @allergy_intolerance_ary[patient].length, 'Expected search by url to have the same results as search by ID'
         end
 
         skip_if_not_found(resource_type: 'AllergyIntolerance', delayed: false)

--- a/lib/modules/uscore_v3.1.0/us_core_allergyintolerance_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_allergyintolerance_sequence.rb
@@ -178,13 +178,6 @@ module Inferno
           assert_bundle_response(reply)
           search_with_type = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
           assert search_with_type.length == @allergy_intolerance_ary[patient].length, 'Expected search by Patient/ID to have the same results as search by ID'
-
-          search_params = search_params.merge('patient': "#{@instance.url}/Patient/#{patient}")
-          reply = get_resource_by_params(versioned_resource_class('AllergyIntolerance'), search_params)
-          assert_response_ok(reply)
-          assert_bundle_response(reply)
-          search_with_url = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
-          assert search_with_url.length == @allergy_intolerance_ary[patient].length, 'Expected search by url to have the same results as search by ID'
         end
 
         skip_if_not_found(resource_type: 'AllergyIntolerance', delayed: false)

--- a/lib/modules/uscore_v3.1.0/us_core_careplan_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_careplan_sequence.rb
@@ -197,16 +197,6 @@ module Inferno
             search_with_type = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
             assert search_with_type.length == resources_returned.length, 'Expected search by Patient/ID to have the same results as search by ID'
 
-            search_params_with_url = search_params.merge('patient': "#{@instance.url}/Patient/#{patient}")
-            reply = get_resource_by_params(versioned_resource_class('CarePlan'), search_params_with_url)
-
-            reply = perform_search_with_status(reply, search_params) if reply.code == 400
-
-            assert_response_ok(reply)
-            assert_bundle_response(reply)
-            search_with_url = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
-            assert search_with_url.length == resources_returned.length, 'Expected search by url to have the same results as search by ID'
-
             break
           end
         end

--- a/lib/modules/uscore_v3.1.0/us_core_careplan_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_careplan_sequence.rb
@@ -89,7 +89,8 @@ module Inferno
 
         when 'patient'
           values_found = resolve_path(resource, 'subject.reference')
-          match_found = values_found.any? { |reference| [value, 'Patient/' + value].include? reference }
+          value = value.split('Patient/').last
+          match_found = values_found.any? { |reference| [value, 'Patient/' + value, "#{@instance.url}/Patient/#{value}"].include? reference }
           assert match_found, "patient in CarePlan/#{resource.id} (#{values_found}) does not match patient requested (#{value})"
 
         when 'status'
@@ -185,6 +186,26 @@ module Inferno
             token_with_system_search_params = search_params.merge('category': value_with_system)
             reply = get_resource_by_params(versioned_resource_class('CarePlan'), token_with_system_search_params)
             validate_search_reply(versioned_resource_class('CarePlan'), reply, token_with_system_search_params)
+
+            search_params_with_type = search_params.merge('patient': "Patient/#{patient}")
+            reply = get_resource_by_params(versioned_resource_class('CarePlan'), search_params_with_type)
+
+            reply = perform_search_with_status(reply, search_params) if reply.code == 400
+
+            assert_response_ok(reply)
+            assert_bundle_response(reply)
+            search_with_type = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
+            assert search_with_type.length == resources_returned.length, 'Expected search by Patient/ID to have the same results as search by ID'
+
+            search_params_with_url = search_params.merge('patient': "#{@instance.url}/Patient/#{patient}")
+            reply = get_resource_by_params(versioned_resource_class('CarePlan'), search_params_with_url)
+
+            reply = perform_search_with_status(reply, search_params) if reply.code == 400
+
+            assert_response_ok(reply)
+            assert_bundle_response(reply)
+            search_with_url = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
+            assert search_with_url.length == resources_returned.length, 'Expected search by url to have the same results as search by ID'
 
             break
           end

--- a/lib/modules/uscore_v3.1.0/us_core_careteam_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_careteam_sequence.rb
@@ -171,14 +171,6 @@ module Inferno
             search_with_type = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
             assert search_with_type.length == resources_returned.length, 'Expected search by Patient/ID to have the same results as search by ID'
 
-            search_params_with_url = search_params.merge('patient': "#{@instance.url}/Patient/#{patient}")
-            reply = get_resource_by_params(versioned_resource_class('CareTeam'), search_params_with_url)
-
-            assert_response_ok(reply)
-            assert_bundle_response(reply)
-            search_with_url = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
-            assert search_with_url.length == resources_returned.length, 'Expected search by url to have the same results as search by ID'
-
             break if values_found == 2
           end
         end

--- a/lib/modules/uscore_v3.1.0/us_core_careteam_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_careteam_sequence.rb
@@ -71,7 +71,8 @@ module Inferno
 
         when 'patient'
           values_found = resolve_path(resource, 'subject.reference')
-          match_found = values_found.any? { |reference| [value, 'Patient/' + value].include? reference }
+          value = value.split('Patient/').last
+          match_found = values_found.any? { |reference| [value, 'Patient/' + value, "#{@instance.url}/Patient/#{value}"].include? reference }
           assert match_found, "patient in CareTeam/#{resource.id} (#{values_found}) does not match patient requested (#{value})"
 
         when 'status'
@@ -161,6 +162,22 @@ module Inferno
             save_resource_references(versioned_resource_class('CareTeam'), @care_team_ary[patient])
             save_delayed_sequence_references(resources_returned, USCore310CareteamSequenceDefinitions::DELAYED_REFERENCES)
             validate_reply_entries(resources_returned, search_params)
+
+            search_params_with_type = search_params.merge('patient': "Patient/#{patient}")
+            reply = get_resource_by_params(versioned_resource_class('CareTeam'), search_params_with_type)
+
+            assert_response_ok(reply)
+            assert_bundle_response(reply)
+            search_with_type = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
+            assert search_with_type.length == resources_returned.length, 'Expected search by Patient/ID to have the same results as search by ID'
+
+            search_params_with_url = search_params.merge('patient': "#{@instance.url}/Patient/#{patient}")
+            reply = get_resource_by_params(versioned_resource_class('CareTeam'), search_params_with_url)
+
+            assert_response_ok(reply)
+            assert_bundle_response(reply)
+            search_with_url = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
+            assert search_with_url.length == resources_returned.length, 'Expected search by url to have the same results as search by ID'
 
             break if values_found == 2
           end

--- a/lib/modules/uscore_v3.1.0/us_core_condition_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_condition_sequence.rb
@@ -209,13 +209,6 @@ module Inferno
           assert_bundle_response(reply)
           search_with_type = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
           assert search_with_type.length == @condition_ary[patient].length, 'Expected search by Patient/ID to have the same results as search by ID'
-
-          search_params = search_params.merge('patient': "#{@instance.url}/Patient/#{patient}")
-          reply = get_resource_by_params(versioned_resource_class('Condition'), search_params)
-          assert_response_ok(reply)
-          assert_bundle_response(reply)
-          search_with_url = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
-          assert search_with_url.length == @condition_ary[patient].length, 'Expected search by url to have the same results as search by ID'
         end
 
         skip_if_not_found(resource_type: 'Condition', delayed: false)

--- a/lib/modules/uscore_v3.1.0/us_core_diagnosticreport_lab_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_diagnosticreport_lab_sequence.rb
@@ -80,7 +80,8 @@ module Inferno
 
         when 'patient'
           values_found = resolve_path(resource, 'subject.reference')
-          match_found = values_found.any? { |reference| [value, 'Patient/' + value].include? reference }
+          value = value.split('Patient/').last
+          match_found = values_found.any? { |reference| [value, 'Patient/' + value, "#{@instance.url}/Patient/#{value}"].include? reference }
           assert match_found, "patient in DiagnosticReport/#{resource.id} (#{values_found}) does not match patient requested (#{value})"
 
         when 'category'
@@ -201,6 +202,26 @@ module Inferno
             token_with_system_search_params = search_params.merge('category': value_with_system)
             reply = get_resource_by_params(versioned_resource_class('DiagnosticReport'), token_with_system_search_params)
             validate_search_reply(versioned_resource_class('DiagnosticReport'), reply, token_with_system_search_params)
+
+            search_params_with_type = search_params.merge('patient': "Patient/#{patient}")
+            reply = get_resource_by_params(versioned_resource_class('DiagnosticReport'), search_params_with_type)
+
+            reply = perform_search_with_status(reply, search_params) if reply.code == 400
+
+            assert_response_ok(reply)
+            assert_bundle_response(reply)
+            search_with_type = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
+            assert search_with_type.length == resources_returned.length, 'Expected search by Patient/ID to have the same results as search by ID'
+
+            search_params_with_url = search_params.merge('patient': "#{@instance.url}/Patient/#{patient}")
+            reply = get_resource_by_params(versioned_resource_class('DiagnosticReport'), search_params_with_url)
+
+            reply = perform_search_with_status(reply, search_params) if reply.code == 400
+
+            assert_response_ok(reply)
+            assert_bundle_response(reply)
+            search_with_url = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
+            assert search_with_url.length == resources_returned.length, 'Expected search by url to have the same results as search by ID'
 
             break
           end

--- a/lib/modules/uscore_v3.1.0/us_core_diagnosticreport_lab_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_diagnosticreport_lab_sequence.rb
@@ -213,16 +213,6 @@ module Inferno
             search_with_type = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
             assert search_with_type.length == resources_returned.length, 'Expected search by Patient/ID to have the same results as search by ID'
 
-            search_params_with_url = search_params.merge('patient': "#{@instance.url}/Patient/#{patient}")
-            reply = get_resource_by_params(versioned_resource_class('DiagnosticReport'), search_params_with_url)
-
-            reply = perform_search_with_status(reply, search_params) if reply.code == 400
-
-            assert_response_ok(reply)
-            assert_bundle_response(reply)
-            search_with_url = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
-            assert search_with_url.length == resources_returned.length, 'Expected search by url to have the same results as search by ID'
-
             break
           end
         end

--- a/lib/modules/uscore_v3.1.0/us_core_diagnosticreport_note_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_diagnosticreport_note_sequence.rb
@@ -80,7 +80,8 @@ module Inferno
 
         when 'patient'
           values_found = resolve_path(resource, 'subject.reference')
-          match_found = values_found.any? { |reference| [value, 'Patient/' + value].include? reference }
+          value = value.split('Patient/').last
+          match_found = values_found.any? { |reference| [value, 'Patient/' + value, "#{@instance.url}/Patient/#{value}"].include? reference }
           assert match_found, "patient in DiagnosticReport/#{resource.id} (#{values_found}) does not match patient requested (#{value})"
 
         when 'category'
@@ -201,6 +202,26 @@ module Inferno
             token_with_system_search_params = search_params.merge('category': value_with_system)
             reply = get_resource_by_params(versioned_resource_class('DiagnosticReport'), token_with_system_search_params)
             validate_search_reply(versioned_resource_class('DiagnosticReport'), reply, token_with_system_search_params)
+
+            search_params_with_type = search_params.merge('patient': "Patient/#{patient}")
+            reply = get_resource_by_params(versioned_resource_class('DiagnosticReport'), search_params_with_type)
+
+            reply = perform_search_with_status(reply, search_params) if reply.code == 400
+
+            assert_response_ok(reply)
+            assert_bundle_response(reply)
+            search_with_type = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
+            assert search_with_type.length == resources_returned.length, 'Expected search by Patient/ID to have the same results as search by ID'
+
+            search_params_with_url = search_params.merge('patient': "#{@instance.url}/Patient/#{patient}")
+            reply = get_resource_by_params(versioned_resource_class('DiagnosticReport'), search_params_with_url)
+
+            reply = perform_search_with_status(reply, search_params) if reply.code == 400
+
+            assert_response_ok(reply)
+            assert_bundle_response(reply)
+            search_with_url = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
+            assert search_with_url.length == resources_returned.length, 'Expected search by url to have the same results as search by ID'
 
             break
           end

--- a/lib/modules/uscore_v3.1.0/us_core_diagnosticreport_note_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_diagnosticreport_note_sequence.rb
@@ -213,16 +213,6 @@ module Inferno
             search_with_type = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
             assert search_with_type.length == resources_returned.length, 'Expected search by Patient/ID to have the same results as search by ID'
 
-            search_params_with_url = search_params.merge('patient': "#{@instance.url}/Patient/#{patient}")
-            reply = get_resource_by_params(versioned_resource_class('DiagnosticReport'), search_params_with_url)
-
-            reply = perform_search_with_status(reply, search_params) if reply.code == 400
-
-            assert_response_ok(reply)
-            assert_bundle_response(reply)
-            search_with_url = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
-            assert search_with_url.length == resources_returned.length, 'Expected search by url to have the same results as search by ID'
-
             break
           end
         end

--- a/lib/modules/uscore_v3.1.0/us_core_documentreference_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_documentreference_sequence.rb
@@ -87,7 +87,8 @@ module Inferno
 
         when 'patient'
           values_found = resolve_path(resource, 'subject.reference')
-          match_found = values_found.any? { |reference| [value, 'Patient/' + value].include? reference }
+          value = value.split('Patient/').last
+          match_found = values_found.any? { |reference| [value, 'Patient/' + value, "#{@instance.url}/Patient/#{value}"].include? reference }
           assert match_found, "patient in DocumentReference/#{resource.id} (#{values_found}) does not match patient requested (#{value})"
 
         when 'category'
@@ -210,6 +211,20 @@ module Inferno
           save_resource_references(versioned_resource_class('DocumentReference'), @document_reference_ary[patient])
           save_delayed_sequence_references(@document_reference_ary[patient], USCore310DocumentreferenceSequenceDefinitions::DELAYED_REFERENCES)
           validate_reply_entries(@document_reference_ary[patient], search_params)
+
+          search_params = search_params.merge('patient': "Patient/#{patient}")
+          reply = get_resource_by_params(versioned_resource_class('DocumentReference'), search_params)
+          assert_response_ok(reply)
+          assert_bundle_response(reply)
+          search_with_type = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
+          assert search_with_type.length == @document_reference_ary[patient].length, 'Expected search by Patient/ID to have the same results as search by ID'
+
+          search_params = search_params.merge('patient': "#{@instance.url}/Patient/#{patient}")
+          reply = get_resource_by_params(versioned_resource_class('DocumentReference'), search_params)
+          assert_response_ok(reply)
+          assert_bundle_response(reply)
+          search_with_url = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
+          assert search_with_url.length == @document_reference_ary[patient].length, 'Expected search by url to have the same results as search by ID'
         end
 
         skip_if_not_found(resource_type: 'DocumentReference', delayed: false)

--- a/lib/modules/uscore_v3.1.0/us_core_documentreference_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_documentreference_sequence.rb
@@ -218,13 +218,6 @@ module Inferno
           assert_bundle_response(reply)
           search_with_type = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
           assert search_with_type.length == @document_reference_ary[patient].length, 'Expected search by Patient/ID to have the same results as search by ID'
-
-          search_params = search_params.merge('patient': "#{@instance.url}/Patient/#{patient}")
-          reply = get_resource_by_params(versioned_resource_class('DocumentReference'), search_params)
-          assert_response_ok(reply)
-          assert_bundle_response(reply)
-          search_with_url = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
-          assert search_with_url.length == @document_reference_ary[patient].length, 'Expected search by url to have the same results as search by ID'
         end
 
         skip_if_not_found(resource_type: 'DocumentReference', delayed: false)

--- a/lib/modules/uscore_v3.1.0/us_core_encounter_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_encounter_sequence.rb
@@ -82,7 +82,8 @@ module Inferno
 
         when 'patient'
           values_found = resolve_path(resource, 'subject.reference')
-          match_found = values_found.any? { |reference| [value, 'Patient/' + value].include? reference }
+          value = value.split('Patient/').last
+          match_found = values_found.any? { |reference| [value, 'Patient/' + value, "#{@instance.url}/Patient/#{value}"].include? reference }
           assert match_found, "patient in Encounter/#{resource.id} (#{values_found}) does not match patient requested (#{value})"
 
         when 'status'

--- a/lib/modules/uscore_v3.1.0/us_core_goal_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_goal_sequence.rb
@@ -176,13 +176,6 @@ module Inferno
           assert_bundle_response(reply)
           search_with_type = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
           assert search_with_type.length == @goal_ary[patient].length, 'Expected search by Patient/ID to have the same results as search by ID'
-
-          search_params = search_params.merge('patient': "#{@instance.url}/Patient/#{patient}")
-          reply = get_resource_by_params(versioned_resource_class('Goal'), search_params)
-          assert_response_ok(reply)
-          assert_bundle_response(reply)
-          search_with_url = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
-          assert search_with_url.length == @goal_ary[patient].length, 'Expected search by url to have the same results as search by ID'
         end
 
         skip_if_not_found(resource_type: 'Goal', delayed: false)

--- a/lib/modules/uscore_v3.1.0/us_core_goal_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_goal_sequence.rb
@@ -77,7 +77,8 @@ module Inferno
 
         when 'patient'
           values_found = resolve_path(resource, 'subject.reference')
-          match_found = values_found.any? { |reference| [value, 'Patient/' + value].include? reference }
+          value = value.split('Patient/').last
+          match_found = values_found.any? { |reference| [value, 'Patient/' + value, "#{@instance.url}/Patient/#{value}"].include? reference }
           assert match_found, "patient in Goal/#{resource.id} (#{values_found}) does not match patient requested (#{value})"
 
         when 'target-date'
@@ -168,6 +169,20 @@ module Inferno
           save_resource_references(versioned_resource_class('Goal'), @goal_ary[patient])
           save_delayed_sequence_references(@goal_ary[patient], USCore310GoalSequenceDefinitions::DELAYED_REFERENCES)
           validate_reply_entries(@goal_ary[patient], search_params)
+
+          search_params = search_params.merge('patient': "Patient/#{patient}")
+          reply = get_resource_by_params(versioned_resource_class('Goal'), search_params)
+          assert_response_ok(reply)
+          assert_bundle_response(reply)
+          search_with_type = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
+          assert search_with_type.length == @goal_ary[patient].length, 'Expected search by Patient/ID to have the same results as search by ID'
+
+          search_params = search_params.merge('patient': "#{@instance.url}/Patient/#{patient}")
+          reply = get_resource_by_params(versioned_resource_class('Goal'), search_params)
+          assert_response_ok(reply)
+          assert_bundle_response(reply)
+          search_with_url = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
+          assert search_with_url.length == @goal_ary[patient].length, 'Expected search by url to have the same results as search by ID'
         end
 
         skip_if_not_found(resource_type: 'Goal', delayed: false)

--- a/lib/modules/uscore_v3.1.0/us_core_immunization_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_immunization_sequence.rb
@@ -176,13 +176,6 @@ module Inferno
           assert_bundle_response(reply)
           search_with_type = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
           assert search_with_type.length == @immunization_ary[patient].length, 'Expected search by Patient/ID to have the same results as search by ID'
-
-          search_params = search_params.merge('patient': "#{@instance.url}/Patient/#{patient}")
-          reply = get_resource_by_params(versioned_resource_class('Immunization'), search_params)
-          assert_response_ok(reply)
-          assert_bundle_response(reply)
-          search_with_url = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
-          assert search_with_url.length == @immunization_ary[patient].length, 'Expected search by url to have the same results as search by ID'
         end
 
         skip_if_not_found(resource_type: 'Immunization', delayed: false)

--- a/lib/modules/uscore_v3.1.0/us_core_immunization_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_immunization_sequence.rb
@@ -71,7 +71,8 @@ module Inferno
 
         when 'patient'
           values_found = resolve_path(resource, 'patient.reference')
-          match_found = values_found.any? { |reference| [value, 'Patient/' + value].include? reference }
+          value = value.split('Patient/').last
+          match_found = values_found.any? { |reference| [value, 'Patient/' + value, "#{@instance.url}/Patient/#{value}"].include? reference }
           assert match_found, "patient in Immunization/#{resource.id} (#{values_found}) does not match patient requested (#{value})"
 
         when 'status'
@@ -168,6 +169,20 @@ module Inferno
           save_resource_references(versioned_resource_class('Immunization'), @immunization_ary[patient])
           save_delayed_sequence_references(@immunization_ary[patient], USCore310ImmunizationSequenceDefinitions::DELAYED_REFERENCES)
           validate_reply_entries(@immunization_ary[patient], search_params)
+
+          search_params = search_params.merge('patient': "Patient/#{patient}")
+          reply = get_resource_by_params(versioned_resource_class('Immunization'), search_params)
+          assert_response_ok(reply)
+          assert_bundle_response(reply)
+          search_with_type = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
+          assert search_with_type.length == @immunization_ary[patient].length, 'Expected search by Patient/ID to have the same results as search by ID'
+
+          search_params = search_params.merge('patient': "#{@instance.url}/Patient/#{patient}")
+          reply = get_resource_by_params(versioned_resource_class('Immunization'), search_params)
+          assert_response_ok(reply)
+          assert_bundle_response(reply)
+          search_with_url = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
+          assert search_with_url.length == @immunization_ary[patient].length, 'Expected search by url to have the same results as search by ID'
         end
 
         skip_if_not_found(resource_type: 'Immunization', delayed: false)

--- a/lib/modules/uscore_v3.1.0/us_core_implantable_device_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_implantable_device_sequence.rb
@@ -157,13 +157,6 @@ module Inferno
           assert_bundle_response(reply)
           search_with_type = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
           assert search_with_type.length == @device_ary[patient].length, 'Expected search by Patient/ID to have the same results as search by ID'
-
-          search_params = search_params.merge('patient': "#{@instance.url}/Patient/#{patient}")
-          reply = get_resource_by_params(versioned_resource_class('Device'), search_params)
-          assert_response_ok(reply)
-          assert_bundle_response(reply)
-          search_with_url = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
-          assert search_with_url.length == @device_ary[patient].length, 'Expected search by url to have the same results as search by ID'
         end
 
         skip_if_not_found(resource_type: 'Device', delayed: false)

--- a/lib/modules/uscore_v3.1.0/us_core_implantable_device_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_implantable_device_sequence.rb
@@ -74,7 +74,8 @@ module Inferno
 
         when 'patient'
           values_found = resolve_path(resource, 'patient.reference')
-          match_found = values_found.any? { |reference| [value, 'Patient/' + value].include? reference }
+          value = value.split('Patient/').last
+          match_found = values_found.any? { |reference| [value, 'Patient/' + value, "#{@instance.url}/Patient/#{value}"].include? reference }
           assert match_found, "patient in Device/#{resource.id} (#{values_found}) does not match patient requested (#{value})"
 
         when 'type'
@@ -149,6 +150,20 @@ module Inferno
           save_resource_references(versioned_resource_class('Device'), @device_ary[patient])
           save_delayed_sequence_references(@device_ary[patient], USCore310ImplantableDeviceSequenceDefinitions::DELAYED_REFERENCES)
           validate_reply_entries(@device_ary[patient], search_params)
+
+          search_params = search_params.merge('patient': "Patient/#{patient}")
+          reply = get_resource_by_params(versioned_resource_class('Device'), search_params)
+          assert_response_ok(reply)
+          assert_bundle_response(reply)
+          search_with_type = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
+          assert search_with_type.length == @device_ary[patient].length, 'Expected search by Patient/ID to have the same results as search by ID'
+
+          search_params = search_params.merge('patient': "#{@instance.url}/Patient/#{patient}")
+          reply = get_resource_by_params(versioned_resource_class('Device'), search_params)
+          assert_response_ok(reply)
+          assert_bundle_response(reply)
+          search_with_url = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
+          assert search_with_url.length == @device_ary[patient].length, 'Expected search by url to have the same results as search by ID'
         end
 
         skip_if_not_found(resource_type: 'Device', delayed: false)

--- a/lib/modules/uscore_v3.1.0/us_core_medicationrequest_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_medicationrequest_sequence.rb
@@ -227,16 +227,6 @@ module Inferno
             search_with_type = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
             assert search_with_type.length == resources_returned.length, 'Expected search by Patient/ID to have the same results as search by ID'
 
-            search_params_with_url = search_params.merge('patient': "#{@instance.url}/Patient/#{patient}")
-            reply = get_resource_by_params(versioned_resource_class('MedicationRequest'), search_params_with_url)
-
-            reply = perform_search_with_status(reply, search_params) if reply.code == 400
-
-            assert_response_ok(reply)
-            assert_bundle_response(reply)
-            search_with_url = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
-            assert search_with_url.length == resources_returned.length, 'Expected search by url to have the same results as search by ID'
-
             test_medication_inclusion(@medication_request_ary[patient], search_params)
             break
           end

--- a/lib/modules/uscore_v3.1.0/us_core_medicationrequest_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_medicationrequest_sequence.rb
@@ -84,7 +84,8 @@ module Inferno
 
         when 'patient'
           values_found = resolve_path(resource, 'subject.reference')
-          match_found = values_found.any? { |reference| [value, 'Patient/' + value].include? reference }
+          value = value.split('Patient/').last
+          match_found = values_found.any? { |reference| [value, 'Patient/' + value, "#{@instance.url}/Patient/#{value}"].include? reference }
           assert match_found, "patient in MedicationRequest/#{resource.id} (#{values_found}) does not match patient requested (#{value})"
 
         when 'encounter'
@@ -215,6 +216,26 @@ module Inferno
             save_resource_references(versioned_resource_class('MedicationRequest'), @medication_request_ary[patient])
             save_delayed_sequence_references(resources_returned, USCore310MedicationrequestSequenceDefinitions::DELAYED_REFERENCES)
             validate_reply_entries(resources_returned, search_params)
+
+            search_params_with_type = search_params.merge('patient': "Patient/#{patient}")
+            reply = get_resource_by_params(versioned_resource_class('MedicationRequest'), search_params_with_type)
+
+            reply = perform_search_with_status(reply, search_params) if reply.code == 400
+
+            assert_response_ok(reply)
+            assert_bundle_response(reply)
+            search_with_type = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
+            assert search_with_type.length == resources_returned.length, 'Expected search by Patient/ID to have the same results as search by ID'
+
+            search_params_with_url = search_params.merge('patient': "#{@instance.url}/Patient/#{patient}")
+            reply = get_resource_by_params(versioned_resource_class('MedicationRequest'), search_params_with_url)
+
+            reply = perform_search_with_status(reply, search_params) if reply.code == 400
+
+            assert_response_ok(reply)
+            assert_bundle_response(reply)
+            search_with_url = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
+            assert search_with_url.length == resources_returned.length, 'Expected search by url to have the same results as search by ID'
 
             test_medication_inclusion(@medication_request_ary[patient], search_params)
             break

--- a/lib/modules/uscore_v3.1.0/us_core_observation_lab_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_observation_lab_sequence.rb
@@ -212,16 +212,6 @@ module Inferno
             search_with_type = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
             assert search_with_type.length == resources_returned.length, 'Expected search by Patient/ID to have the same results as search by ID'
 
-            search_params_with_url = search_params.merge('patient': "#{@instance.url}/Patient/#{patient}")
-            reply = get_resource_by_params(versioned_resource_class('Observation'), search_params_with_url)
-
-            reply = perform_search_with_status(reply, search_params) if reply.code == 400
-
-            assert_response_ok(reply)
-            assert_bundle_response(reply)
-            search_with_url = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
-            assert search_with_url.length == resources_returned.length, 'Expected search by url to have the same results as search by ID'
-
             break
           end
         end

--- a/lib/modules/uscore_v3.1.0/us_core_procedure_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_procedure_sequence.rb
@@ -190,13 +190,6 @@ module Inferno
           assert_bundle_response(reply)
           search_with_type = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
           assert search_with_type.length == @procedure_ary[patient].length, 'Expected search by Patient/ID to have the same results as search by ID'
-
-          search_params = search_params.merge('patient': "#{@instance.url}/Patient/#{patient}")
-          reply = get_resource_by_params(versioned_resource_class('Procedure'), search_params)
-          assert_response_ok(reply)
-          assert_bundle_response(reply)
-          search_with_url = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
-          assert search_with_url.length == @procedure_ary[patient].length, 'Expected search by url to have the same results as search by ID'
         end
 
         skip_if_not_found(resource_type: 'Procedure', delayed: false)

--- a/lib/modules/uscore_v3.1.0/us_core_procedure_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_procedure_sequence.rb
@@ -78,7 +78,8 @@ module Inferno
 
         when 'patient'
           values_found = resolve_path(resource, 'subject.reference')
-          match_found = values_found.any? { |reference| [value, 'Patient/' + value].include? reference }
+          value = value.split('Patient/').last
+          match_found = values_found.any? { |reference| [value, 'Patient/' + value, "#{@instance.url}/Patient/#{value}"].include? reference }
           assert match_found, "patient in Procedure/#{resource.id} (#{values_found}) does not match patient requested (#{value})"
 
         when 'date'
@@ -182,6 +183,20 @@ module Inferno
           save_resource_references(versioned_resource_class('Procedure'), @procedure_ary[patient])
           save_delayed_sequence_references(@procedure_ary[patient], USCore310ProcedureSequenceDefinitions::DELAYED_REFERENCES)
           validate_reply_entries(@procedure_ary[patient], search_params)
+
+          search_params = search_params.merge('patient': "Patient/#{patient}")
+          reply = get_resource_by_params(versioned_resource_class('Procedure'), search_params)
+          assert_response_ok(reply)
+          assert_bundle_response(reply)
+          search_with_type = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
+          assert search_with_type.length == @procedure_ary[patient].length, 'Expected search by Patient/ID to have the same results as search by ID'
+
+          search_params = search_params.merge('patient': "#{@instance.url}/Patient/#{patient}")
+          reply = get_resource_by_params(versioned_resource_class('Procedure'), search_params)
+          assert_response_ok(reply)
+          assert_bundle_response(reply)
+          search_with_url = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
+          assert search_with_url.length == @procedure_ary[patient].length, 'Expected search by url to have the same results as search by ID'
         end
 
         skip_if_not_found(resource_type: 'Procedure', delayed: false)

--- a/lib/modules/uscore_v3.1.0/us_core_pulse_oximetry_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_pulse_oximetry_sequence.rb
@@ -212,16 +212,6 @@ module Inferno
             search_with_type = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
             assert search_with_type.length == resources_returned.length, 'Expected search by Patient/ID to have the same results as search by ID'
 
-            search_params_with_url = search_params.merge('patient': "#{@instance.url}/Patient/#{patient}")
-            reply = get_resource_by_params(versioned_resource_class('Observation'), search_params_with_url)
-
-            reply = perform_search_with_status(reply, search_params) if reply.code == 400
-
-            assert_response_ok(reply)
-            assert_bundle_response(reply)
-            search_with_url = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
-            assert search_with_url.length == resources_returned.length, 'Expected search by url to have the same results as search by ID'
-
             break
           end
         end

--- a/lib/modules/uscore_v3.1.0/us_core_pulse_oximetry_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_pulse_oximetry_sequence.rb
@@ -110,7 +110,8 @@ module Inferno
 
         when 'patient'
           values_found = resolve_path(resource, 'subject.reference')
-          match_found = values_found.any? { |reference| [value, 'Patient/' + value].include? reference }
+          value = value.split('Patient/').last
+          match_found = values_found.any? { |reference| [value, 'Patient/' + value, "#{@instance.url}/Patient/#{value}"].include? reference }
           assert match_found, "patient in Observation/#{resource.id} (#{values_found}) does not match patient requested (#{value})"
 
         end
@@ -200,6 +201,26 @@ module Inferno
             token_with_system_search_params = search_params.merge('code': value_with_system)
             reply = get_resource_by_params(versioned_resource_class('Observation'), token_with_system_search_params)
             validate_search_reply(versioned_resource_class('Observation'), reply, token_with_system_search_params)
+
+            search_params_with_type = search_params.merge('patient': "Patient/#{patient}")
+            reply = get_resource_by_params(versioned_resource_class('Observation'), search_params_with_type)
+
+            reply = perform_search_with_status(reply, search_params) if reply.code == 400
+
+            assert_response_ok(reply)
+            assert_bundle_response(reply)
+            search_with_type = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
+            assert search_with_type.length == resources_returned.length, 'Expected search by Patient/ID to have the same results as search by ID'
+
+            search_params_with_url = search_params.merge('patient': "#{@instance.url}/Patient/#{patient}")
+            reply = get_resource_by_params(versioned_resource_class('Observation'), search_params_with_url)
+
+            reply = perform_search_with_status(reply, search_params) if reply.code == 400
+
+            assert_response_ok(reply)
+            assert_bundle_response(reply)
+            search_with_url = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
+            assert search_with_url.length == resources_returned.length, 'Expected search by url to have the same results as search by ID'
 
             break
           end

--- a/lib/modules/uscore_v3.1.0/us_core_smokingstatus_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_smokingstatus_sequence.rb
@@ -216,16 +216,6 @@ module Inferno
             search_with_type = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
             assert search_with_type.length == resources_returned.length, 'Expected search by Patient/ID to have the same results as search by ID'
 
-            search_params_with_url = search_params.merge('patient': "#{@instance.url}/Patient/#{patient}")
-            reply = get_resource_by_params(versioned_resource_class('Observation'), search_params_with_url)
-
-            reply = perform_search_with_status(reply, search_params) if reply.code == 400
-
-            assert_response_ok(reply)
-            assert_bundle_response(reply)
-            search_with_url = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
-            assert search_with_url.length == resources_returned.length, 'Expected search by url to have the same results as search by ID'
-
             break
           end
         end

--- a/lib/modules/uscore_v3.1.0/us_core_smokingstatus_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_smokingstatus_sequence.rb
@@ -114,7 +114,8 @@ module Inferno
 
         when 'patient'
           values_found = resolve_path(resource, 'subject.reference')
-          match_found = values_found.any? { |reference| [value, 'Patient/' + value].include? reference }
+          value = value.split('Patient/').last
+          match_found = values_found.any? { |reference| [value, 'Patient/' + value, "#{@instance.url}/Patient/#{value}"].include? reference }
           assert match_found, "patient in Observation/#{resource.id} (#{values_found}) does not match patient requested (#{value})"
 
         end
@@ -204,6 +205,26 @@ module Inferno
             token_with_system_search_params = search_params.merge('code': value_with_system)
             reply = get_resource_by_params(versioned_resource_class('Observation'), token_with_system_search_params)
             validate_search_reply(versioned_resource_class('Observation'), reply, token_with_system_search_params)
+
+            search_params_with_type = search_params.merge('patient': "Patient/#{patient}")
+            reply = get_resource_by_params(versioned_resource_class('Observation'), search_params_with_type)
+
+            reply = perform_search_with_status(reply, search_params) if reply.code == 400
+
+            assert_response_ok(reply)
+            assert_bundle_response(reply)
+            search_with_type = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
+            assert search_with_type.length == resources_returned.length, 'Expected search by Patient/ID to have the same results as search by ID'
+
+            search_params_with_url = search_params.merge('patient': "#{@instance.url}/Patient/#{patient}")
+            reply = get_resource_by_params(versioned_resource_class('Observation'), search_params_with_url)
+
+            reply = perform_search_with_status(reply, search_params) if reply.code == 400
+
+            assert_response_ok(reply)
+            assert_bundle_response(reply)
+            search_with_url = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
+            assert search_with_url.length == resources_returned.length, 'Expected search by url to have the same results as search by ID'
 
             break
           end


### PR DESCRIPTION
This PR adds search by Patient/ID and url for each first search by patient. 

**Submitter:**
- [X] This pull request describes why these changes were made
- [X] Internal ticket for this PR: https://oncprojectracking.healthit.gov/support/browse/FI-849
- [X] Internal ticket links to this PR
- [X] Internal ticket is properly labeled (Community/Program)
- [X] Internal ticket has a justification for its Community/Program label
- [X] Code diff has been reviewed for extraneous/missing code
- [] Tests are included and test edge cases
- [ ] Tests/code quality metrics have been run locally and pass


**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
