### PR TITLE
FI-870 Ensure correct test instance found in smart redirect when no state.

### DIFF
--- a/lib/app/endpoint/oauth2_endpoints.rb
+++ b/lib/app/endpoint/oauth2_endpoints.rb
@@ -18,8 +18,10 @@ module Inferno
           end
 
           get '/oauth2/:key/redirect/?' do
-            @instance = Inferno::Models::TestingInstance.first(state: params[:state])
-            return resume_execution if @instance.present?
+            unless params[:state].blank?
+              @instance = Inferno::Models::TestingInstance.first(state: params[:state])
+              return resume_execution if @instance.present?
+            end
 
             @instance = Inferno::Models::TestingInstance.get(instance_id_from_cookie)
             halt 500, no_instance_for_state_error_message if @instance.nil?

--- a/lib/app/utils/oauth2_error_messages.rb
+++ b/lib/app/utils/oauth2_error_messages.rb
@@ -7,11 +7,7 @@ module Inferno
         %(
           <p>
             Inferno has detected an issue with the SMART launch.
-            <% if params[:state].nil?} %>
-              No 'state' parameter was returned by the authorization server.
-            <% else %>
-              No actively running launch sequences found with a 'state' parameter of '#{params[:state]}'.
-            <% end %>
+            #{param_description}
             The authorization server is not returning the correct state variable and
             therefore Inferno cannot identify which server is currently under test.
             Please click your browser's "Back" button to return to Inferno,
@@ -20,6 +16,12 @@ module Inferno
           #{server_error_message}
           #{server_error_description}
         )
+      end
+
+      def param_description
+        return 'No state parameter was returned by the authorization server. ' if params[:state].nil?
+
+        "No actively running launch sequences found with a 'state' parameter of '#{params[:state]}'."
       end
 
       def server_error_message

--- a/lib/app/utils/oauth2_error_messages.rb
+++ b/lib/app/utils/oauth2_error_messages.rb
@@ -19,7 +19,7 @@ module Inferno
       end
 
       def param_description
-        return 'No state parameter was returned by the authorization server. ' if params[:state].nil?
+        return "No 'state' parameter was returned by the authorization server." if params[:state].nil?
 
         "No actively running launch sequences found with a 'state' parameter of '#{params[:state]}'."
       end

--- a/lib/app/utils/oauth2_error_messages.rb
+++ b/lib/app/utils/oauth2_error_messages.rb
@@ -7,7 +7,11 @@ module Inferno
         %(
           <p>
             Inferno has detected an issue with the SMART launch.
-            No actively running launch sequences found with a state of #{params[:state]}.
+            <% if params[:state].nil?} %>
+              No 'state' parameter was returned by the authorization server.
+            <% else %>
+              No actively running launch sequences found with a 'state' parameter of '#{params[:state]}'.
+            <% end %>
             The authorization server is not returning the correct state variable and
             therefore Inferno cannot identify which server is currently under test.
             Please click your browser's "Back" button to return to Inferno,

--- a/lib/app/views/default.erb
+++ b/lib/app/views/default.erb
@@ -74,7 +74,7 @@
           No actively running launch sequences found for iss <%=params[:iss]%>.
           Please ensure that the EHR launch test is actively running before attempting to launch Inferno from the EHR.
         <% elsif error_code == 'no_state' %>
-          Inferno has detected an issue with the SMART launch. No actively running launch sequences found with a state of <%=params[:state]%>.
+          Inferno has detected an issue with the SMART launch. No actively running launch sequences found with a state parameter of '<%=params[:state]%>'.
           The authorization server is not returning the correct state variable and therefore Inferno cannot identify which server is currently under test.
         <% end %>
       </div>

--- a/lib/app/views/guided.erb
+++ b/lib/app/views/guided.erb
@@ -75,7 +75,7 @@
           No actively running launch sequences found for iss <%=params[:iss]%>.
           Please ensure that the EHR launch test is actively running before attempting to launch Inferno from the EHR.
         <% elsif error_code == 'no_state' %>
-          Inferno has detected an issue with the SMART launch. No actively running launch sequences found with a state of <%=params[:state]%>.
+          Inferno has detected an issue with the SMART launch. No actively running launch sequences found with a state parameter of '<%=params[:state]%>'.
           The authorization server is not returning the correct state variable and therefore Inferno cannot identify which server is currently under test.
         <% end %>
       </div>

--- a/lib/app/views/onc_program.erb
+++ b/lib/app/views/onc_program.erb
@@ -75,7 +75,7 @@
           No actively running launch sequences found for iss <%=params[:iss]%>.
           Please ensure that the EHR launch test is actively running before attempting to launch Inferno from the EHR.
         <% elsif error_code == 'no_state' %>
-          Inferno has detected an issue with the SMART launch. No actively running launch sequences found with a state of <%=params[:state]%>.
+          Inferno has detected an issue with the SMART launch. No actively running launch sequences found with a state parameter of '<%=params[:state]%>'.
           The authorization server is not returning the correct state variable and therefore Inferno cannot identify which server is currently under test.
         <% end %>
       </div>

