### PR TITLE
Fi 873 add diagnostic report blurb

### DIFF
--- a/generator/uscore/templates/sequence.rb.erb
+++ b/generator/uscore/templates/sequence.rb.erb
@@ -47,7 +47,9 @@ module Inferno
         <%searches.select { |search_param| search_param[:expectation] == 'SHALL' && !search_param[:must_support_or_mandatory]}.each do |search| %>
           * <%=search[:names].join('+ ')%><%end%>
         <% end %>
-        
+        <% if resource == 'DiagnosticReport' %>
+        We search by patient + category before doing a search by just patient in order to differentiate the two Diagnostic Report profiles. 
+        <% end %>
         ### Search Parameters
         The first search uses the selected patient(s) from the prior launch sequence. Any subsequent searches will look for its 
         parameter values from the results of the first search. For example, the `identifier` search in the patient sequence is 

--- a/generator/uscore/templates/sequence.rb.erb
+++ b/generator/uscore/templates/sequence.rb.erb
@@ -65,7 +65,7 @@ module Inferno
         <%end%>
         ## Must Support
         Each profile has a list of elements marked as "must support". This test sequence expects to see each of these elements
-        at least once. If at least one cannot be found, the test will fail. The test will look through the `#{title.gsub(/\s+/, '')}`
+        at least once. If at least one cannot be found, the test will fail. The test will look through the <%=resource%>
         resources found for these elements.
 
         ## Profile Validation

--- a/generator/uscore/templates/sequence.rb.erb
+++ b/generator/uscore/templates/sequence.rb.erb
@@ -48,7 +48,7 @@ module Inferno
           * <%=search[:names].join('+ ')%><%end%>
         <% end %>
         <% if resource == 'DiagnosticReport' %>
-        We search by patient + category before doing a search by just patient in order to differentiate the two Diagnostic Report profiles. 
+        Inferno will search by patient + category before doing a search by only patient in order to differentiate the two Diagnostic Report profiles. 
         <% end %>
         ### Search Parameters
         The first search uses the selected patient(s) from the prior launch sequence. Any subsequent searches will look for its 

--- a/lib/modules/uscore_v3.1.0/bodyheight_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/bodyheight_sequence.rb
@@ -48,7 +48,7 @@ module Inferno
 
         ## Must Support
         Each profile has a list of elements marked as "must support". This test sequence expects to see each of these elements
-        at least once. If at least one cannot be found, the test will fail. The test will look through the `#{title.gsub(/\s+/, '')}`
+        at least once. If at least one cannot be found, the test will fail. The test will look through the Observation
         resources found for these elements.
 
         ## Profile Validation

--- a/lib/modules/uscore_v3.1.0/bodytemp_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/bodytemp_sequence.rb
@@ -48,7 +48,7 @@ module Inferno
 
         ## Must Support
         Each profile has a list of elements marked as "must support". This test sequence expects to see each of these elements
-        at least once. If at least one cannot be found, the test will fail. The test will look through the `#{title.gsub(/\s+/, '')}`
+        at least once. If at least one cannot be found, the test will fail. The test will look through the Observation
         resources found for these elements.
 
         ## Profile Validation

--- a/lib/modules/uscore_v3.1.0/bodyweight_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/bodyweight_sequence.rb
@@ -48,7 +48,7 @@ module Inferno
 
         ## Must Support
         Each profile has a list of elements marked as "must support". This test sequence expects to see each of these elements
-        at least once. If at least one cannot be found, the test will fail. The test will look through the `#{title.gsub(/\s+/, '')}`
+        at least once. If at least one cannot be found, the test will fail. The test will look through the Observation
         resources found for these elements.
 
         ## Profile Validation

--- a/lib/modules/uscore_v3.1.0/bp_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/bp_sequence.rb
@@ -48,7 +48,7 @@ module Inferno
 
         ## Must Support
         Each profile has a list of elements marked as "must support". This test sequence expects to see each of these elements
-        at least once. If at least one cannot be found, the test will fail. The test will look through the `#{title.gsub(/\s+/, '')}`
+        at least once. If at least one cannot be found, the test will fail. The test will look through the Observation
         resources found for these elements.
 
         ## Profile Validation

