### PR TITLE
FI-891: Token Exchange Unrequested Scopes

### DIFF
--- a/lib/modules/onc_program/onc_token_refresh_sequence.rb
+++ b/lib/modules/onc_program/onc_token_refresh_sequence.rb
@@ -189,7 +189,7 @@ module Inferno
 
         oauth2_headers['Authorization'] = encoded_secret(client_id, instance_client_secret) if instance_confidential_client
 
-        oauth2_params['scope'] = instance_scopes if provide_scope
+        oauth2_params['scope'] = @instance.received_scopes || instance_scopes if provide_scope
 
         LoggedRestClient.post(@instance.oauth_token_endpoint, oauth2_params, oauth2_headers)
       end

--- a/lib/modules/onc_program/onc_token_refresh_sequence.rb
+++ b/lib/modules/onc_program/onc_token_refresh_sequence.rb
@@ -172,7 +172,7 @@ module Inferno
       end
 
       def validate_and_save_refresh_response(token_response)
-        validate_token_response_contents(token_response, require_expires_in: true, check_unrequested_scopes: true)
+        validate_token_response_contents(token_response, require_expires_in: true, check_scope_subset: true)
         warning { validate_token_response_headers(token_response) }
       end
 

--- a/lib/modules/onc_program/onc_token_refresh_sequence.rb
+++ b/lib/modules/onc_program/onc_token_refresh_sequence.rb
@@ -117,6 +117,8 @@ module Inferno
             the token refresh response should include the HTTP Cache-Control response header field with a value of no-store, as well as the Pragma response header field with a value of no-cache
             to be consistent with the requirements of the inital access token exchange.
 
+            [`scopes` returned must be a strict subset of the scopes granted in the original launch](http://www.hl7.org/fhir/smart-app-launch/index.html#step-5-later-app-uses-a-refresh-token-to-obtain-a-new-access-token)
+
           )
         end
 
@@ -149,6 +151,8 @@ module Inferno
             Although not required in the token refresh portion of the SMART App Launch Guide,
             the token refresh response should include the HTTP Cache-Control response header field with a value of no-store, as well as the Pragma response header field with a value of no-cache
             to be consistent with the requirements of the inital access token exchange.
+
+            [`scopes` returned must be a strict subset of the scopes granted in the original launch](http://www.hl7.org/fhir/smart-app-launch/index.html#step-5-later-app-uses-a-refresh-token-to-obtain-a-new-access-token)
           )
         end
 

--- a/lib/modules/onc_program/onc_token_refresh_sequence.rb
+++ b/lib/modules/onc_program/onc_token_refresh_sequence.rb
@@ -168,7 +168,7 @@ module Inferno
       end
 
       def validate_and_save_refresh_response(token_response)
-        validate_token_response_contents(token_response, require_expires_in: true)
+        validate_token_response_contents(token_response, require_expires_in: true, check_unrequested_scopes: true)
         warning { validate_token_response_headers(token_response) }
       end
 

--- a/lib/modules/onc_program/shared_onc_launch_tests.rb
+++ b/lib/modules/onc_program/shared_onc_launch_tests.rb
@@ -45,7 +45,7 @@ module Inferno
         # with the one used in the ehr launch.
       end
 
-      def validate_token_response_contents(token_response, require_expires_in:)
+      def validate_token_response_contents(token_response, require_expires_in:, check_unrequested_scopes: false)
         skip_if token_response.blank?, no_token_response_message
 
         assert_valid_json(token_response.body)
@@ -101,8 +101,13 @@ module Inferno
           assert missing_scopes.empty?, "Token exchange response did not include expected scopes: #{missing_scopes}"
         end
 
-        extra_scopes = actual_scopes - expected_scopes
-        assert extra_scopes.empty?, "Token response contained unrequested scopes: #{extra_scopes.join(', ')}"
+        # During a token refresh scopes provided must be a strict sub-set of the scopes granted in the original launch.
+        # This does not apply to the original token exchange
+        # See: https://github.com/onc-healthit/inferno/issues/464 and other related issues tagged linked to that issue.
+        if check_unrequested_scopes
+          extra_scopes = actual_scopes - expected_scopes
+          assert extra_scopes.empty?, "Token response contained unrequested scopes: #{extra_scopes.join(', ')}"
+        end
 
         warning do
           assert @token_response_body['patient'].present?, 'No patient id provided in token exchange.'

