### PR TITLE
FI-896 Allow 401 or 403 response on insufficient / limited access tests.

### DIFF
--- a/generator/uscore/templates/access_verify_sequence.rb.erb
+++ b/generator/uscore/templates/access_verify_sequence.rb.erb
@@ -40,6 +40,27 @@ module Inferno
         <% end %>
       end
 
+      def assert_response_insufficient_scope(response)
+
+        # This is intended for tests that are expecting the server to reject a
+        # resource request due to user not authorizing the application for that
+        # particular resource.  In early versions of this test, these tests
+        # expected a 401 (Unauthorized), but after later review it seems
+        # reasonable for a server to return 403 (Forbidden) instead.  This
+        # assertion therefore allows either.  403 may be the only correct
+        # answer, but further review is required before preventing 401 from
+        # being returned because that is a large change because it may cause
+        # some previously passing servers to fail.
+
+        message = "Bad response code: expected 403 (Forbidden), but found #{response.code}.  401 is also allowed."
+        assert [401, 403].include?(response.code), message
+
+        warning do
+          assert response.code == 403, "403 (Forbidden) is the preferred response code for authenticated requests with insufficient authorization for the request. #{response.code} was returned."
+        end
+
+      end
+
       def url_property
         'onc_sl_url'
       end
@@ -110,7 +131,9 @@ module Inferno
           assert_response_ok reply
           pass "Access expected to be granted and request properly returned #{reply&.response&.dig(:code)}"
         else
-          assert_response_unauthorized reply
+
+          assert_response_insufficient_scope reply
+
         end
 
       end
@@ -167,7 +190,7 @@ module Inferno
           pass "Access expected to be granted and request properly returned #{reply&.response&.dig(:code)}"
     
         else
-          assert_response_unauthorized reply
+          assert_response_insufficient_scope reply
         end
 
       end<% end %>

--- a/generator/uscore/templates/access_verify_sequence.rb.erb
+++ b/generator/uscore/templates/access_verify_sequence.rb.erb
@@ -11,10 +11,10 @@ module Inferno
       description 'Verify that access to resource types can be restricted to app.'
       test_id_prefix 'AVR'
       details %(
-        This test ensures that patients have control  to grant or deny access to a subset of resources to an app.
-        It also verifies that patients can deny refresh token access.  The tester provides a list of resources
-        that will be granted during the SMART App Launch process, and this test verifies that the scope granted
-        is consistent with what the tester provided.  It also formulates queries to ensure that the app
+        This test ensures that patients are able to grant or deny access to a subset of resources to an app.
+        It also verifies that patients can prevent issuance of a refresh token by denying the `offline_access` scope.  The tester provides a list of resources
+        that will be granted during the SMART App Launch process, and this test verifies that the scopes granted
+        are consistent with what the tester provided.  It also formulates queries to ensure that the app
         is either given access to, or denied access to, the appropriate resource types based on those chosen
         by the tester.
         
@@ -23,15 +23,15 @@ module Inferno
           * <%= resource[:resource]%><% end %>
 
         For each of the resources that can be mapped to USCDI data class or elements, this set of tests
-        performs a minimum number of requests to determine that the resource type can be accessed or denied given the
+        performs a minimum number of requests to determine if access to the resource type is appropriately allowed or denied given the
         scope granted.  In the case of the Patient resource, this test simply performs a read request.
         For other resources, it performs a search by patient that must be supported by the server.  In some cases,
         servers can return an error message if a status search parameter is not provided.  For these, the
         test will perform an additional search with the required status search parameter.
 
-        This set of tests do not attempt to access resources that do not directly map to USCDI v1, including Encounter, Location,
+        This set of tests does not attempt to access resources that do not directly map to USCDI v1, including Encounter, Location,
         Organization, Practitioner, PractionerRole, and RelatedPerson.  It also does not test Provenance, as this
-        resource type is accessed as queries through other resource types.  These resource types are accessed in the more
+        resource type is accessed by queries through other resource types.  These resource types are accessed in the more
         comprehensive Single Patient Query tests.
 
         If the tester chooses to not grant access to a resource, the queries associated with that resource must
@@ -49,16 +49,16 @@ module Inferno
         <% non_delayed_sequences.group_by{|sequence| sequence[:resource]}.values.map(&:first).each do |resource| %>
           * <%= resource[:resource] %><% end %>
 
-        For each of the resources that can be mapped to USCDI data class or elements, this set of tests
+        For each of the resource types that can be mapped to USCDI data class or elements, this set of tests
         performs a minimum number of requests to determine that the resource type can be accessed given the
         scope granted.  In the case of the Patient resource, this test simply performs a read request.
         For other resources, it performs a search by patient that must be supported by the server.  In some cases,
         servers can return an error message if a status search parameter is not provided.  For these, the
         test will perform an additional search with the required status search parameter.
-
-        This set of tests do not attempt to access resources that do not directly map to USCDI v1, including Encounter, Location,
+  
+        This set of tests does not attempt to access resources that do not directly map to USCDI v1, including Encounter, Location,
         Organization, Practitioner, PractionerRole, and RelatedPerson.  It also does not test Provenance, as this
-        resource type is accessed as queries through other resource types. These resources types are accessed in the more
+        resource type is accessed by queries through other resource types. These resources types are accessed in the more
         comprehensive Single Patient Query tests.
       )
       <% end %>