--- a/lib/modules/uscore_v3.1.0/headcircum_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/headcircum_sequence.rb
@@ -48,7 +48,7 @@ module Inferno
 
         ## Must Support
         Each profile has a list of elements marked as "must support". This test sequence expects to see each of these elements
-        at least once. If at least one cannot be found, the test will fail. The test will look through the `#{title.gsub(/\s+/, '')}`
+        at least once. If at least one cannot be found, the test will fail. The test will look through the Observation
         resources found for these elements.
 
         ## Profile Validation

--- a/lib/modules/uscore_v3.1.0/heartrate_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/heartrate_sequence.rb
@@ -48,7 +48,7 @@ module Inferno
 
         ## Must Support
         Each profile has a list of elements marked as "must support". This test sequence expects to see each of these elements
-        at least once. If at least one cannot be found, the test will fail. The test will look through the `#{title.gsub(/\s+/, '')}`
+        at least once. If at least one cannot be found, the test will fail. The test will look through the Observation
         resources found for these elements.
 
         ## Profile Validation

--- a/lib/modules/uscore_v3.1.0/pediatric_bmi_for_age_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/pediatric_bmi_for_age_sequence.rb
@@ -48,7 +48,7 @@ module Inferno
 
         ## Must Support
         Each profile has a list of elements marked as "must support". This test sequence expects to see each of these elements
-        at least once. If at least one cannot be found, the test will fail. The test will look through the `#{title.gsub(/\s+/, '')}`
+        at least once. If at least one cannot be found, the test will fail. The test will look through the Observation
         resources found for these elements.
 
         ## Profile Validation

--- a/lib/modules/uscore_v3.1.0/pediatric_weight_for_height_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/pediatric_weight_for_height_sequence.rb
@@ -48,7 +48,7 @@ module Inferno
 
         ## Must Support
         Each profile has a list of elements marked as "must support". This test sequence expects to see each of these elements
-        at least once. If at least one cannot be found, the test will fail. The test will look through the `#{title.gsub(/\s+/, '')}`
+        at least once. If at least one cannot be found, the test will fail. The test will look through the Observation
         resources found for these elements.
 
         ## Profile Validation

--- a/lib/modules/uscore_v3.1.0/resprate_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/resprate_sequence.rb
@@ -48,7 +48,7 @@ module Inferno
 
         ## Must Support
         Each profile has a list of elements marked as "must support". This test sequence expects to see each of these elements
-        at least once. If at least one cannot be found, the test will fail. The test will look through the `#{title.gsub(/\s+/, '')}`
+        at least once. If at least one cannot be found, the test will fail. The test will look through the Observation
         resources found for these elements.
 
         ## Profile Validation

--- a/lib/modules/uscore_v3.1.0/us_core_allergyintolerance_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_allergyintolerance_sequence.rb
@@ -46,7 +46,7 @@ module Inferno
 
         ## Must Support
         Each profile has a list of elements marked as "must support". This test sequence expects to see each of these elements
-        at least once. If at least one cannot be found, the test will fail. The test will look through the `#{title.gsub(/\s+/, '')}`
+        at least once. If at least one cannot be found, the test will fail. The test will look through the AllergyIntolerance
         resources found for these elements.
 
         ## Profile Validation

--- a/lib/modules/uscore_v3.1.0/us_core_careplan_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_careplan_sequence.rb
@@ -46,7 +46,7 @@ module Inferno
 
         ## Must Support
         Each profile has a list of elements marked as "must support". This test sequence expects to see each of these elements
-        at least once. If at least one cannot be found, the test will fail. The test will look through the `#{title.gsub(/\s+/, '')}`
+        at least once. If at least one cannot be found, the test will fail. The test will look through the CarePlan
         resources found for these elements.
 
         ## Profile Validation

--- a/lib/modules/uscore_v3.1.0/us_core_careteam_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_careteam_sequence.rb
@@ -46,7 +46,7 @@ module Inferno
 
         ## Must Support
         Each profile has a list of elements marked as "must support". This test sequence expects to see each of these elements
-        at least once. If at least one cannot be found, the test will fail. The test will look through the `#{title.gsub(/\s+/, '')}`
+        at least once. If at least one cannot be found, the test will fail. The test will look through the CareTeam
         resources found for these elements.
 
         ## Profile Validation

