### PR TITLE
fix period comparator search

### DIFF
--- a/generator/uscore/uscore_generator.rb
+++ b/generator/uscore/uscore_generator.rb
@@ -1181,14 +1181,14 @@ module Inferno
         search_code = ''
         param_comparators = find_comparators(search_params, sequence)
         param_comparators.each do |param, comparators|
-          param_val_name = param_value_name(param)
           param_info = sequence[:search_param_descriptions][param.to_sym]
+          get_element_string = "#{resolve_element_path(param_info, sequence[:delayed_sequence])} { |el| get_value_for_search_param(el).present? }"
           type = param_info[:type]
           case type
           when 'Period', 'date'
             search_code += %(\n
               [#{comparators.keys.map { |comparator| "'#{comparator}'" }.join(', ')}].each do |comparator|
-                comparator_val = date_comparator_value(comparator, #{resolve_element_path(param_info, sequence[:delayed_sequence])} { |el| get_value_for_search_param(el).present? })
+                comparator_val = date_comparator_value(comparator, #{get_element_string})
                 comparator_search_params = search_params.merge('#{param}': comparator_val)
                 reply = get_resource_by_params(versioned_resource_class('#{sequence[:resource]}'), comparator_search_params)
                 validate_search_reply(versioned_resource_class('#{sequence[:resource]}'), reply, comparator_search_params)

--- a/generator/uscore/uscore_generator.rb
+++ b/generator/uscore/uscore_generator.rb
@@ -1188,7 +1188,7 @@ module Inferno
           when 'Period', 'date'
             search_code += %(\n
               [#{comparators.keys.map { |comparator| "'#{comparator}'" }.join(', ')}].each do |comparator|
-                comparator_val = date_comparator_value(comparator, #{param_val_name})
+                comparator_val = date_comparator_value(comparator, #{resolve_element_path(param_info, sequence[:delayed_sequence])} { |el| get_value_for_search_param(el).present? })
                 comparator_search_params = search_params.merge('#{param}': comparator_val)
                 reply = get_resource_by_params(versioned_resource_class('#{sequence[:resource]}'), comparator_search_params)
                 validate_search_reply(versioned_resource_class('#{sequence[:resource]}'), reply, comparator_search_params)

--- a/lib/app/models/request_response.rb
+++ b/lib/app/models/request_response.rb
@@ -14,7 +14,7 @@ module Inferno
       property :response_body, Text
       property :direction, String
       property :instance_id, String
-      property :request_index, Serial, unique_index: true
+      property :request_index, String, unique_index: true
 
       property :timestamp, DateTime, default: proc { DateTime.now }
 

--- a/lib/app/models/request_response.rb
+++ b/lib/app/models/request_response.rb
@@ -14,7 +14,7 @@ module Inferno
       property :response_body, Text
       property :direction, String
       property :instance_id, String
-      property :request_index, String, unique_index: true
+      property :request_index, Serial, unique_index: true
 
       property :timestamp, DateTime, default: proc { DateTime.now }
 

--- a/lib/app/sequence_base.rb
+++ b/lib/app/sequence_base.rb
@@ -841,9 +841,9 @@ module Inferno
 
         case comparator
         when 'lt', 'le'
-          comparator + (DateTime.xmlschema(date) + 1).xmlschema
+          comparator + (DateTime.xmlschema(date) + 2).xmlschema
         when 'gt', 'ge'
-          comparator + (DateTime.xmlschema(date) - 1).xmlschema
+          comparator + (DateTime.xmlschema(date) - 2).xmlschema
         else
           ''
         end

--- a/lib/app/sequence_base.rb
+++ b/lib/app/sequence_base.rb
@@ -837,13 +837,12 @@ module Inferno
       end
 
       def date_comparator_value(comparator, date)
-        date = date.slice(2..-1) if ['gt', 'ge', 'lt', 'le'].include? date[0, 2]
-
+        date = date.start || date.end if date.is_a? FHIR::Period
         case comparator
         when 'lt', 'le'
-          comparator + (DateTime.xmlschema(date) + 2).xmlschema
+          comparator + (DateTime.xmlschema(date) + 1).xmlschema
         when 'gt', 'ge'
-          comparator + (DateTime.xmlschema(date) - 2).xmlschema
+          comparator + (DateTime.xmlschema(date) - 1).xmlschema
         else
           ''
         end

--- a/lib/modules/uscore_v3.1.0/bodyheight_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/bodyheight_sequence.rb
@@ -259,7 +259,7 @@ module Inferno
           validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
 
           ['gt', 'lt', 'le', 'ge'].each do |comparator|
-            comparator_val = date_comparator_value(comparator, search_params[:date])
+            comparator_val = date_comparator_value(comparator, resolve_element_from_path(@observation_ary[patient], 'effective') { |el| get_value_for_search_param(el).present? })
             comparator_search_params = search_params.merge('date': comparator_val)
             reply = get_resource_by_params(versioned_resource_class('Observation'), comparator_search_params)
             validate_search_reply(versioned_resource_class('Observation'), reply, comparator_search_params)
@@ -360,7 +360,7 @@ module Inferno
           validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
 
           ['gt', 'lt', 'le', 'ge'].each do |comparator|
-            comparator_val = date_comparator_value(comparator, search_params[:date])
+            comparator_val = date_comparator_value(comparator, resolve_element_from_path(@observation_ary[patient], 'effective') { |el| get_value_for_search_param(el).present? })
             comparator_search_params = search_params.merge('date': comparator_val)
             reply = get_resource_by_params(versioned_resource_class('Observation'), comparator_search_params)
             validate_search_reply(versioned_resource_class('Observation'), reply, comparator_search_params)

--- a/lib/modules/uscore_v3.1.0/bodytemp_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/bodytemp_sequence.rb
@@ -259,7 +259,7 @@ module Inferno
           validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
 
           ['gt', 'lt', 'le', 'ge'].each do |comparator|
-            comparator_val = date_comparator_value(comparator, search_params[:date])
+            comparator_val = date_comparator_value(comparator, resolve_element_from_path(@observation_ary[patient], 'effective') { |el| get_value_for_search_param(el).present? })
             comparator_search_params = search_params.merge('date': comparator_val)
             reply = get_resource_by_params(versioned_resource_class('Observation'), comparator_search_params)
             validate_search_reply(versioned_resource_class('Observation'), reply, comparator_search_params)
@@ -360,7 +360,7 @@ module Inferno
           validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
 
           ['gt', 'lt', 'le', 'ge'].each do |comparator|
-            comparator_val = date_comparator_value(comparator, search_params[:date])
+            comparator_val = date_comparator_value(comparator, resolve_element_from_path(@observation_ary[patient], 'effective') { |el| get_value_for_search_param(el).present? })
             comparator_search_params = search_params.merge('date': comparator_val)
             reply = get_resource_by_params(versioned_resource_class('Observation'), comparator_search_params)
             validate_search_reply(versioned_resource_class('Observation'), reply, comparator_search_params)

--- a/lib/modules/uscore_v3.1.0/bodyweight_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/bodyweight_sequence.rb
@@ -259,7 +259,7 @@ module Inferno
           validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
 
           ['gt', 'lt', 'le', 'ge'].each do |comparator|
-            comparator_val = date_comparator_value(comparator, search_params[:date])
+            comparator_val = date_comparator_value(comparator, resolve_element_from_path(@observation_ary[patient], 'effective') { |el| get_value_for_search_param(el).present? })
             comparator_search_params = search_params.merge('date': comparator_val)
             reply = get_resource_by_params(versioned_resource_class('Observation'), comparator_search_params)
             validate_search_reply(versioned_resource_class('Observation'), reply, comparator_search_params)
@@ -360,7 +360,7 @@ module Inferno
           validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
 
           ['gt', 'lt', 'le', 'ge'].each do |comparator|
-            comparator_val = date_comparator_value(comparator, search_params[:date])
+            comparator_val = date_comparator_value(comparator, resolve_element_from_path(@observation_ary[patient], 'effective') { |el| get_value_for_search_param(el).present? })
             comparator_search_params = search_params.merge('date': comparator_val)
             reply = get_resource_by_params(versioned_resource_class('Observation'), comparator_search_params)
             validate_search_reply(versioned_resource_class('Observation'), reply, comparator_search_params)

--- a/lib/modules/uscore_v3.1.0/bp_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/bp_sequence.rb
@@ -259,7 +259,7 @@ module Inferno
           validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
 
           ['gt', 'lt', 'le', 'ge'].each do |comparator|
-            comparator_val = date_comparator_value(comparator, search_params[:date])
+            comparator_val = date_comparator_value(comparator, resolve_element_from_path(@observation_ary[patient], 'effective') { |el| get_value_for_search_param(el).present? })
             comparator_search_params = search_params.merge('date': comparator_val)
             reply = get_resource_by_params(versioned_resource_class('Observation'), comparator_search_params)
             validate_search_reply(versioned_resource_class('Observation'), reply, comparator_search_params)
@@ -360,7 +360,7 @@ module Inferno
           validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
 
           ['gt', 'lt', 'le', 'ge'].each do |comparator|
-            comparator_val = date_comparator_value(comparator, search_params[:date])
+            comparator_val = date_comparator_value(comparator, resolve_element_from_path(@observation_ary[patient], 'effective') { |el| get_value_for_search_param(el).present? })
             comparator_search_params = search_params.merge('date': comparator_val)
             reply = get_resource_by_params(versioned_resource_class('Observation'), comparator_search_params)
             validate_search_reply(versioned_resource_class('Observation'), reply, comparator_search_params)

--- a/lib/modules/uscore_v3.1.0/headcircum_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/headcircum_sequence.rb
@@ -259,7 +259,7 @@ module Inferno
           validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
 
           ['gt', 'lt', 'le', 'ge'].each do |comparator|
-            comparator_val = date_comparator_value(comparator, search_params[:date])
+            comparator_val = date_comparator_value(comparator, resolve_element_from_path(@observation_ary[patient], 'effective') { |el| get_value_for_search_param(el).present? })
             comparator_search_params = search_params.merge('date': comparator_val)
             reply = get_resource_by_params(versioned_resource_class('Observation'), comparator_search_params)
             validate_search_reply(versioned_resource_class('Observation'), reply, comparator_search_params)
@@ -360,7 +360,7 @@ module Inferno
           validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
 
           ['gt', 'lt', 'le', 'ge'].each do |comparator|
-            comparator_val = date_comparator_value(comparator, search_params[:date])
+            comparator_val = date_comparator_value(comparator, resolve_element_from_path(@observation_ary[patient], 'effective') { |el| get_value_for_search_param(el).present? })
             comparator_search_params = search_params.merge('date': comparator_val)
             reply = get_resource_by_params(versioned_resource_class('Observation'), comparator_search_params)
             validate_search_reply(versioned_resource_class('Observation'), reply, comparator_search_params)

--- a/lib/modules/uscore_v3.1.0/heartrate_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/heartrate_sequence.rb
@@ -259,7 +259,7 @@ module Inferno
           validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
 
           ['gt', 'lt', 'le', 'ge'].each do |comparator|
-            comparator_val = date_comparator_value(comparator, search_params[:date])
+            comparator_val = date_comparator_value(comparator, resolve_element_from_path(@observation_ary[patient], 'effective') { |el| get_value_for_search_param(el).present? })
             comparator_search_params = search_params.merge('date': comparator_val)
             reply = get_resource_by_params(versioned_resource_class('Observation'), comparator_search_params)
             validate_search_reply(versioned_resource_class('Observation'), reply, comparator_search_params)
@@ -360,7 +360,7 @@ module Inferno
           validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
 
           ['gt', 'lt', 'le', 'ge'].each do |comparator|
-            comparator_val = date_comparator_value(comparator, search_params[:date])
+            comparator_val = date_comparator_value(comparator, resolve_element_from_path(@observation_ary[patient], 'effective') { |el| get_value_for_search_param(el).present? })
             comparator_search_params = search_params.merge('date': comparator_val)
             reply = get_resource_by_params(versioned_resource_class('Observation'), comparator_search_params)
             validate_search_reply(versioned_resource_class('Observation'), reply, comparator_search_params)

--- a/lib/modules/uscore_v3.1.0/pediatric_bmi_for_age_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/pediatric_bmi_for_age_sequence.rb
@@ -259,7 +259,7 @@ module Inferno
           validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
 
           ['gt', 'lt', 'le', 'ge'].each do |comparator|
-            comparator_val = date_comparator_value(comparator, search_params[:date])
+            comparator_val = date_comparator_value(comparator, resolve_element_from_path(@observation_ary[patient], 'effective') { |el| get_value_for_search_param(el).present? })
             comparator_search_params = search_params.merge('date': comparator_val)
             reply = get_resource_by_params(versioned_resource_class('Observation'), comparator_search_params)
             validate_search_reply(versioned_resource_class('Observation'), reply, comparator_search_params)
@@ -360,7 +360,7 @@ module Inferno
           validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
 
           ['gt', 'lt', 'le', 'ge'].each do |comparator|
-            comparator_val = date_comparator_value(comparator, search_params[:date])
+            comparator_val = date_comparator_value(comparator, resolve_element_from_path(@observation_ary[patient], 'effective') { |el| get_value_for_search_param(el).present? })
             comparator_search_params = search_params.merge('date': comparator_val)
             reply = get_resource_by_params(versioned_resource_class('Observation'), comparator_search_params)
             validate_search_reply(versioned_resource_class('Observation'), reply, comparator_search_params)

--- a/lib/modules/uscore_v3.1.0/pediatric_weight_for_height_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/pediatric_weight_for_height_sequence.rb
@@ -259,7 +259,7 @@ module Inferno
           validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
 
           ['gt', 'lt', 'le', 'ge'].each do |comparator|
-            comparator_val = date_comparator_value(comparator, search_params[:date])
+            comparator_val = date_comparator_value(comparator, resolve_element_from_path(@observation_ary[patient], 'effective') { |el| get_value_for_search_param(el).present? })
             comparator_search_params = search_params.merge('date': comparator_val)
             reply = get_resource_by_params(versioned_resource_class('Observation'), comparator_search_params)
             validate_search_reply(versioned_resource_class('Observation'), reply, comparator_search_params)
@@ -360,7 +360,7 @@ module Inferno
           validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
 
           ['gt', 'lt', 'le', 'ge'].each do |comparator|
-            comparator_val = date_comparator_value(comparator, search_params[:date])
+            comparator_val = date_comparator_value(comparator, resolve_element_from_path(@observation_ary[patient], 'effective') { |el| get_value_for_search_param(el).present? })
             comparator_search_params = search_params.merge('date': comparator_val)
             reply = get_resource_by_params(versioned_resource_class('Observation'), comparator_search_params)
             validate_search_reply(versioned_resource_class('Observation'), reply, comparator_search_params)

--- a/lib/modules/uscore_v3.1.0/resprate_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/resprate_sequence.rb
@@ -259,7 +259,7 @@ module Inferno
           validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
 
           ['gt', 'lt', 'le', 'ge'].each do |comparator|
-            comparator_val = date_comparator_value(comparator, search_params[:date])
+            comparator_val = date_comparator_value(comparator, resolve_element_from_path(@observation_ary[patient], 'effective') { |el| get_value_for_search_param(el).present? })
             comparator_search_params = search_params.merge('date': comparator_val)
             reply = get_resource_by_params(versioned_resource_class('Observation'), comparator_search_params)
             validate_search_reply(versioned_resource_class('Observation'), reply, comparator_search_params)
@@ -360,7 +360,7 @@ module Inferno
           validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
 
           ['gt', 'lt', 'le', 'ge'].each do |comparator|
-            comparator_val = date_comparator_value(comparator, search_params[:date])
+            comparator_val = date_comparator_value(comparator, resolve_element_from_path(@observation_ary[patient], 'effective') { |el| get_value_for_search_param(el).present? })
             comparator_search_params = search_params.merge('date': comparator_val)
             reply = get_resource_by_params(versioned_resource_class('Observation'), comparator_search_params)
             validate_search_reply(versioned_resource_class('Observation'), reply, comparator_search_params)

--- a/lib/modules/uscore_v3.1.0/us_core_diagnosticreport_lab_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_diagnosticreport_lab_sequence.rb
@@ -336,7 +336,7 @@ module Inferno
           validate_search_reply(versioned_resource_class('DiagnosticReport'), reply, search_params)
 
           ['gt', 'lt', 'le', 'ge'].each do |comparator|
-            comparator_val = date_comparator_value(comparator, search_params[:date])
+            comparator_val = date_comparator_value(comparator, resolve_element_from_path(@diagnostic_report_ary[patient], 'effective') { |el| get_value_for_search_param(el).present? })
             comparator_search_params = search_params.merge('date': comparator_val)
             reply = get_resource_by_params(versioned_resource_class('DiagnosticReport'), comparator_search_params)
             validate_search_reply(versioned_resource_class('DiagnosticReport'), reply, comparator_search_params)
@@ -431,7 +431,7 @@ module Inferno
           validate_search_reply(versioned_resource_class('DiagnosticReport'), reply, search_params)
 
           ['gt', 'lt', 'le', 'ge'].each do |comparator|
-            comparator_val = date_comparator_value(comparator, search_params[:date])
+            comparator_val = date_comparator_value(comparator, resolve_element_from_path(@diagnostic_report_ary[patient], 'effective') { |el| get_value_for_search_param(el).present? })
             comparator_search_params = search_params.merge('date': comparator_val)
             reply = get_resource_by_params(versioned_resource_class('DiagnosticReport'), comparator_search_params)
             validate_search_reply(versioned_resource_class('DiagnosticReport'), reply, comparator_search_params)

--- a/lib/modules/uscore_v3.1.0/us_core_diagnosticreport_note_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_diagnosticreport_note_sequence.rb
@@ -336,7 +336,7 @@ module Inferno
           validate_search_reply(versioned_resource_class('DiagnosticReport'), reply, search_params)
 
           ['gt', 'lt', 'le', 'ge'].each do |comparator|
-            comparator_val = date_comparator_value(comparator, search_params[:date])
+            comparator_val = date_comparator_value(comparator, resolve_element_from_path(@diagnostic_report_ary[patient], 'effective') { |el| get_value_for_search_param(el).present? })
             comparator_search_params = search_params.merge('date': comparator_val)
             reply = get_resource_by_params(versioned_resource_class('DiagnosticReport'), comparator_search_params)
             validate_search_reply(versioned_resource_class('DiagnosticReport'), reply, comparator_search_params)
@@ -431,7 +431,7 @@ module Inferno
           validate_search_reply(versioned_resource_class('DiagnosticReport'), reply, search_params)
 
           ['gt', 'lt', 'le', 'ge'].each do |comparator|
-            comparator_val = date_comparator_value(comparator, search_params[:date])
+            comparator_val = date_comparator_value(comparator, resolve_element_from_path(@diagnostic_report_ary[patient], 'effective') { |el| get_value_for_search_param(el).present? })
             comparator_search_params = search_params.merge('date': comparator_val)
             reply = get_resource_by_params(versioned_resource_class('DiagnosticReport'), comparator_search_params)
             validate_search_reply(versioned_resource_class('DiagnosticReport'), reply, comparator_search_params)

--- a/lib/modules/uscore_v3.1.0/us_core_documentreference_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_documentreference_sequence.rb
@@ -440,7 +440,7 @@ module Inferno
           validate_search_reply(versioned_resource_class('DocumentReference'), reply, search_params)
 
           ['gt', 'lt', 'le', 'ge'].each do |comparator|
-            comparator_val = date_comparator_value(comparator, search_params[:period])
+            comparator_val = date_comparator_value(comparator, resolve_element_from_path(@document_reference_ary[patient], 'context.period') { |el| get_value_for_search_param(el).present? })
             comparator_search_params = search_params.merge('period': comparator_val)
             reply = get_resource_by_params(versioned_resource_class('DocumentReference'), comparator_search_params)
             validate_search_reply(versioned_resource_class('DocumentReference'), reply, comparator_search_params)

--- a/lib/modules/uscore_v3.1.0/us_core_goal_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_goal_sequence.rb
@@ -222,7 +222,7 @@ module Inferno
           validate_search_reply(versioned_resource_class('Goal'), reply, search_params)
 
           ['gt', 'lt', 'le', 'ge'].each do |comparator|
-            comparator_val = date_comparator_value(comparator, search_params[:'target-date'])
+            comparator_val = date_comparator_value(comparator, resolve_element_from_path(@goal_ary[patient], 'target.dueDate') { |el| get_value_for_search_param(el).present? })
             comparator_search_params = search_params.merge('target-date': comparator_val)
             reply = get_resource_by_params(versioned_resource_class('Goal'), comparator_search_params)
             validate_search_reply(versioned_resource_class('Goal'), reply, comparator_search_params)

--- a/lib/modules/uscore_v3.1.0/us_core_immunization_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_immunization_sequence.rb
@@ -222,7 +222,7 @@ module Inferno
           validate_search_reply(versioned_resource_class('Immunization'), reply, search_params)
 
           ['gt', 'lt', 'le', 'ge'].each do |comparator|
-            comparator_val = date_comparator_value(comparator, search_params[:date])
+            comparator_val = date_comparator_value(comparator, resolve_element_from_path(@immunization_ary[patient], 'occurrence') { |el| get_value_for_search_param(el).present? })
             comparator_search_params = search_params.merge('date': comparator_val)
             reply = get_resource_by_params(versioned_resource_class('Immunization'), comparator_search_params)
             validate_search_reply(versioned_resource_class('Immunization'), reply, comparator_search_params)

--- a/lib/modules/uscore_v3.1.0/us_core_observation_lab_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_observation_lab_sequence.rb
@@ -303,7 +303,7 @@ module Inferno
           validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
 
           ['gt', 'lt', 'le', 'ge'].each do |comparator|
-            comparator_val = date_comparator_value(comparator, search_params[:date])
+            comparator_val = date_comparator_value(comparator, resolve_element_from_path(@observation_ary[patient], 'effective') { |el| get_value_for_search_param(el).present? })
             comparator_search_params = search_params.merge('date': comparator_val)
             reply = get_resource_by_params(versioned_resource_class('Observation'), comparator_search_params)
             validate_search_reply(versioned_resource_class('Observation'), reply, comparator_search_params)
@@ -360,7 +360,7 @@ module Inferno
           validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
 
           ['gt', 'lt', 'le', 'ge'].each do |comparator|
-            comparator_val = date_comparator_value(comparator, search_params[:date])
+            comparator_val = date_comparator_value(comparator, resolve_element_from_path(@observation_ary[patient], 'effective') { |el| get_value_for_search_param(el).present? })
             comparator_search_params = search_params.merge('date': comparator_val)
             reply = get_resource_by_params(versioned_resource_class('Observation'), comparator_search_params)
             validate_search_reply(versioned_resource_class('Observation'), reply, comparator_search_params)

--- a/lib/modules/uscore_v3.1.0/us_core_procedure_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_procedure_sequence.rb
@@ -235,7 +235,7 @@ module Inferno
           validate_search_reply(versioned_resource_class('Procedure'), reply, search_params)
 
           ['gt', 'lt', 'le', 'ge'].each do |comparator|
-            comparator_val = date_comparator_value(comparator, search_params[:date])
+            comparator_val = date_comparator_value(comparator, resolve_element_from_path(@procedure_ary[patient], 'performed') { |el| get_value_for_search_param(el).present? })
             comparator_search_params = search_params.merge('date': comparator_val)
             reply = get_resource_by_params(versioned_resource_class('Procedure'), comparator_search_params)
             validate_search_reply(versioned_resource_class('Procedure'), reply, comparator_search_params)
@@ -287,7 +287,7 @@ module Inferno
           validate_search_reply(versioned_resource_class('Procedure'), reply, search_params)
 
           ['gt', 'lt', 'le', 'ge'].each do |comparator|
-            comparator_val = date_comparator_value(comparator, search_params[:date])
+            comparator_val = date_comparator_value(comparator, resolve_element_from_path(@procedure_ary[patient], 'performed') { |el| get_value_for_search_param(el).present? })
             comparator_search_params = search_params.merge('date': comparator_val)
             reply = get_resource_by_params(versioned_resource_class('Procedure'), comparator_search_params)
             validate_search_reply(versioned_resource_class('Procedure'), reply, comparator_search_params)

--- a/lib/modules/uscore_v3.1.0/us_core_pulse_oximetry_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_pulse_oximetry_sequence.rb
@@ -259,7 +259,7 @@ module Inferno
           validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
 
           ['gt', 'lt', 'le', 'ge'].each do |comparator|
-            comparator_val = date_comparator_value(comparator, search_params[:date])
+            comparator_val = date_comparator_value(comparator, resolve_element_from_path(@observation_ary[patient], 'effective') { |el| get_value_for_search_param(el).present? })
             comparator_search_params = search_params.merge('date': comparator_val)
             reply = get_resource_by_params(versioned_resource_class('Observation'), comparator_search_params)
             validate_search_reply(versioned_resource_class('Observation'), reply, comparator_search_params)
@@ -360,7 +360,7 @@ module Inferno
           validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
 
           ['gt', 'lt', 'le', 'ge'].each do |comparator|
-            comparator_val = date_comparator_value(comparator, search_params[:date])
+            comparator_val = date_comparator_value(comparator, resolve_element_from_path(@observation_ary[patient], 'effective') { |el| get_value_for_search_param(el).present? })
             comparator_search_params = search_params.merge('date': comparator_val)
             reply = get_resource_by_params(versioned_resource_class('Observation'), comparator_search_params)
             validate_search_reply(versioned_resource_class('Observation'), reply, comparator_search_params)

--- a/test/unit/sequence_base_test.rb
+++ b/test/unit/sequence_base_test.rb
@@ -84,6 +84,35 @@ class SequenceBaseTest < MiniTest::Test
     end
   end
 
+  describe '#date_comparator_value' do
+    before do
+      @instance = Inferno::Models::TestingInstance.create(selected_module: 'uscore_v3.0.0')
+      client = FHIR::Client.new('')
+      @sequence = Inferno::Sequence::SequenceBase.new(@instance, client, true)
+    end
+
+    it 'returns searches for periods' do
+      period = FHIR::Period.new('start' => '2020-07-01T12:12:12+00:00')
+      assert @sequence.date_comparator_value('gt', period) == 'gt2020-06-30T12:12:12+00:00'
+
+      period = FHIR::Period.new('end' => '2020-07-01T12:12:12+00:00')
+      assert @sequence.date_comparator_value('ge', period) == 'ge2020-06-30T12:12:12+00:00'
+
+      period = FHIR::Period.new('start' => '2020-07-03')
+      assert @sequence.date_comparator_value('le', period) == 'le2020-07-04T00:00:00+00:00'
+
+      period = FHIR::Period.new('start' => '2020-07')
+      assert @sequence.date_comparator_value('lt', period) == 'lt2020-07-02T00:00:00+00:00'
+    end
+
+    it 'returns searches for datetimes' do
+      assert @sequence.date_comparator_value('le', '2020') == 'le2020-01-02T00:00:00+00:00'
+      assert @sequence.date_comparator_value('lt', '2020-04') == 'lt2020-04-02T00:00:00+00:00'
+      assert @sequence.date_comparator_value('gt', '2020-04-01') == 'gt2020-03-31T00:00:00+00:00'
+      assert @sequence.date_comparator_value('ge', '2020-04-01T00:00:00+00:00') == 'ge2020-03-31T00:00:00+00:00'
+    end
+  end
+
   describe '#save_delayed_sequence_references' do
     before do
       @instance = Inferno::Models::TestingInstance.create(selected_module: 'uscore_v3.0.0')


### PR DESCRIPTION
This PR fixes a bug where lt and le comparator searches will search by the start date instead of the day after the start date of periods. This is caused by a recent change to how the normal period searches are performed. 

To test, the procedure sequence should pass with the reference data set.

**Submitter:**
- [X] This pull request describes why these changes were made
- [X] Internal ticket for this PR: https://oncprojectracking.healthit.gov/support/browse/FI-906
- [X] Internal ticket links to this PR
- [X] Internal ticket is properly labeled (Community/Program)
- [X] Internal ticket has a justification for its Community/Program label
- [X] Code diff has been reviewed for extraneous/missing code
- [ ] Tests are included and test edge cases
- [ ] Tests/code quality metrics have been run locally and pass


**Reviewer 1:**

Name:
- [x] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
