### PR TITLE
Update the terminology Docker instructions in the readme to include the use of a .env file, and add that file to the .ignores

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -14,6 +14,7 @@ tmp/*
 .vscode/*
 sequence_coverage.csv
 fhir-pgdata/
+.env
 
 # Auto-generated terminology files
 MR*.pipe
@@ -23,3 +24,9 @@ resources/terminology/validators
 
 # Don't need .git in the container
 .git
+.gitattributes
+.gitignore
+.github/*
+
+# Don't need documentation in the container
+README.md

--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ tmp/*
 resources/terminology/*
 sequence_coverage.csv
 fhir-pgdata/
+.env
 
 # Auto-generated terminology files
 MR*.pipe

--- a/README.md
+++ b/README.md
@@ -105,6 +105,8 @@ Prerequisites:
 * A UMLS account
 * A working Docker toolchain, which has been assigned at least 10GB of RAM (The Metathesaurus step requires 8GB of RAM for the Java process)
   * Note: the Docker terminology process will not run unless Docker has access to at least 10GB of RAM.
+* At least 33 GB of free disk space on the Host OS, for downloading/unzipping/processing the terminology files.
+  * Note: this space needs to be allocated on the host because Docker maps these files through to the Host, to allow for building in the dedicated terminology container.
 * A copy of the Inferno repository, which contains the required Docker and Ruby files
 
 You can prebuild the terminology docker container by running the following command:

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ self-contained environment.
 Prerequisites:
 * A UMLS account
 * A working Docker toolchain, which has been assigned at least 10GB of RAM (The Metathesaurus step requires 8GB of RAM for the Java process)
-  * Note: the Docker terminology process will not run unless Docker has access to at least this much RAM.
+  * Note: the Docker terminology process will not run unless Docker has access to at least this 10GB of RAM.
 * A copy of the Inferno repository, which contains the required Docker and Ruby files
 
 You can prebuild the terminology docker container by running the following command:

--- a/README.md
+++ b/README.md
@@ -104,19 +104,26 @@ self-contained environment.
 Prerequisites:
 * A UMLS account
 * A working Docker toolchain, which has been assigned at least 10GB of RAM (The Metathesaurus step requires 8GB of RAM for the Java process)
+  * Note: the Docker terminology process will not run unless Docker has access to at least this much RAM.
 * A copy of the Inferno repository, which contains the required Docker and Ruby files
 
 You can prebuild the terminology docker container by running the following command:
 ```sh
 docker-compose -f terminology_compose.yml build
 ```
-Once the container is built, you can run the terminology creation task by using the following commands, in order:
+Once the container is built, you will have to add your UMLS username and passwords to a file named `.env` at the root of the inferno project. The file should look like this:
 ```sh
-export UMLS_USERNAME=<your UMLS username>
-export UMLS_PASSWORD=<your UMLS password>
+UMLS_USERNAME=<your UMLS username>
+UMLS_PASSWORD=<your UMLS password>
+```
+Once that file exists, you can run the terminology creation task by using the following commands, in order:
+```sh
 docker-compose -f terminology_compose.yml up
 ```
-This will run the terminology creation steps in order, using the UMLS credentials supplied. These tasks may take several hours. If the creation task is cancelled in progress and restarted, it will restart after the last _completed_ step. Intermediate files are saved to `tmp/terminology` in the Inferno repository that the Docker Compose job is run from, and the validators are saved to `resources/terminology/validators/bloom`, where Inferno can use them for validation.
+This will run the terminology creation steps in order, using the UMLS credentials supplied in `.env`. These tasks may take several hours. If the creation task is cancelled in progress and restarted, it will restart after the last _completed_ step. Intermediate files are saved to `tmp/terminology` in the Inferno repository that the Docker Compose job is run from, and the validators are saved to `resources/terminology/validators/bloom`, where Inferno can use them for validation.
+
+#### Cleanup
+Once the terminology building is done, the `.env` file should be deleted to remove the UMLS username and password from the system.
 
 If this Docker-based method does not work based on your architecture, manual setup and creation of the terminology validators is documented [on this wiki page](https://github.com/onc-healthit/inferno/wiki/Installing-Terminology-Validators#building-the-validators-without-docker)
 

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ self-contained environment.
 Prerequisites:
 * A UMLS account
 * A working Docker toolchain, which has been assigned at least 10GB of RAM (The Metathesaurus step requires 8GB of RAM for the Java process)
-  * Note: the Docker terminology process will not run unless Docker has access to at least this 10GB of RAM.
+  * Note: the Docker terminology process will not run unless Docker has access to at least 10GB of RAM.
 * A copy of the Inferno repository, which contains the required Docker and Ruby files
 
 You can prebuild the terminology docker container by running the following command:
@@ -124,6 +124,10 @@ This will run the terminology creation steps in order, using the UMLS credential
 
 #### Cleanup
 Once the terminology building is done, the `.env` file should be deleted to remove the UMLS username and password from the system.
+
+Optionally, the files and folders in `tmp/terminology/` can be deleted after terminology building to free up space, as they are several GB in size. If you intend to re-run the terminology builder, these files can be left to speed up building in the future, since the builder will be able to skip the initial download/preprocessing steps.
+
+#### Manual build instructions
 
 If this Docker-based method does not work based on your architecture, manual setup and creation of the terminology validators is documented [on this wiki page](https://github.com/onc-healthit/inferno/wiki/Installing-Terminology-Validators#building-the-validators-without-docker)
 


### PR DESCRIPTION
The terminology dockerfile instructions were too Linux-specific before (specifying that users should `EXPORT` a couple of environment variables). This PR updates the instructions to specify that those variables should be placed in a file named `.env` at the root of the inferno project. Docker-compose will pick those variables up and inject them into the terminology docker container.

The `.env` file has been added to `.gitignore`, to make sure it doesn't get accidentally committed, and `.dockerignore`, to keep it from getting mapped into any docker containers.

Pull requests into Inferno require the following items to be completed. Submitter and reviewer 
should check the relevant check boxes when the associated item is done. For items that are not 
applicable, note it's not applicable ("N/A") and check the box. For example, external Pull 
Requests do not require ticket links.

**Submitter:**
- [x] This pull request describes why these changes were made
- [x] Internal ticket for this PR:
- [x] Internal ticket links to this PR
- [x] Internal ticket is properly labeled (Community/Program)
- [x] Internal ticket has a justification for its Community/Program label
- [x] Code diff has been reviewed for extraneous/missing code
- [x] Tests are included and test edge cases N/A
- [x] Tests/code quality metrics have been run locally and pass N/A


**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