--- a/generator/uscore/templates/access_verify_sequence.rb.erb
+++ b/generator/uscore/templates/access_verify_sequence.rb.erb
@@ -7,21 +7,61 @@ module Inferno
       title '<%=access_verify_restriction.titlecase%> Resource Type Access'
 
       <% if access_verify_restriction == 'restricted' %>
+      <%# METADATA FOR RESTRICTED ACCESS TEST%>
       description 'Verify that access to resource types can be restricted to app.'
       test_id_prefix 'AVR'
+      details %(
+        This test ensures that patients have control  to grant or deny access to a subset of resources to an app.
+        It also verifies that patients can deny refresh token access.  The tester provides a list of resources
+        that will be granted during the SMART App Launch process, and this test verifies that the scope granted
+        is consistent with what the tester provided.  It also formulates queries to ensure that the app
+        is either given access to, or denied access to, the appropriate resource types based on those chosen
+        by the tester.
+        
+        Resources that can be mapped to USCDI are checked in this test, including:
+        <% non_delayed_sequences.group_by{|sequence| sequence[:resource]}.values.map(&:first).each do |resource| %>
+          * <%= resource[:resource]%><% end %>
+
+        For each of the resources that can be mapped to USCDI data class or elements, this set of tests
+        performs a minimum number of requests to determine that the resource type can be accessed or denied given the
+        scope granted.  In the case of the Patient resource, this test simply performs a read request.
+        For other resources, it performs a search by patient that must be supported by the server.  In some cases,
+        servers can return an error message if a status search parameter is not provided.  For these, the
+        test will perform an additional search with the required status search parameter.
+
+        This set of tests do not attempt to access resources that do not directly map to USCDI v1, including Encounter, Location,
+        Organization, Practitioner, PractionerRole, and RelatedPerson.  It also does not test Provenance, as this
+        resource type is accessed as queries through other resource types.  These resource types are accessed in the more
+        comprehensive Single Patient Query tests.
+
+        If the tester chooses to not grant access to a resource, the queries associated with that resource must
+        result in either a 401 (Unauthorized) or 403 (Forbidden) status code.  The flexiblity provided here
+        is due to some ambiguity in the specifications tested.
+      )
       <% else %>
+      <%# METADATA FOR FULL ACCESS TEST %>
       description 'Verify that all resource types can be accessed by apps with appropriate scopes.'
       test_id_prefix 'AVU'
-      <% end %>
-
       details %(
-      
-        The following are required to be seen:
+        This test ensures that apps have full access to USCDI resources if granted access by the tester.
+        The tester must grant access to the following resources during the SMART Launch process,
+        and this test ensures they all can be accessed:
         <% non_delayed_sequences.group_by{|sequence| sequence[:resource]}.values.map(&:first).each do |resource| %>
-          * <%= resource[:resource] + "\n" %><% end %>
-      
-      )
+          * <%= resource[:resource] %><% end %>
 
+        For each of the resources that can be mapped to USCDI data class or elements, this set of tests
+        performs a minimum number of requests to determine that the resource type can be accessed given the
+        scope granted.  In the case of the Patient resource, this test simply performs a read request.
+        For other resources, it performs a search by patient that must be supported by the server.  In some cases,
+        servers can return an error message if a status search parameter is not provided.  For these, the
+        test will perform an additional search with the required status search parameter.
+
+        This set of tests do not attempt to access resources that do not directly map to USCDI v1, including Encounter, Location,
+        Organization, Practitioner, PractionerRole, and RelatedPerson.  It also does not test Provenance, as this
+        resource type is accessed as queries through other resource types. These resources types are accessed in the more
+        comprehensive Single Patient Query tests.
+      )
+      <% end %>
       requires :onc_sl_url, :token, :patient_id, :received_scopes<% if access_verify_restriction == 'restricted' %>, :onc_sl_expected_resources<% end %>
 
       def scopes
