### PR TITLE
FI-561: Fix OSD-05 error message formatting

### DIFF
--- a/lib/modules/onc_program/onc_smart_discovery_sequence.rb
+++ b/lib/modules/onc_program/onc_smart_discovery_sequence.rb
@@ -256,8 +256,8 @@ module Inferno
             The #{endpoint[:description]} url is not consistent between the
             well-known configuration and the conformance statement:
 
-            Well-known #{url} url: #{well_known_url}
-            Conformance #{url} url: #{conformance_url}
+            * Well-known #{url} url: #{well_known_url}
+            * Conformance #{url} url: #{conformance_url}
           )
         end
       end


### PR DESCRIPTION
This branch adds bullets to make the error message for OSD-05 more readable (in the examples below the urls are consistent, I just changed the assertion to make the error appear).

Before:
![Screen Shot 2020-06-09 at 3 02 07 PM](https://user-images.githubusercontent.com/15969967/84189229-f14b9200-aa62-11ea-9e83-84aec0fcb259.png)


After:
![Screen Shot 2020-06-09 at 3 04 02 PM](https://user-images.githubusercontent.com/15969967/84189244-f90b3680-aa62-11ea-89b9-938072bad1bb.png)


**Submitter:**
- [x] This pull request describes why these changes were made
- [x] Internal ticket links to this PR
- [x] Internal ticket is properly labeled (Community/Program)
- [x] Internal ticket has a justification for its Community/Program label
- [x] Code diff has been reviewed for extraneous/missing code
- n/a Tests are included and test edge cases
- [x] Tests/code quality metrics have been run locally and pass


**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
