### PR TITLE
FI-883: Load Server State modal via AJAX

### DIFF
--- a/lib/app/endpoint/landing.rb
+++ b/lib/app/endpoint/landing.rb
@@ -18,6 +18,10 @@ module Inferno
           # Custom landing page intended to be overwritten for branded deployments
           erb :landing
         end
+
+        get '/server_state/?' do
+          erb :server_state, { layout: false }
+        end
       end
     end
   end

--- a/lib/app/views/layout.erb
+++ b/lib/app/views/layout.erb
@@ -52,8 +52,11 @@
               <span aria-hidden="true">&times;</span>
             </button>
           </div>
-          <div class="modal-body">
-            <%= erb(:server_state, {}, {}) %>
+          <div class="modal-body" id="ServerStatusModalBody">
+            <div class="container">
+              <div class="spinner-border"><span class="sr-only">Loading</span></div>
+              Loading...
+            </div>
           </div>
         </div>
       </div>

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -439,4 +439,15 @@ $(function(){
       $('#preset-select').trigger("change", preset_id);
     }
   }
+
+  // Load the server state modal only if it's called
+  $("#ServerStatusModal").on('show.bs.modal', function() {
+    // Only load the state modal if #server-state doesn't already exist
+    // AKA if we haven't already loaded it before
+    if (!($("#server-state").length > 0)) {
+      $.get('/server_state', function(data) {
+        $("#ServerStatusModalBody").html(data);
+      });
+    }
+  });
 }); 


### PR DESCRIPTION
Previously, we were loading the "server state" modal in on every page load, whether or not it was viewed. This was a lot of HTML to send and render every time. This PR makes it so that the server state info is rendered in its own GET request, and fetched via AJAX the first time the modal is opened.

Pull requests into Inferno require the following items to be completed. Submitter and reviewer 
should check the relevant check boxes when the associated item is done. For items that are not 
applicable, note it's not applicable ("N/A") and check the box. For example, external Pull 
Requests do not require ticket links.

**Submitter:**
- [x] This pull request describes why these changes were made
- [x] Internal ticket for this PR: FI-883
- [x] Internal ticket links to this PR
- [x] Internal ticket is properly labeled (Community/Program)
- [x] Internal ticket has a justification for its Community/Program label
- [x] Code diff has been reviewed for extraneous/missing code
- [x] Tests are included and test edge cases
- [x] Tests/code quality metrics have been run locally and pass


**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