--- a/lib/modules/onc_program/shared_onc_launch_tests.rb
+++ b/lib/modules/onc_program/shared_onc_launch_tests.rb
@@ -322,8 +322,7 @@ module Inferno
                 includes an access token or a message indicating that the
                 authorization request has been denied.
                 `access_token`, `token_type`, and `scope` are required. `token_type` must
-                be Bearer. `expires_in` is required for token refreshes. `scope`
-                must be a strict subset of the requested scopes, or empty.
+                be Bearer. `expires_in` is required for token refreshes.
               )
             end
 

--- a/lib/modules/onc_program/shared_onc_launch_tests.rb
+++ b/lib/modules/onc_program/shared_onc_launch_tests.rb
@@ -98,7 +98,7 @@ module Inferno
 
         warning do
           missing_scopes = expected_scopes - actual_scopes
-          assert missing_scopes.empty?, "Token exchange response did not include expected scopes: #{missing_scopes}"
+          assert missing_scopes.empty?, "Token exchange response did not include all requested scopes.  These may have been denied by user: #{missing_scopes}"
         end
 
         # During a token refresh scopes provided must be a strict sub-set of the scopes granted in the original launch.
@@ -390,7 +390,7 @@ module Inferno
               patient_scope_found = false
 
               scopes.each do |scope|
-                bad_format_message = "#{received_or_requested.capitalize} scope '#{scope}' does not follow the format: #{patient_or_user}/[ resource | * ].[ read | * ]"
+                bad_format_message = "#{received_or_requested.capitalize} scope '#{scope}' does not follow the format: `#{patient_or_user}/[ resource | * ].[ read | * ]`"
                 scope_pieces = scope.split('/')
 
                 assert scope_pieces.count == 2, bad_format_message
@@ -406,7 +406,7 @@ module Inferno
                 patient_scope_found = true
               end
 
-              assert patient_scope_found, "#{patient_or_user.capitalize}-level scope in the format: #{patient_or_user}/[ resource | * ].[ read | *] was not #{received_or_requested}."
+              assert patient_scope_found, "#{patient_or_user.capitalize}-level scope in the format: `#{patient_or_user}/[ resource | * ].[ read | *]` was not #{received_or_requested}."
             end
           end
         end

--- a/lib/modules/onc_program/shared_onc_launch_tests.rb
+++ b/lib/modules/onc_program/shared_onc_launch_tests.rb
@@ -106,7 +106,7 @@ module Inferno
         # See: https://github.com/onc-healthit/inferno/issues/464 and other related issues tagged linked to that issue.
         if check_scope_subset
           extra_scopes = actual_scopes - @instance.received_scopes.split(' ')
-          assert extra_scopes.empty?, "Token response contained scopes which are not a subset of those provided in the original launch: #{extra_scopes.join(', ')}"
+          assert extra_scopes.empty?, "Token response contained scope which is not a subset of the scope granted to the original access token: #{extra_scopes.join(', ')}"
         end
 
         warning do

--- a/lib/modules/onc_program/shared_onc_launch_tests.rb
+++ b/lib/modules/onc_program/shared_onc_launch_tests.rb
@@ -45,7 +45,7 @@ module Inferno
         # with the one used in the ehr launch.
       end
 
-      def validate_token_response_contents(token_response, require_expires_in:, check_unrequested_scopes: false)
+      def validate_token_response_contents(token_response, require_expires_in:, check_scope_subset: false)
         skip_if token_response.blank?, no_token_response_message
 
         assert_valid_json(token_response.body)
@@ -104,9 +104,9 @@ module Inferno
         # During a token refresh scopes provided must be a strict sub-set of the scopes granted in the original launch.
         # This does not apply to the original token exchange
         # See: https://github.com/onc-healthit/inferno/issues/464 and other related issues tagged linked to that issue.
-        if check_unrequested_scopes
-          extra_scopes = actual_scopes - expected_scopes
-          assert extra_scopes.empty?, "Token response contained unrequested scopes: #{extra_scopes.join(', ')}"
+        if check_scope_subset
+          extra_scopes = actual_scopes - @instance.received_scopes.split(' ')
+          assert extra_scopes.empty?, "Token response contained scopes which are not a subset of those provided in the original launch: #{extra_scopes.join(', ')}"
         end
 
         warning do