@@ -47,17 +87,10 @@ module Inferno
         # particular resource.  In early versions of this test, these tests
         # expected a 401 (Unauthorized), but after later review it seems
         # reasonable for a server to return 403 (Forbidden) instead.  This
-        # assertion therefore allows either.  403 may be the only correct
-        # answer, but further review is required before preventing 401 from
-        # being returned because that is a large change because it may cause
-        # some previously passing servers to fail.
+        # assertion therefore allows either.
 
-        message = "Bad response code: expected 403 (Forbidden), but found #{response.code}.  401 is also allowed."
+        message = "Bad response code: expected 403 (Forbidden) or 401 (Unauthorized), but found #{response.code}."
         assert [401, 403].include?(response.code), message
-
-        warning do
-          assert response.code == 403, "403 (Forbidden) is the preferred response code for authenticated requests with insufficient authorization for the request. #{response.code} was returned."
-        end
 
       end
 

--- a/lib/modules/uscore_v3.1.0/access_verify_restricted_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/access_verify_restricted_sequence.rb
@@ -49,6 +49,25 @@ module Inferno
         @instance.onc_sl_expected_resources&.split(',')&.map { |resource| "patient/#{resource.strip}.read" }&.join(' ')
       end
 
+      def assert_response_insufficient_scope(response)
+        # This is intended for tests that are expecting the server to reject a
+        # resource request due to user not authorizing the application for that
+        # particular resource.  In early versions of this test, these tests
+        # expected a 401 (Unauthorized), but after later review it seems
+        # reasonable for a server to return 403 (Forbidden) instead.  This
+        # assertion therefore allows either.  403 may be the only correct
+        # answer, but further review is required before preventing 401 from
+        # being returned because that is a large change because it may cause
+        # some previously passing servers to fail.
+
+        message = "Bad response code: expected 403 (Forbidden), but found #{response.code}.  401 is also allowed."
+        assert [401, 403].include?(response.code), message
+
+        warning do
+          assert response.code == 403, "403 (Forbidden) is the preferred response code for authenticated requests with insufficient authorization for the request. #{response.code} was returned."
+        end
+      end
+
       def url_property
         'onc_sl_url'
       end
@@ -123,7 +142,9 @@ module Inferno
           assert_response_ok reply
           pass "Access expected to be granted and request properly returned #{reply&.response&.dig(:code)}"
         else
-          assert_response_unauthorized reply
+
+          assert_response_insufficient_scope reply
+
         end
       end
 
@@ -173,7 +194,7 @@ module Inferno
           pass "Access expected to be granted and request properly returned #{reply&.response&.dig(:code)}"
 
         else
-          assert_response_unauthorized reply
+          assert_response_insufficient_scope reply
         end
       end
 
@@ -224,7 +245,7 @@ module Inferno
           pass "Access expected to be granted and request properly returned #{reply&.response&.dig(:code)}"
 
         else
-          assert_response_unauthorized reply
+          assert_response_insufficient_scope reply
         end
       end
 
@@ -275,7 +296,7 @@ module Inferno
           pass "Access expected to be granted and request properly returned #{reply&.response&.dig(:code)}"
 
         else
-          assert_response_unauthorized reply
+          assert_response_insufficient_scope reply
         end
       end
 
@@ -325,7 +346,7 @@ module Inferno
           pass "Access expected to be granted and request properly returned #{reply&.response&.dig(:code)}"
 
         else
-          assert_response_unauthorized reply
+          assert_response_insufficient_scope reply
         end
       end
 
@@ -361,7 +382,7 @@ module Inferno
           pass "Access expected to be granted and request properly returned #{reply&.response&.dig(:code)}"
 
         else
-          assert_response_unauthorized reply
+          assert_response_insufficient_scope reply
         end
       end
 
@@ -412,7 +433,7 @@ module Inferno
           pass "Access expected to be granted and request properly returned #{reply&.response&.dig(:code)}"
 
         else
-          assert_response_unauthorized reply
+          assert_response_insufficient_scope reply
         end
       end
 
@@ -462,7 +483,7 @@ module Inferno
           pass "Access expected to be granted and request properly returned #{reply&.response&.dig(:code)}"
 
         else