--- a/lib/modules/uscore_v3.1.0/us_core_condition_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_condition_sequence.rb
@@ -46,7 +46,7 @@ module Inferno
 
         ## Must Support
         Each profile has a list of elements marked as "must support". This test sequence expects to see each of these elements
-        at least once. If at least one cannot be found, the test will fail. The test will look through the `#{title.gsub(/\s+/, '')}`
+        at least once. If at least one cannot be found, the test will fail. The test will look through the Condition
         resources found for these elements.
 
         ## Profile Validation

--- a/lib/modules/uscore_v3.1.0/us_core_diagnosticreport_lab_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_diagnosticreport_lab_sequence.rb
@@ -51,7 +51,7 @@ module Inferno
 
         ## Must Support
         Each profile has a list of elements marked as "must support". This test sequence expects to see each of these elements
-        at least once. If at least one cannot be found, the test will fail. The test will look through the `#{title.gsub(/\s+/, '')}`
+        at least once. If at least one cannot be found, the test will fail. The test will look through the DiagnosticReport
         resources found for these elements.
 
         ## Profile Validation

--- a/lib/modules/uscore_v3.1.0/us_core_diagnosticreport_lab_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_diagnosticreport_lab_sequence.rb
@@ -34,7 +34,7 @@ module Inferno
 
 
 
-        We search by patient + category before doing a search by just patient in order to differentiate the two Diagnostic Report profiles.
+        Inferno will search by patient + category before doing a search by only patient in order to differentiate the two Diagnostic Report profiles.
 
         ### Search Parameters
         The first search uses the selected patient(s) from the prior launch sequence. Any subsequent searches will look for its

--- a/lib/modules/uscore_v3.1.0/us_core_diagnosticreport_lab_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_diagnosticreport_lab_sequence.rb
@@ -34,6 +34,8 @@ module Inferno
 
 
 
+        We search by patient + category before doing a search by just patient in order to differentiate the two Diagnostic Report profiles.
+
         ### Search Parameters
         The first search uses the selected patient(s) from the prior launch sequence. Any subsequent searches will look for its
         parameter values from the results of the first search. For example, the `identifier` search in the patient sequence is

--- a/lib/modules/uscore_v3.1.0/us_core_diagnosticreport_note_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_diagnosticreport_note_sequence.rb
@@ -51,7 +51,7 @@ module Inferno
 
         ## Must Support
         Each profile has a list of elements marked as "must support". This test sequence expects to see each of these elements
-        at least once. If at least one cannot be found, the test will fail. The test will look through the `#{title.gsub(/\s+/, '')}`
+        at least once. If at least one cannot be found, the test will fail. The test will look through the DiagnosticReport
         resources found for these elements.
 
         ## Profile Validation

--- a/lib/modules/uscore_v3.1.0/us_core_diagnosticreport_note_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_diagnosticreport_note_sequence.rb
@@ -34,7 +34,7 @@ module Inferno
 
 
 
-        We search by patient + category before doing a search by just patient in order to differentiate the two Diagnostic Report profiles.
+        Inferno will search by patient + category before doing a search by only patient in order to differentiate the two Diagnostic Report profiles.
 
         ### Search Parameters
         The first search uses the selected patient(s) from the prior launch sequence. Any subsequent searches will look for its

--- a/lib/modules/uscore_v3.1.0/us_core_diagnosticreport_note_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_diagnosticreport_note_sequence.rb
@@ -34,6 +34,8 @@ module Inferno
 
 
 
+        We search by patient + category before doing a search by just patient in order to differentiate the two Diagnostic Report profiles.
+
         ### Search Parameters
         The first search uses the selected patient(s) from the prior launch sequence. Any subsequent searches will look for its
         parameter values from the results of the first search. For example, the `identifier` search in the patient sequence is

--- a/lib/modules/uscore_v3.1.0/us_core_documentreference_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_documentreference_sequence.rb
@@ -50,7 +50,7 @@ module Inferno
 
         ## Must Support
         Each profile has a list of elements marked as "must support". This test sequence expects to see each of these elements
-        at least once. If at least one cannot be found, the test will fail. The test will look through the `#{title.gsub(/\s+/, '')}`
+        at least once. If at least one cannot be found, the test will fail. The test will look through the DocumentReference
         resources found for these elements.
 
         ## Profile Validation