--- a/lib/modules/onc_program/test/onc_ehr_launch_sequence_test.rb
+++ b/lib/modules/onc_program/test/onc_ehr_launch_sequence_test.rb
@@ -51,7 +51,7 @@ describe Inferno::Sequence::OncEHRLaunchSequence do
       @instance.instance_variable_set(:@scopes, @sequence.required_scopes.join(' '))
       exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
 
-      assert_equal 'User-level scope in the format: user/[ resource | * ].[ read | *] was not requested.', exception.message
+      assert_equal 'User-level scope in the format: `user/[ resource | * ].[ read | *]` was not requested.', exception.message
     end
 
     it 'fails when no user-level scope was received' do
@@ -59,7 +59,7 @@ describe Inferno::Sequence::OncEHRLaunchSequence do
       @instance.instance_variable_set(:@received_scopes, @sequence.required_scopes.join(' '))
       exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
 
-      assert_equal 'User-level scope in the format: user/[ resource | * ].[ read | *] was not received.', exception.message
+      assert_equal 'User-level scope in the format: `user/[ resource | * ].[ read | *]` was not received.', exception.message
     end
 
     it 'fails when a badly formatted scope was requested' do
@@ -68,7 +68,7 @@ describe Inferno::Sequence::OncEHRLaunchSequence do
         @instance.instance_variable_set(:@scopes, (@sequence.required_scopes + [scope]).join(' '))
         exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
 
-        assert_equal "Requested scope '#{scope}' does not follow the format: user/[ resource | * ].[ read | * ]", exception.message
+        assert_equal "Requested scope '#{scope}' does not follow the format: `user/[ resource | * ].[ read | * ]`", exception.message
       end
 
       bad_resource_type = 'ValueSet'
@@ -87,7 +87,7 @@ describe Inferno::Sequence::OncEHRLaunchSequence do
         @instance.instance_variable_set(:@received_scopes, (@sequence.required_scopes + [scope]).join(' '))
         exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
 
-        assert_equal "Received scope '#{scope}' does not follow the format: user/[ resource | * ].[ read | * ]", exception.message
+        assert_equal "Received scope '#{scope}' does not follow the format: `user/[ resource | * ].[ read | * ]`", exception.message
       end
 
       bad_resource_type = 'ValueSet'

--- a/lib/modules/onc_program/test/onc_standalone_launch_sequence_test.rb
+++ b/lib/modules/onc_program/test/onc_standalone_launch_sequence_test.rb
@@ -51,7 +51,7 @@ describe Inferno::Sequence::OncStandaloneLaunchSequence do
       @instance.instance_variable_set(:@onc_sl_scopes, @sequence.required_scopes.join(' '))
       exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
 
-      assert_equal 'Patient-level scope in the format: patient/[ resource | * ].[ read | *] was not requested.', exception.message
+      assert_equal 'Patient-level scope in the format: `patient/[ resource | * ].[ read | *]` was not requested.', exception.message
     end
 
     it 'fails when no patient-level scope was received' do
@@ -59,7 +59,7 @@ describe Inferno::Sequence::OncStandaloneLaunchSequence do
       @instance.instance_variable_set(:@received_scopes, @sequence.required_scopes.join(' '))
       exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
 
-      assert_equal 'Patient-level scope in the format: patient/[ resource | * ].[ read | *] was not received.', exception.message
+      assert_equal 'Patient-level scope in the format: `patient/[ resource | * ].[ read | *]` was not received.', exception.message
     end
 
     it 'fails when a badly formatted scope was requested' do
@@ -68,7 +68,7 @@ describe Inferno::Sequence::OncStandaloneLaunchSequence do
         @instance.instance_variable_set(:@onc_sl_scopes, (@sequence.required_scopes + [scope]).join(' '))
         exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
 
-        assert_equal "Requested scope '#{scope}' does not follow the format: patient/[ resource | * ].[ read | * ]", exception.message
+        assert_equal "Requested scope '#{scope}' does not follow the format: `patient/[ resource | * ].[ read | * ]`", exception.message
       end
 
       bad_resource_type = 'ValueSet'
@@ -87,7 +87,7 @@ describe Inferno::Sequence::OncStandaloneLaunchSequence do
         @instance.instance_variable_set(:@received_scopes, (@sequence.required_scopes + [scope]).join(' '))
         exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
 
