### PR TITLE
Fix ordering of RequestResponses

### DIFF
--- a/lib/app/models/request_response.rb
+++ b/lib/app/models/request_response.rb
@@ -14,7 +14,7 @@ module Inferno
       property :response_body, Text
       property :direction, String
       property :instance_id, String
-      property :sequence, Serial, unique_index: true
+      property :request_index, Serial, unique_index: true
 
       property :timestamp, DateTime, default: proc { DateTime.now }
 

--- a/lib/app/models/request_response.rb
+++ b/lib/app/models/request_response.rb
@@ -14,6 +14,7 @@ module Inferno
       property :response_body, Text
       property :direction, String
       property :instance_id, String
+      property :sequence, Serial, unique_index: true
 
       property :timestamp, DateTime, default: proc { DateTime.now }
 

--- a/lib/app/models/test_result.rb
+++ b/lib/app/models/test_result.rb
@@ -27,7 +27,7 @@ module Inferno
       property :redirect_to_url, String
       property :expect_redirect_failure, Boolean, default: false
 
-      has n, :request_responses, through: Resource, order: [:timestamp.asc]
+      has n, :request_responses, through: Resource, order: [:sequence.asc]
       has n, :test_warnings
       has n, :information_messages
       belongs_to :sequence_result

--- a/lib/app/models/test_result.rb
+++ b/lib/app/models/test_result.rb
@@ -27,7 +27,7 @@ module Inferno
       property :redirect_to_url, String
       property :expect_redirect_failure, Boolean, default: false
 
-      has n, :request_responses, through: Resource, order: [:sequence.asc]
+      has n, :request_responses, through: Resource, order: [:request_index.asc]
       has n, :test_warnings
       has n, :information_messages
       belongs_to :sequence_result


### PR DESCRIPTION
RequestResponses were being shown out of order due to insufficient precision in how timestamps are stored in the database. This branch adds a new field to store their order, as shown in the screenshots below (check the order from bottom to top).

Before:
![Screen Shot 2020-06-10 at 12 52 15 PM](https://user-images.githubusercontent.com/15969967/84314590-4e644800-ab36-11ea-8330-99e251153e4a.png)

After:
![Screen Shot 2020-06-10 at 2 45 12 PM](https://user-images.githubusercontent.com/15969967/84314607-53c19280-ab36-11ea-8bcc-5feb5f95bd53.png)


**Submitter:**
- [x] This pull request describes why these changes were made
- [x] Internal ticket links to this PR
- [x] Internal ticket is properly labeled (Community/Program)
- [x] Internal ticket has a justification for its Community/Program label
- [x] Code diff has been reviewed for extraneous/missing code
- n/a Tests are included and test edge cases
- [x] Tests/code quality metrics have been run locally and pass


**Reviewer 1:**

Name:
- [x] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [x] The tests appropriately test the new code, including edge cases
- [x] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
