### PR TITLE
FI-830: Check available RAM for terminology processing

### DIFF
--- a/bin/run_terminology.sh
+++ b/bin/run_terminology.sh
@@ -1,11 +1,14 @@
 #!/bin/bash
 set -e
 
-available_ram_kb=$(cat /proc/meminfo | grep MemTotal | sed -r 's/MemTotal:\s+([0-9]+)\skB/\1/')
-(( available_ram_gb=$available_ram_kb / 1000 / 1000 ))
-if (( $available_ram_gb < 10 )); then
+# Check available memory when running in docker
+if [ -f /.dockerenv ]; then
+  available_ram_kb=$(cat /proc/meminfo | grep MemTotal | sed -r 's/MemTotal:\s+([0-9]+)\skB/\1/')
+  (( available_ram_gb=$available_ram_kb / 1000 / 1000 ))
+  if (( $available_ram_gb < 10 )); then
     echo "10 GB of RAM must be available in order to process the terminology, but only $available_ram_gb GB are available"
     exit 1
+  fi
 fi
 
 temp_folder="tmp/terminology"

--- a/bin/run_terminology.sh
+++ b/bin/run_terminology.sh
@@ -1,6 +1,13 @@
 #!/bin/bash
 set -e
 
+available_ram_kb=$(cat /proc/meminfo | grep MemTotal | sed -r 's/MemTotal:\s+([0-9]+)\skB/\1/')
+(( available_ram_gb=$available_ram_kb / 1000 / 1000 ))
+if (( $available_ram_gb < 10 )); then
+    echo "10 GB of RAM must be available in order to process the terminology, but only $available_ram_gb GB are available"
+    exit 1
+fi
+
 temp_folder="tmp/terminology"
 
 if [[ ! -f "$temp_folder/umls.zip" ]]; then

--- a/terminology_compose.yml
+++ b/terminology_compose.yml
@@ -1,6 +1,6 @@
 version: '3.2'
 services:
-  ruby_server:
+  terminology_builder:
     build:
       context: .
       dockerfile: terminology_dockerfile


### PR DESCRIPTION
This branch updates the terminology processing script to ensure that 10 GB of ram are available before processing.

With < 10 GB:
```
ᐅ docker-compose -f terminology_compose.yml up
Recreating inferno-program_terminology_builder_1 ... done
Attaching to inferno-program_terminology_builder_1
terminology_builder_1  | 10 GB of RAM must be available in order to process the terminology, but only 8 GB is available
inferno-program_terminology_builder_1 exited with code 1
```

With 10 GB:
```
ᐅ docker-compose -f terminology_compose.yml up
Starting inferno-program_terminology_builder_1 ... done
Attaching to inferno-program_terminology_builder_1
terminology_builder_1  | UMLS Username environment variable is empty
inferno-program_terminology_builder_1 exited with code 1
```

**Submitter:**
- [x] This pull request describes why these changes were made
- [x] Internal ticket links to this PR
- [x] Internal ticket is properly labeled (Community/Program)
- [x] Internal ticket has a justification for its Community/Program label
- [x] Code diff has been reviewed for extraneous/missing code
- n/a Tests are included and test edge cases
- [x] Tests/code quality metrics have been run locally and pass


**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