-          assert_response_unauthorized reply
+          assert_response_insufficient_scope reply
         end
       end
 
@@ -512,7 +533,7 @@ module Inferno
           pass "Access expected to be granted and request properly returned #{reply&.response&.dig(:code)}"
 
         else
-          assert_response_unauthorized reply
+          assert_response_insufficient_scope reply
         end
       end
 
@@ -562,7 +583,7 @@ module Inferno
           pass "Access expected to be granted and request properly returned #{reply&.response&.dig(:code)}"
 
         else
-          assert_response_unauthorized reply
+          assert_response_insufficient_scope reply
         end
       end
 
@@ -613,7 +634,7 @@ module Inferno
           pass "Access expected to be granted and request properly returned #{reply&.response&.dig(:code)}"
 
         else
-          assert_response_unauthorized reply
+          assert_response_insufficient_scope reply
         end
       end
 
@@ -664,7 +685,7 @@ module Inferno
           pass "Access expected to be granted and request properly returned #{reply&.response&.dig(:code)}"
 
         else
-          assert_response_unauthorized reply
+          assert_response_insufficient_scope reply
         end
       end
 
@@ -714,7 +735,7 @@ module Inferno
           pass "Access expected to be granted and request properly returned #{reply&.response&.dig(:code)}"
 
         else
-          assert_response_unauthorized reply
+          assert_response_insufficient_scope reply
         end
       end
     end

--- a/lib/modules/uscore_v3.1.0/access_verify_restricted_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/access_verify_restricted_sequence.rb
@@ -8,10 +8,10 @@ module Inferno
       description 'Verify that access to resource types can be restricted to app.'
       test_id_prefix 'AVR'
       details %(
-        This test ensures that patients have control  to grant or deny access to a subset of resources to an app.
-        It also verifies that patients can deny refresh token access.  The tester provides a list of resources
-        that will be granted during the SMART App Launch process, and this test verifies that the scope granted
-        is consistent with what the tester provided.  It also formulates queries to ensure that the app
+        This test ensures that patients are able to grant or deny access to a subset of resources to an app.
+        It also verifies that patients can prevent issuance of a refresh token by denying the `offline_access` scope.  The tester provides a list of resources
+        that will be granted during the SMART App Launch process, and this test verifies that the scopes granted
+        are consistent with what the tester provided.  It also formulates queries to ensure that the app
         is either given access to, or denied access to, the appropriate resource types based on those chosen
         by the tester.
 
@@ -31,15 +31,15 @@ module Inferno
           * Procedure
 
         For each of the resources that can be mapped to USCDI data class or elements, this set of tests
-        performs a minimum number of requests to determine that the resource type can be accessed or denied given the
+        performs a minimum number of requests to determine if access to the resource type is appropriately allowed or denied given the
         scope granted.  In the case of the Patient resource, this test simply performs a read request.
         For other resources, it performs a search by patient that must be supported by the server.  In some cases,
         servers can return an error message if a status search parameter is not provided.  For these, the
         test will perform an additional search with the required status search parameter.
 
-        This set of tests do not attempt to access resources that do not directly map to USCDI v1, including Encounter, Location,
+        This set of tests does not attempt to access resources that do not directly map to USCDI v1, including Encounter, Location,
         Organization, Practitioner, PractionerRole, and RelatedPerson.  It also does not test Provenance, as this
-        resource type is accessed as queries through other resource types.  These resource types are accessed in the more
+        resource type is accessed by queries through other resource types.  These resource types are accessed in the more
         comprehensive Single Patient Query tests.
 
         If the tester chooses to not grant access to a resource, the queries associated with that resource must

--- a/lib/modules/uscore_v3.1.0/access_verify_unrestricted_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/access_verify_unrestricted_sequence.rb
@@ -25,16 +25,16 @@ module Inferno
           * Observation
           * Procedure
 
-        For each of the resources that can be mapped to USCDI data class or elements, this set of tests
+        For each of the resource types that can be mapped to USCDI data class or elements, this set of tests
         performs a minimum number of requests to determine that the resource type can be accessed given the
         scope granted.  In the case of the Patient resource, this test simply performs a read request.
         For other resources, it performs a search by patient that must be supported by the server.  In some cases,
         servers can return an error message if a status search parameter is not provided.  For these, the
         test will perform an additional search with the required status search parameter.
 
-        This set of tests do not attempt to access resources that do not directly map to USCDI v1, including Encounter, Location,
+        This set of tests does not attempt to access resources that do not directly map to USCDI v1, including Encounter, Location,
         Organization, Practitioner, PractionerRole, and RelatedPerson.  It also does not test Provenance, as this
-        resource type is accessed as queries through other resource types. These resources types are accessed in the more
+        resource type is accessed by queries through other resource types. These resources types are accessed in the more
         comprehensive Single Patient Query tests.
       )
 