--- a/test/integration/oauth2_endpoints_test.rb
+++ b/test/integration/oauth2_endpoints_test.rb
@@ -39,6 +39,13 @@ class OAuth2EndpointsTest < MiniTest::Test
 
   def setup
     WebMock.disable_net_connect!
+
+    # Guard against misconfigured environment because we are purging the database
+    raise "Tests must run in test environment, currently #{Inferno::ENVIRONMENT}" unless Inferno::ENVIRONMENT == :test
+
+    Inferno::Models::TestResult.destroy!
+    Inferno::Models::SequenceResult.destroy!
+    Inferno::Models::TestingInstance.destroy!
   end
 
   def test_launch_response_success
@@ -188,14 +195,13 @@ class OAuth2EndpointsTest < MiniTest::Test
 
       assert last_response.status == 500
 
-      expected_error_message = "No actively running launch sequences found with a state of #{bad_state}"
+      expected_error_message = "No actively running launch sequences found with a 'state' parameter of '#{bad_state}'"
       assert last_response.body.include? expected_error_message
       break
     end
   end
 
   def test_redirect_response_no_state
-    state = SecureRandom.uuid
     instance = create_testing_instance
     sequence_result = create_sequence_result(
       testing_instance: instance,
@@ -206,11 +212,11 @@ class OAuth2EndpointsTest < MiniTest::Test
     )
 
     EventMachine.run do
-      get "/inferno/oauth2/static/redirect"
+      get '/inferno/oauth2/static/redirect'
 
       assert last_response.status == 500
 
-      expected_error_message = "No actively running launch sequences found"
+      expected_error_message = 'No actively running launch sequences found'
       assert last_response.body.include? expected_error_message
 
       break

--- a/test/integration/oauth2_endpoints_test.rb
+++ b/test/integration/oauth2_endpoints_test.rb
@@ -216,7 +216,7 @@ class OAuth2EndpointsTest < MiniTest::Test
 
       assert last_response.status == 500
 
-      expected_error_message = 'No actively running launch sequences found'
+      expected_error_message = 'No state parameter was returned by the authorization server'
       assert last_response.body.include? expected_error_message
 
       break

--- a/test/integration/oauth2_endpoints_test.rb
+++ b/test/integration/oauth2_endpoints_test.rb
@@ -216,7 +216,7 @@ class OAuth2EndpointsTest < MiniTest::Test
 
       assert last_response.status == 500
 
-      expected_error_message = 'No state parameter was returned by the authorization server'
+      expected_error_message = "No 'state' parameter was returned by the authorization server"
       assert last_response.body.include? expected_error_message
 
       break

--- a/test/integration/oauth2_endpoints_test.rb
+++ b/test/integration/oauth2_endpoints_test.rb
@@ -194,6 +194,29 @@ class OAuth2EndpointsTest < MiniTest::Test
     end
   end
 
+  def test_redirect_response_no_state
+    state = SecureRandom.uuid
+    instance = create_testing_instance
+    sequence_result = create_sequence_result(
+      testing_instance: instance,
+      wait_at_endpoint: 'redirect'
+    )
+    Inferno::Models::TestResult.create(
+      sequence_result: sequence_result
+    )
+
+    EventMachine.run do
+      get "/inferno/oauth2/static/redirect"
+
+      assert last_response.status == 500
+
+      expected_error_message = "No actively running launch sequences found"
+      assert last_response.body.include? expected_error_message
+
+      break
+    end
+  end
+
   def test_redirect_response_bad_state
     state = SecureRandom.uuid
     instance = create_testing_instance(state: state)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -5,7 +5,8 @@ SimpleCov.start do
   add_filter '/test/'
 end
 
-ENV['RACK_ENV'] = 'test'
+ENV['APP_ENV'] = ENV['RACK_ENV'] = 'test'
+
 require 'minitest/autorun'
 require 'webmock/minitest'
 require 'rack/test'


### PR DESCRIPTION
If during the launch process you visit Infenro's launch URI without a state, inferno will match you to the wrong instance. It should see that no state param was passed, then check if there is a cookie with the instance stored there, and redirect you to the instance in the cookie.

Previous to this fix, the logic is set up so that Inferno will find you the first instance with a state of 'nil', which will be present in any instance that hasn't yet run any inferno launches.

To recreate, simply go to https://inferno.healthit.gov/inferno/oauth2/static/redirect.
**Submitter:**
- [x] This pull request describes why these changes were made
- [x] Internal ticket for this PR:
- [x] Internal ticket links to this PR
- [x] Internal ticket is properly labeled (Community/Program)
- [x] Internal ticket has a justification for its Community/Program label
- [x] Code diff has been reviewed for extraneous/missing code
- n/a Tests are included and test edge cases
- [x] Tests/code quality metrics have been run locally and pass


**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
