### PR TITLE
FI-888 fix end range problem and add unit tests

### DIFF
--- a/lib/app/sequence_base.rb
+++ b/lib/app/sequence_base.rb
@@ -801,7 +801,8 @@ module Inferno
                          if element.start.present?
                            'gt' + (DateTime.xmlschema(element.start) - 1).xmlschema
                          else
-                           'lt' + (DateTime.xmlschema(element.end) + 1).xmlschema
+                           end_datetime = get_fhir_datetime_range(element.end)[:end]
+                           'lt' + (end_datetime + 1).xmlschema
                          end
                        when FHIR::Reference
                          element.reference

--- a/test/unit/sequence_base_test.rb
+++ b/test/unit/sequence_base_test.rb
@@ -123,14 +123,50 @@ class SequenceBaseTest < MiniTest::Test
     end
 
     it 'returns value from period' do
-      { start: '2020-05-26', end: '2020-05-26' }.each do |key, value|
-        element = FHIR::Period.new(key => value)
-        expected_value = if key == :start
-                           'gt2020-05-25T00:00:00+00:00'
-                         else
-                           'lt2020-05-27T00:00:00+00:00'
-                         end
-        assert @sequence.get_value_for_search_param(element) == expected_value
+      [
+        {
+          element: FHIR::Period.new('start' => '2020'),
+          expected: 'gt2019-12-31T00:00:00+00:00'
+        },
+        {
+          element: FHIR::Period.new('start' => '2020', 'end' => '2020'),
+          expected: 'gt2019-12-31T00:00:00+00:00'
+        },
+        {
+          element: FHIR::Period.new('end' => '2020'),
+          expected: 'lt2021-01-01T23:59:59+00:00'
+        },
+        {
+          element: FHIR::Period.new('end' => '2020'),
+          expected: 'lt2021-01-01T23:59:59+00:00'
+        },
+        {
+          element: FHIR::Period.new('start' => '2020-01'),
+          expected: 'gt2019-12-31T00:00:00+00:00'
+        },
+        {
+          element: FHIR::Period.new('end' => '2020-01'),
+          expected: 'lt2020-02-01T23:59:59+00:00'
+        },
+        {
+          element: FHIR::Period.new('start' => '2020-01-01'),
+          expected: 'gt2019-12-31T00:00:00+00:00'
+        },
+        {
+          element: FHIR::Period.new('end' => '2020-01-01'),
+          expected: 'lt2020-01-02T23:59:59+00:00'
+        },
+        {
+          element: FHIR::Period.new('start' => '2015-02-07T13:28:17-05:00'),
+          expected: 'gt2015-02-06T13:28:17-05:00'
+        },
+        {
+          element: FHIR::Period.new('end' => '2015-02-07T13:28:17-05:00'),
+          expected: 'lt2015-02-08T13:28:17-05:00'
+        }
+      ].each do |expectation|
+        actual_value = @sequence.get_value_for_search_param(expectation[:element])
+        assert actual_value == expectation[:expected], "Expected: #{expectation[:expected]}, Saw: #{actual_value}"
       end
     end
 

--- a/test/unit/sequence_base_test.rb
+++ b/test/unit/sequence_base_test.rb
@@ -137,10 +137,6 @@ class SequenceBaseTest < MiniTest::Test
           expected: 'lt2021-01-01T23:59:59+00:00'
         },
         {
-          element: FHIR::Period.new('end' => '2020'),
-          expected: 'lt2021-01-01T23:59:59+00:00'
-        },
-        {
           element: FHIR::Period.new('start' => '2020-01'),
           expected: 'gt2019-12-31T00:00:00+00:00'
         },


### PR DESCRIPTION
This PR fixes an issue when getting a value to search by when the period has no start date. It also adds more unit tests for getting a search value from a period .

**Submitter:**
- [X] This pull request describes why these changes were made
- [X] Internal ticket for this PR: https://oncprojectracking.healthit.gov/support/browse/FI-888
- [X] Internal ticket links to this PR
- [X] Internal ticket is properly labeled (Community/Program)
- [X] Internal ticket has a justification for its Community/Program label
- [X] Code diff has been reviewed for extraneous/missing code
- [X] Tests are included and test edge cases
- [X] Tests/code quality metrics have been run locally and pass


**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
