### PR TITLE
subtract/add a day when doing searches based on period

### DIFF
--- a/lib/app/sequence_base.rb
+++ b/lib/app/sequence_base.rb
@@ -799,9 +799,9 @@ module Inferno
         search_value = case element
                        when FHIR::Period
                          if element.start.present?
-                           'gt' + element.start
+                           'gt' + (DateTime.xmlschema(element.start) - 1).xmlschema
                          else
-                           'lt' + element.end
+                           'lt' + (DateTime.xmlschema(element.end) + 1).xmlschema
                          end
                        when FHIR::Reference
                          element.reference

--- a/test/unit/sequence_base_test.rb
+++ b/test/unit/sequence_base_test.rb
@@ -123,12 +123,12 @@ class SequenceBaseTest < MiniTest::Test
     end
 
     it 'returns value from period' do
-      { start: 'now', end: 'later' }.each do |key, value|
+      { start: '2020-05-26', end: '2020-05-26' }.each do |key, value|
         element = FHIR::Period.new(key => value)
         expected_value = if key == :start
-                           'gt' + value
+                           'gt2020-05-25T00:00:00+00:00'
                          else
-                           'lt' + value
+                           'lt2020-05-27T00:00:00+00:00'
                          end
         assert @sequence.get_value_for_search_param(element) == expected_value
       end


### PR DESCRIPTION
This PR fixes a bug where we incorrectly get the search value for periods that start and end on the same day. To get around this, I'm just going to subtract one day from the initial start date and add one day to the end date.

**Submitter:**
- [X] This pull request describes why these changes were made
- [X] Internal ticket for this PR: https://oncprojectracking.healthit.gov/support/browse/FI-878
- [X] Internal ticket links to this PR
- [X] Internal ticket is properly labeled (Community/Program)
- [X] Internal ticket has a justification for its Community/Program label
- [X] Code diff has been reviewed for extraneous/missing code
- [X] Tests are included and test edge cases
- [X] Tests/code quality metrics have been run locally and pass


**Reviewer 1:**

Name:
- [x] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [x] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