--- a/lib/modules/uscore_v3.1.0/access_verify_unrestricted_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/access_verify_unrestricted_sequence.rb
@@ -7,36 +7,35 @@ module Inferno
 
       description 'Verify that all resource types can be accessed by apps with appropriate scopes.'
       test_id_prefix 'AVU'
-
       details %(
-
-        The following are required to be seen:
+        This test ensures that apps have full access to USCDI resources if granted access by the tester.
+        The tester must grant access to the following resources during the SMART Launch process,
+        and this test ensures they all can be accessed:
 
           * AllergyIntolerance
-
           * CarePlan
-
           * CareTeam
-
           * Condition
-
           * Device
-
           * DiagnosticReport
-
           * DocumentReference
-
           * Goal
-
           * Immunization
-
           * MedicationRequest
-
           * Observation
-
           * Procedure
 
+        For each of the resources that can be mapped to USCDI data class or elements, this set of tests
+        performs a minimum number of requests to determine that the resource type can be accessed given the
+        scope granted.  In the case of the Patient resource, this test simply performs a read request.
+        For other resources, it performs a search by patient that must be supported by the server.  In some cases,
+        servers can return an error message if a status search parameter is not provided.  For these, the
+        test will perform an additional search with the required status search parameter.
 
+        This set of tests do not attempt to access resources that do not directly map to USCDI v1, including Encounter, Location,
+        Organization, Practitioner, PractionerRole, and RelatedPerson.  It also does not test Provenance, as this
+        resource type is accessed as queries through other resource types. These resources types are accessed in the more
+        comprehensive Single Patient Query tests.
       )
 
       requires :onc_sl_url, :token, :patient_id, :received_scopes
@@ -70,17 +69,10 @@ module Inferno
         # particular resource.  In early versions of this test, these tests
         # expected a 401 (Unauthorized), but after later review it seems
         # reasonable for a server to return 403 (Forbidden) instead.  This
-        # assertion therefore allows either.  403 may be the only correct
-        # answer, but further review is required before preventing 401 from
-        # being returned because that is a large change because it may cause
-        # some previously passing servers to fail.
+        # assertion therefore allows either.
 
-        message = "Bad response code: expected 403 (Forbidden), but found #{response.code}.  401 is also allowed."
+        message = "Bad response code: expected 403 (Forbidden) or 401 (Unauthorized), but found #{response.code}."
         assert [401, 403].include?(response.code), message
-
-        warning do
-          assert response.code == 403, "403 (Forbidden) is the preferred response code for authenticated requests with insufficient authorization for the request. #{response.code} was returned."
-        end
       end
 
       def url_property

--- a/lib/modules/uscore_v3.1.0/access_verify_unrestricted_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/access_verify_unrestricted_sequence.rb
@@ -64,6 +64,25 @@ module Inferno
         all_resources.map { |resource| "patient/#{resource.strip}.read" }&.join(' ')
       end
 
+      def assert_response_insufficient_scope(response)
+        # This is intended for tests that are expecting the server to reject a
+        # resource request due to user not authorizing the application for that
+        # particular resource.  In early versions of this test, these tests
+        # expected a 401 (Unauthorized), but after later review it seems
+        # reasonable for a server to return 403 (Forbidden) instead.  This
+        # assertion therefore allows either.  403 may be the only correct
+        # answer, but further review is required before preventing 401 from
+        # being returned because that is a large change because it may cause
+        # some previously passing servers to fail.
+
+        message = "Bad response code: expected 403 (Forbidden), but found #{response.code}.  401 is also allowed."
+        assert [401, 403].include?(response.code), message
+
+        warning do
+          assert response.code == 403, "403 (Forbidden) is the preferred response code for authenticated requests with insufficient authorization for the request. #{response.code} was returned."
+        end
+      end
+
       def url_property
         'onc_sl_url'
       end
@@ -135,7 +154,9 @@ module Inferno
           assert_response_ok reply
           pass "Access expected to be granted and request properly returned #{reply&.response&.dig(:code)}"
         else
-          assert_response_unauthorized reply
+
+          assert_response_insufficient_scope reply
+
         end
       end
 
