### PR TITLE
Fi 884 scrub presets

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -94,39 +94,17 @@ bulk_data_jwks:
     
 # preset fhir servers: optional. Minimally requires name, uri, module, optional inferno_uri, client_id, client_secret, scopes, instructions link
 presets:
-  reference_server:
-    name: FHIR Reference Server
-    uri: http://localhost:8080/r4
-    module: onc_program
+  localhost_reference_server:
     inferno_uri: http://localhost:4567
+    name: Inferno Reference Server
+    uri: https://inferno.healthit.gov/reference-server/r4
+    module: onc_program
     client_id: SAMPLE_CONFIDENTIAL_CLIENT_ID
     confidential_client: true
     client_secret: SAMPLE_CONFIDENTIAL_CLIENT_SECRET
-    onc_sl_url: http://localhost:8080/r4
+    onc_sl_url: https://inferno.healthit.gov/reference-server/r4
     onc_sl_client_id: SAMPLE_CONFIDENTIAL_CLIENT_ID
     onc_sl_confidential_client: true
     onc_sl_client_secret: SAMPLE_CONFIDENTIAL_CLIENT_SECRET
-  cerner:
-    name: Cerner
-    uri: https://fhir-ehr.sandboxcerner.com/r4/0b8a0111-e8e6-4c26-a91c-5069cbc6b1ca
-    module: onc_program
-    inferno_uri: http://localhost:4567
-    client_id: a710f7e1-9e4b-4518-b5ba-69d0a25caebe
-    confidential_client: false
-    instructions: |
-      To login for EHR launch https://cernercare.com/accounts/login Login/Password: smacvicar@mitre.org/TUAuAJnDyen59dn-
-      You must use scopes: launch online_access openid profile patient/AllergyIntolerance.read patient/Condition.read patient/DocumentReference.read patient/Device.read patient/Encounter.read patient/Immunization.read patient/Organization.read patient/MedicationRequest.read patient/Patient.read patient/Procedure.read user/Practitioner.read
-      ehr launch only, go to https://code.cerner.com/developer/smart-on-fhir/apps after logging in
-      use portal/portal for user login
-  care_evolution:
-    name: Care Evolution
-    uri: https://fhir.careevolution.com/Master.Adapter1.WebClient/api/fhir-r4
-    client_id: 55990bf8-d85f-4a60-84b3-4699d1892f58
-    confidential_client: true
-    client_secret: secret
-    instructions: |
-      https://fhir.careevolution.com/Master.Adapter1.WebClient/fhir?prefix=fhir-r4
-      click on 'smart clients can be registered here'
-      user: rscanlon@mitre.org/InfernoInferno1
-      only patient launch supported?
-      use scope launch/patient patient/*.*
+    onc_public_client_id: SAMPLE_PUBLIC_CLIENT_ID
+    patient_ids: "76,185"

--- a/lib/app/views/layout.erb
+++ b/lib/app/views/layout.erb
@@ -62,10 +62,10 @@
     <footer class="footer">
       <div class="container row">
         <div class="col-sm text-left">
-          <a target="_blank" href="https://github.com/onc-healthit/inferno">Open Source</a>
+          <a target="_blank" href="https://github.com/onc-healthit/inferno-program">Open Source</a>
         </div>
         <div class="col-sm text-center">
-          <a target="_blank" href="https://github.com/onc-healthit/inferno/issues">Issues</a>
+          <a target="_blank" href="https://github.com/onc-healthit/inferno-program/issues">Issues</a>
         </div>
         <div class="col-sm text-right">
           <a href="#" data-toggle="modal" data-target="#ServerStatusModal">


### PR DESCRIPTION
This cleans up the presets for when you load up inferno on localhost.  It also fixes two links to the wrong github repo on the bottom of the interface.

**Submitter:**
- [x] This pull request describes why these changes were made
- [x] Internal ticket for this PR: Fi 884
- [x] Internal ticket links to this PR
- [x] Internal ticket is properly labeled (Community/Program)
- [x] Internal ticket has a justification for its Community/Program label
- [x] Code diff has been reviewed for extraneous/missing code
- n/a Tests are included and test edge cases
- [x] Tests/code quality metrics have been run locally and pass


**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