--- a/lib/modules/uscore_v3.1.0/us_core_encounter_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_encounter_sequence.rb
@@ -30,7 +30,7 @@ module Inferno
 
         ## Must Support
         Each profile has a list of elements marked as "must support". This test sequence expects to see each of these elements
-        at least once. If at least one cannot be found, the test will fail. The test will look through the `#{title.gsub(/\s+/, '')}`
+        at least once. If at least one cannot be found, the test will fail. The test will look through the Encounter
         resources found for these elements.
 
         ## Profile Validation

--- a/lib/modules/uscore_v3.1.0/us_core_goal_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_goal_sequence.rb
@@ -46,7 +46,7 @@ module Inferno
 
         ## Must Support
         Each profile has a list of elements marked as "must support". This test sequence expects to see each of these elements
-        at least once. If at least one cannot be found, the test will fail. The test will look through the `#{title.gsub(/\s+/, '')}`
+        at least once. If at least one cannot be found, the test will fail. The test will look through the Goal
         resources found for these elements.
 
         ## Profile Validation

--- a/lib/modules/uscore_v3.1.0/us_core_immunization_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_immunization_sequence.rb
@@ -46,7 +46,7 @@ module Inferno
 
         ## Must Support
         Each profile has a list of elements marked as "must support". This test sequence expects to see each of these elements
-        at least once. If at least one cannot be found, the test will fail. The test will look through the `#{title.gsub(/\s+/, '')}`
+        at least once. If at least one cannot be found, the test will fail. The test will look through the Immunization
         resources found for these elements.
 
         ## Profile Validation

--- a/lib/modules/uscore_v3.1.0/us_core_implantable_device_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_implantable_device_sequence.rb
@@ -49,7 +49,7 @@ module Inferno
 
         ## Must Support
         Each profile has a list of elements marked as "must support". This test sequence expects to see each of these elements
-        at least once. If at least one cannot be found, the test will fail. The test will look through the `#{title.gsub(/\s+/, '')}`
+        at least once. If at least one cannot be found, the test will fail. The test will look through the Device
         resources found for these elements.
 
         ## Profile Validation

--- a/lib/modules/uscore_v3.1.0/us_core_location_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_location_sequence.rb
@@ -30,7 +30,7 @@ module Inferno
 
         ## Must Support
         Each profile has a list of elements marked as "must support". This test sequence expects to see each of these elements
-        at least once. If at least one cannot be found, the test will fail. The test will look through the `#{title.gsub(/\s+/, '')}`
+        at least once. If at least one cannot be found, the test will fail. The test will look through the Location
         resources found for these elements.
 
         ## Profile Validation

--- a/lib/modules/uscore_v3.1.0/us_core_medicationrequest_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_medicationrequest_sequence.rb
@@ -47,7 +47,7 @@ module Inferno
 
         ## Must Support
         Each profile has a list of elements marked as "must support". This test sequence expects to see each of these elements
-        at least once. If at least one cannot be found, the test will fail. The test will look through the `#{title.gsub(/\s+/, '')}`
+        at least once. If at least one cannot be found, the test will fail. The test will look through the MedicationRequest
         resources found for these elements.
 
         ## Profile Validation

--- a/lib/modules/uscore_v3.1.0/us_core_observation_lab_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_observation_lab_sequence.rb
@@ -48,7 +48,7 @@ module Inferno
 
         ## Must Support
         Each profile has a list of elements marked as "must support". This test sequence expects to see each of these elements
-        at least once. If at least one cannot be found, the test will fail. The test will look through the `#{title.gsub(/\s+/, '')}`
+        at least once. If at least one cannot be found, the test will fail. The test will look through the Observation
         resources found for these elements.
 
         ## Profile Validation

--- a/lib/modules/uscore_v3.1.0/us_core_organization_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_organization_sequence.rb
@@ -30,7 +30,7 @@ module Inferno
 
         ## Must Support
         Each profile has a list of elements marked as "must support". This test sequence expects to see each of these elements
-        at least once. If at least one cannot be found, the test will fail. The test will look through the `#{title.gsub(/\s+/, '')}`
+        at least once. If at least one cannot be found, the test will fail. The test will look through the Organization
         resources found for these elements.
 
         ## Profile Validation

--- a/lib/modules/uscore_v3.1.0/us_core_patient_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_patient_sequence.rb
@@ -50,7 +50,7 @@ module Inferno
 
         ## Must Support
         Each profile has a list of elements marked as "must support". This test sequence expects to see each of these elements
