### PR TITLE
Change must_support missing element to SkipException

### DIFF
--- a/lib/modules/onc_program/bulk_data_group_validation_sequence.rb
+++ b/lib/modules/onc_program/bulk_data_group_validation_sequence.rb
@@ -287,13 +287,13 @@ module Inferno
           missing_must_supports = must_support[:must_support_info]
 
           missing_elements_list = missing_must_supports[:elements].map { |el| "#{el[:path]}#{': ' + el[:fixed_value] if el[:fixed_value].present?}" }
-          assert missing_elements_list.empty?, format(error_string, 'elements', missing_elements_list.join(', '))
+          skip_if missing_elements_list.present?, format(error_string, 'elements', missing_elements_list.join(', '))
 
           missing_slices_list = missing_must_supports[:slices].map { |slice| slice[:name] }
-          assert missing_slices_list.empty?, format(error_string, 'slices', missing_slices_list.join(', '))
+          skip_if missing_slices_list.present?, format(error_string, 'slices', missing_slices_list.join(', '))
 
           missing_extensions_list = missing_must_supports[:extensions].map { |extension| extension[:id] }
-          assert missing_extensions_list.empty?, format(error_string, 'extensions', missing_extensions_list.join(', '))
+          skip_if missing_extensions_list.present?, format(error_string, 'extensions', missing_extensions_list.join(', '))
         end
       end
 

--- a/lib/modules/onc_program/test/bulk_group_validation_sequence_test.rb
+++ b/lib/modules/onc_program/test/bulk_group_validation_sequence_test.rb
@@ -361,7 +361,7 @@ describe Inferno::Sequence::BulkDataGroupExportValidationSequence do
       assert_match(/^Successfully validated [\d]+ resource/, pass_exception.message)
     end
 
-    it 'fails when not all must supports are found' do
+    it 'skips when not all must supports are found' do
       stub_request(:get, @patient_file_location)
         .with(headers: @file_request_headers)
         .to_return(
@@ -387,7 +387,7 @@ describe Inferno::Sequence::BulkDataGroupExportValidationSequence do
           }
         }
       ]
-      assertion_exception = assert_raises(Inferno::AssertionException) { @sequence.test_output_against_profile('Patient', must_supports) }
+      assertion_exception = assert_raises(Inferno::SkipException) { @sequence.test_output_against_profile('Patient', must_supports) }
       assert_match('Could not verify presence of the following must support elements: address.period', assertion_exception.message)
     end
   end


### PR DESCRIPTION
This change synchronize the behavior of must_support tests between single-patient and multi-patients test. 
1) Using SkipException when there are missing must_support element(s)

**Submitter:**
- [x] This pull request describes why these changes were made
- [x] Internal ticket for this PR:
- [x] Internal ticket links to this PR
- [x] Internal ticket is properly labeled (Community/Program)
- [x] Internal ticket has a justification for its Community/Program label
- [x] Code diff has been reviewed for extraneous/missing code
- [x] Tests are included and test edge cases
- [x] Tests/code quality metrics have been run locally and pass


**Reviewer 1:**

Name:
- [x] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [x] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