@@ -185,7 +206,7 @@ module Inferno
           pass "Access expected to be granted and request properly returned #{reply&.response&.dig(:code)}"
 
         else
-          assert_response_unauthorized reply
+          assert_response_insufficient_scope reply
         end
       end
 
@@ -236,7 +257,7 @@ module Inferno
           pass "Access expected to be granted and request properly returned #{reply&.response&.dig(:code)}"
 
         else
-          assert_response_unauthorized reply
+          assert_response_insufficient_scope reply
         end
       end
 
@@ -287,7 +308,7 @@ module Inferno
           pass "Access expected to be granted and request properly returned #{reply&.response&.dig(:code)}"
 
         else
-          assert_response_unauthorized reply
+          assert_response_insufficient_scope reply
         end
       end
 
@@ -337,7 +358,7 @@ module Inferno
           pass "Access expected to be granted and request properly returned #{reply&.response&.dig(:code)}"
 
         else
-          assert_response_unauthorized reply
+          assert_response_insufficient_scope reply
         end
       end
 
@@ -373,7 +394,7 @@ module Inferno
           pass "Access expected to be granted and request properly returned #{reply&.response&.dig(:code)}"
 
         else
-          assert_response_unauthorized reply
+          assert_response_insufficient_scope reply
         end
       end
 
@@ -424,7 +445,7 @@ module Inferno
           pass "Access expected to be granted and request properly returned #{reply&.response&.dig(:code)}"
 
         else
-          assert_response_unauthorized reply
+          assert_response_insufficient_scope reply
         end
       end
 
@@ -474,7 +495,7 @@ module Inferno
           pass "Access expected to be granted and request properly returned #{reply&.response&.dig(:code)}"
 
         else
-          assert_response_unauthorized reply
+          assert_response_insufficient_scope reply
         end
       end
 
@@ -524,7 +545,7 @@ module Inferno
           pass "Access expected to be granted and request properly returned #{reply&.response&.dig(:code)}"
 
         else
-          assert_response_unauthorized reply
+          assert_response_insufficient_scope reply
         end
       end
 
@@ -574,7 +595,7 @@ module Inferno
           pass "Access expected to be granted and request properly returned #{reply&.response&.dig(:code)}"
 
         else
-          assert_response_unauthorized reply
+          assert_response_insufficient_scope reply
         end
       end
 
@@ -625,7 +646,7 @@ module Inferno
           pass "Access expected to be granted and request properly returned #{reply&.response&.dig(:code)}"
 
         else
-          assert_response_unauthorized reply
+          assert_response_insufficient_scope reply
         end
       end
 
@@ -676,7 +697,7 @@ module Inferno
           pass "Access expected to be granted and request properly returned #{reply&.response&.dig(:code)}"
 
         else
-          assert_response_unauthorized reply
+          assert_response_insufficient_scope reply
         end
       end
 
@@ -726,7 +747,7 @@ module Inferno
           pass "Access expected to be granted and request properly returned #{reply&.response&.dig(:code)}"
 
         else
-          assert_response_unauthorized reply
+          assert_response_insufficient_scope reply
         end
       end
     end


### PR DESCRIPTION
The 'Limited Scope' set of tests expects the tester (acting as a patient using an app) to deny access to a subset of the resources allowed.  For those resources that are denied, the previous version of these tests required a `401 Unauthorized` status be returned by the server.  Upon further review, `403 Forbidden` is also suitable, and may be more appropriate than 401.

This PR allows the system under test to return either.  Since this update reflects a relaxation of requirements, it is suitable for a patch update to the Inferno Program set of tests.  Additional analysis is required to determine if `403 Forbidden` is the only suitable response in this case.

This PR considered adding a warning when `401` responses did not include the `WWW-Authenticate` header, as that is a requirement in the HTTP/1.1 specification.  But this was determined to be outside the scope of this PR and may be considered in future versions.

Additionally, this PR considered relaxing the requirements on status codes to expect for revoked tokens.  That set of tests also only expects a `401` status, but perhaps this is too strict.  This was also determined to be outside the scope of this PR and may be considered for future versions.

See #129 


**Submitter:**
- [x] This pull request describes why these changes were made
- [x] Internal ticket for this PR: FI-896
- [X Internal ticket links to this PR
- [X] Internal ticket is properly labeled (Community/Program)
- [X] Internal ticket has a justification for its Community/Program label
- [X] Code diff has been reviewed for extraneous/missing code
- n/a Tests are included and test edge cases
- [X] Tests/code quality metrics have been run locally and pass

This 
**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