-        assert_equal "Received scope '#{scope}' does not follow the format: patient/[ resource | * ].[ read | * ]", exception.message
+        assert_equal "Received scope '#{scope}' does not follow the format: `patient/[ resource | * ].[ read | * ]`", exception.message
       end
 
       bad_resource_type = 'ValueSet'

--- a/lib/modules/onc_program/test/onc_standalone_token_refresh_sequence_test.rb
+++ b/lib/modules/onc_program/test/onc_standalone_token_refresh_sequence_test.rb
@@ -20,7 +20,8 @@ describe Inferno::Sequence::OncStandaloneTokenRefreshSequence do
       oauth_token_endpoint: @token_endpoint,
       scopes: 'bad',
       onc_sl_scopes: 'jkl',
-      refresh_token: 'abc'
+      refresh_token: 'abc',
+      received_scopes: 'jkl'
     )
     @instance.instance_variable_set(:'@module', OpenStruct.new(fhir_version: 'r4'))
     @sequence = @sequence_class.new(@instance, @client)
@@ -261,7 +262,8 @@ class OncStandaloneTokenRefreshSequenceTest < MiniTest::Test
       redirect_uris: 'http://localhost:4567/redirect',
       scopes: 'launch/patient online_access openid profile launch user/*.* patient/*.*',
       onc_sl_scopes: 'launch/patient online_access openid profile launch user/*.* patient/*.*',
-      refresh_token: refresh_token
+      refresh_token: refresh_token,
+      received_scopes: 'launch/patient online_access openid profile launch user/*.* patient/*.*'
     )
     @instance.instance_variable_set(:'@module', OpenStruct.new(fhir_version: 'r4'))
 

--- a/lib/modules/onc_program/test/onc_standalone_token_refresh_sequence_test.rb
+++ b/lib/modules/onc_program/test/onc_standalone_token_refresh_sequence_test.rb
@@ -202,7 +202,7 @@ describe Inferno::Sequence::OncStandaloneTokenRefreshSequence do
       @sequence.validate_and_save_refresh_response(successful_response)
 
       warnings = @sequence.instance_variable_get(:'@test_warnings')
-      assert_includes(warnings, 'Token exchange response did not include expected scopes: ["mno"]')
+      assert_includes(warnings, 'Token exchange response did not include all requested scopes.  These may have been denied by user: ["mno"]')
     end
 
     it 'creates a warning when the body has no patient field' do

--- a/lib/modules/onc_program/test/onc_token_refresh_sequence_test.rb
+++ b/lib/modules/onc_program/test/onc_token_refresh_sequence_test.rb
@@ -19,7 +19,8 @@ describe Inferno::Sequence::OncTokenRefreshSequence do
     @instance = Inferno::Models::TestingInstance.create(
       oauth_token_endpoint: @token_endpoint,
       scopes: 'jkl',
-      refresh_token: 'abc'
+      refresh_token: 'abc',
+      received_scopes: 'jkl'
     )
     @instance.instance_variable_set(:'@module', OpenStruct.new(fhir_version: 'r4'))
     @sequence = @sequence_class.new(@instance, @client)
@@ -257,7 +258,8 @@ class OncTokenRefreshSequenceTest < MiniTest::Test
       initiate_login_uri: 'http://localhost:4567/launch',
       redirect_uris: 'http://localhost:4567/redirect',
       scopes: 'launch/patient online_access openid profile launch user/*.* patient/*.*',
-      refresh_token: @refresh_token
+      refresh_token: @refresh_token,
+      received_scopes: 'launch/patient online_access openid profile launch user/*.* patient/*.*'
     )
     @instance.instance_variable_set(:'@module', OpenStruct.new(fhir_version: 'r4'))
 

--- a/lib/modules/onc_program/test/onc_token_refresh_sequence_test.rb
+++ b/lib/modules/onc_program/test/onc_token_refresh_sequence_test.rb
@@ -201,7 +201,7 @@ describe Inferno::Sequence::OncTokenRefreshSequence do
       @sequence.validate_and_save_refresh_response(successful_response)
 
       warnings = @sequence.instance_variable_get(:'@test_warnings')
-      assert_includes(warnings, 'Token exchange response did not include expected scopes: ["mno"]')
+      assert_includes(warnings, 'Token exchange response did not include all requested scopes.  These may have been denied by user: ["mno"]')
     end
 
     it 'creates a warning when the body has no patient field' do