-        at least once. If at least one cannot be found, the test will fail. The test will look through the `#{title.gsub(/\s+/, '')}`
+        at least once. If at least one cannot be found, the test will fail. The test will look through the Patient
         resources found for these elements.
 
         ## Profile Validation

--- a/lib/modules/uscore_v3.1.0/us_core_practitioner_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_practitioner_sequence.rb
@@ -30,7 +30,7 @@ module Inferno
 
         ## Must Support
         Each profile has a list of elements marked as "must support". This test sequence expects to see each of these elements
-        at least once. If at least one cannot be found, the test will fail. The test will look through the `#{title.gsub(/\s+/, '')}`
+        at least once. If at least one cannot be found, the test will fail. The test will look through the Practitioner
         resources found for these elements.
 
         ## Profile Validation

--- a/lib/modules/uscore_v3.1.0/us_core_practitionerrole_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_practitionerrole_sequence.rb
@@ -30,7 +30,7 @@ module Inferno
 
         ## Must Support
         Each profile has a list of elements marked as "must support". This test sequence expects to see each of these elements
-        at least once. If at least one cannot be found, the test will fail. The test will look through the `#{title.gsub(/\s+/, '')}`
+        at least once. If at least one cannot be found, the test will fail. The test will look through the PractitionerRole
         resources found for these elements.
 
         ## Profile Validation

--- a/lib/modules/uscore_v3.1.0/us_core_procedure_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_procedure_sequence.rb
@@ -47,7 +47,7 @@ module Inferno
 
         ## Must Support
         Each profile has a list of elements marked as "must support". This test sequence expects to see each of these elements
-        at least once. If at least one cannot be found, the test will fail. The test will look through the `#{title.gsub(/\s+/, '')}`
+        at least once. If at least one cannot be found, the test will fail. The test will look through the Procedure
         resources found for these elements.
 
         ## Profile Validation

--- a/lib/modules/uscore_v3.1.0/us_core_provenance_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_provenance_sequence.rb
@@ -29,7 +29,7 @@ module Inferno
 
         ## Must Support
         Each profile has a list of elements marked as "must support". This test sequence expects to see each of these elements
-        at least once. If at least one cannot be found, the test will fail. The test will look through the `#{title.gsub(/\s+/, '')}`
+        at least once. If at least one cannot be found, the test will fail. The test will look through the Provenance
         resources found for these elements.
 
         ## Profile Validation

--- a/lib/modules/uscore_v3.1.0/us_core_pulse_oximetry_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_pulse_oximetry_sequence.rb
@@ -48,7 +48,7 @@ module Inferno
 
         ## Must Support
         Each profile has a list of elements marked as "must support". This test sequence expects to see each of these elements
-        at least once. If at least one cannot be found, the test will fail. The test will look through the `#{title.gsub(/\s+/, '')}`
+        at least once. If at least one cannot be found, the test will fail. The test will look through the Observation
         resources found for these elements.
 
         ## Profile Validation

--- a/lib/modules/uscore_v3.1.0/us_core_smokingstatus_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_smokingstatus_sequence.rb
@@ -52,7 +52,7 @@ module Inferno
 
         ## Must Support
         Each profile has a list of elements marked as "must support". This test sequence expects to see each of these elements
-        at least once. If at least one cannot be found, the test will fail. The test will look through the `#{title.gsub(/\s+/, '')}`
+        at least once. If at least one cannot be found, the test will fail. The test will look through the Observation
         resources found for these elements.
 
         ## Profile Validation


### PR DESCRIPTION
This PR adds a comment in the about section for the diagnostic report sequences that says why we search by patient + category first. I also changed another part of the sequence description to show the resource instead of the test title.

**Submitter:**
- [X] This pull request describes why these changes were made
- [X] Internal ticket for this PR: https://oncprojectracking.healthit.gov/support/browse/FI-873
- [X] Internal ticket links to this PR
- [X] Internal ticket is properly labeled (Community/Program)
- [X] Internal ticket has a justification for its Community/Program label
- [X] Code diff has been reviewed for extraneous/missing code
-  Tests are included and test edge cases
- Tests/code quality metrics have been run locally and pass


**Reviewer 1:**

Name:
- [x] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