--- a/lib/modules/smart/shared_launch_tests.rb
+++ b/lib/modules/smart/shared_launch_tests.rb
@@ -23,7 +23,7 @@ module Inferno
         "State provided in redirect (#{@params[:state]}) does not match expected state (#{@instance.state})."
       end
 
-      def validate_token_response_contents(token_response, require_expires_in:, check_unrequested_scopes: false)
+      def validate_token_response_contents(token_response, require_expires_in:, check_scope_subset: false)
         skip_if token_response.blank?, no_token_response_message
 
         assert_valid_json(token_response.body)
@@ -79,9 +79,9 @@ module Inferno
         # During a token refresh scopes provided must be a strict sub-set of the scopes granted in the original launch.
         # This does not apply to the original token exchange
         # See: https://github.com/onc-healthit/inferno/issues/464 and other related issues tagged linked to that issue.
-        if check_unrequested_scopes
-          extra_scopes = actual_scopes - expected_scopes
-          assert extra_scopes.empty?, "Token response contained unrequested scopes: #{extra_scopes.join(', ')}"
+        if check_scope_subset
+          extra_scopes = actual_scopes - @instance.received_scopes.split(' ')
+          assert extra_scopes.empty?, "Token response contained scopes which are not a subset of those provided in the original launch: #{extra_scopes.join(', ')}"
         end
 
         warning do

--- a/lib/modules/smart/shared_launch_tests.rb
+++ b/lib/modules/smart/shared_launch_tests.rb
@@ -23,7 +23,7 @@ module Inferno
         "State provided in redirect (#{@params[:state]}) does not match expected state (#{@instance.state})."
       end
 
-      def validate_token_response_contents(token_response, require_expires_in:)
+      def validate_token_response_contents(token_response, require_expires_in:, check_unrequested_scopes: false)
         skip_if token_response.blank?, no_token_response_message
 
         assert_valid_json(token_response.body)
@@ -76,8 +76,13 @@ module Inferno
           assert missing_scopes.empty?, "Token exchange response did not include expected scopes: #{missing_scopes}"
         end
 
-        extra_scopes = actual_scopes - expected_scopes
-        assert extra_scopes.empty?, "Token response contained unrequested scopes: #{extra_scopes.join(', ')}"
+        # During a token refresh scopes provided must be a strict sub-set of the scopes granted in the original launch.
+        # This does not apply to the original token exchange
+        # See: https://github.com/onc-healthit/inferno/issues/464 and other related issues tagged linked to that issue.
+        if check_unrequested_scopes
+          extra_scopes = actual_scopes - expected_scopes
+          assert extra_scopes.empty?, "Token response contained unrequested scopes: #{extra_scopes.join(', ')}"
+        end
 
         warning do
           assert @token_response_body['patient'].present?, 'No patient id provided in token exchange.'
@@ -285,8 +290,7 @@ module Inferno
                 includes an access token or a message indicating that the
                 authorization request has been denied.
                 `access_token`, `token_type`, and `scope` are required. `token_type` must
-                be Bearer. `expires_in` is required for token refreshes. `scope`
-                must be a strict subset of the requested scopes, or empty.
+                be Bearer. `expires_in` is required for token refreshes.
               )
             end
 

--- a/lib/modules/smart/test/shared_launch_tests_test.rb
+++ b/lib/modules/smart/test/shared_launch_tests_test.rb
@@ -400,7 +400,7 @@ describe Inferno::Sequence::SharedLaunchTests do
       assert_equal 'Token response did not contain scope as required', exception.message
     end
 
-    it 'fails if the token response contains unrequestesd scopes' do
+    it 'succeeds if the token response contains unrequestesd scopes' do
       @instance.scopes = 'DEF'
       response = {
         access_token: 'ABC',
@@ -409,9 +409,7 @@ describe Inferno::Sequence::SharedLaunchTests do
       }
 
       @sequence.instance_variable_set(:@token_response, OpenStruct.new(body: response.to_json))
-      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
-
-      assert_equal 'Token response contained unrequested scopes: GHI', exception.message
+      @sequence.run_test(@test)
     end
 
     it 'fails if the token_type is not "bearer"' do

--- a/lib/modules/smart/test/token_refresh_sequence_test.rb
+++ b/lib/modules/smart/test/token_refresh_sequence_test.rb
@@ -14,10 +14,10 @@ describe Inferno::Sequence::TokenRefreshSequence do
 
   let(:unrequested_scope_body) do
     {
-        'access_token' => 'abc',
-        'expires_in' => 300,
-        'token_type' => 'Bearer',
-        'scope' => 'jkl asd'
+      'access_token' => 'abc',
+      'expires_in' => 300,
+      'token_type' => 'Bearer',
+      'scope' => 'jkl asd'
     }
   end
 
@@ -127,10 +127,9 @@ describe Inferno::Sequence::TokenRefreshSequence do
     end
 
     it 'fails when the token refresh includes unrequested scopes' do
-
       stub_request(:post, @token_endpoint)
-          .with(body: hash_including(scope: 'jkl'))
-          .to_return(status: 200, body: unrequested_scope_body.to_json, headers: {})
+        .with(body: hash_including(scope: 'jkl'))
+        .to_return(status: 200, body: unrequested_scope_body.to_json, headers: {})
 
       exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
       assert_equal 'Token response contained unrequested scopes: asd', exception.message
@@ -168,10 +167,9 @@ describe Inferno::Sequence::TokenRefreshSequence do
     end
 
     it 'fails when the token refresh includes unrequested scopes' do
-
       stub_request(:post, @token_endpoint)
-          .with { |request| !request.body.include? 'scope' }
-          .to_return(status: 200, body: unrequested_scope_body.to_json, headers: {})
+        .with { |request| !request.body.include? 'scope' }
+        .to_return(status: 200, body: unrequested_scope_body.to_json, headers: {})
 
       exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
       assert_equal 'Token response contained unrequested scopes: asd', exception.message

--- a/lib/modules/smart/token_refresh_sequence.rb
+++ b/lib/modules/smart/token_refresh_sequence.rb
@@ -138,7 +138,7 @@ module Inferno
       end
 
       def validate_and_save_refresh_response(token_response)
-        validate_token_response_contents(token_response, require_expires_in: true, check_unrequested_scopes: true)
+        validate_token_response_contents(token_response, require_expires_in: true, check_scope_subset: true)
         warning { validate_token_response_headers(token_response) }
       end
 

--- a/lib/modules/smart/token_refresh_sequence.rb
+++ b/lib/modules/smart/token_refresh_sequence.rb
@@ -117,6 +117,8 @@ module Inferno
             Although not required in the token refresh portion of the SMART App Launch Guide,
             the token refresh response should include the HTTP Cache-Control response header field with a value of no-store, as well as the Pragma response header field with a value of no-cache
             to be consistent with the requirements of the inital access token exchange.
+
+            [`scopes` returned must be a strict subset of the scopes granted in the original launch](http://www.hl7.org/fhir/smart-app-launch/index.html#step-5-later-app-uses-a-refresh-token-to-obtain-a-new-access-token)
           )
         end
 

--- a/lib/modules/smart/token_refresh_sequence.rb
+++ b/lib/modules/smart/token_refresh_sequence.rb
@@ -86,6 +86,8 @@ module Inferno
             the token refresh response should include the HTTP Cache-Control response header field with a value of no-store, as well as the Pragma response header field with a value of no-cache
             to be consistent with the requirements of the inital access token exchange.
 
+            [`scopes` returned must be a strict subset of the scopes granted in the original launch](http://www.hl7.org/fhir/smart-app-launch/index.html#step-5-later-app-uses-a-refresh-token-to-obtain-a-new-access-token)
+
           )
         end
 
@@ -134,7 +136,7 @@ module Inferno
       end
 
       def validate_and_save_refresh_response(token_response)
-        validate_token_response_contents(token_response, require_expires_in: true)
+        validate_token_response_contents(token_response, require_expires_in: true, check_unrequested_scopes: true)
         warning { validate_token_response_headers(token_response) }
       end
 


### PR DESCRIPTION
Fix checks for unrequested scopes to only apply to token refresh.  This check was erroneously applied to the initial OAuth 2.0 token exchange.

[JIRA Issue](https://oncprojectracking.healthit.gov/support/browse/FI-891)
Relevant GH Issue: https://github.com/onc-healthit/inferno/issues/464

**Submitter:**
- [x] This pull request describes why these changes were made
- [x] Internal ticket for this PR:
- [x] Internal ticket links to this PR
- [x] Internal ticket is properly labeled (Community/Program)
- [ ] Internal ticket has a justification for its Community/Program label
- [x] Code diff has been reviewed for extraneous/missing code
- [x] Tests are included and test edge cases
- [x] Tests/code quality metrics have been run locally and pass


**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
