### PR TITLE
FI-919: Check code inclusion rake task

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,28 @@ Once the terminology building is done, the `.env` file should be deleted to remo
 
 Optionally, the files and folders in `tmp/terminology/` can be deleted after terminology building to free up space, as they are several GB in size. If you intend to re-run the terminology builder, these files can be left to speed up building in the future, since the builder will be able to skip the initial download/preprocessing steps.
 
+#### Spot Checking the Terminology Files
+You can use the following `rake` command to spot check the validators to make sure they are installed correctly:
+
+```ruby
+bundle exec rake "terminology:check_code[91935009,http://snomed.info/sct, http://hl7.org/fhir/us/core/ValueSet/us-core-allergy-substance]"
+```
+Should return:
+
+```shell
+X http://snomed.info/sct|91935009  is not in http://hl7.org/fhir/us/core/ValueSet/us-core-allergy-substance
+```
+And
+```ruby
+be rake "terminology:check_code[91935009,http://snomed.info/sct]"
+```
+Should return:
+
+```shell
+✓ http://snomed.info/sct|91935009  is in http://snomed.info/sct
+```
+
+
 #### Manual build instructions
 
 If this Docker-based method does not work based on your architecture, manual setup and creation of the terminology validators is documented [on this wiki page](https://github.com/onc-healthit/inferno/wiki/Installing-Terminology-Validators#building-the-validators-without-docker)

--- a/lib/tasks/tasks.rake
+++ b/lib/tasks/tasks.rake
@@ -1123,8 +1123,8 @@ namespace :terminology do |_argv|
   desc 'Check if the code is in the specified ValueSet.  Omit the ValueSet to check against CodeSystem'
   task :check_code, [:code, :system, :valueset] do |_t, args|
     args.with_defaults(system: nil, valueset: nil)
-    code_display = args.system ? args.code.to_s : "#{args.system}|#{args.code}"
-    if Inferno::Terminology.validate_code(code: args.code, system: args.system, valueset_url: args.valueset)
+    code_display = args.system ? "#{args.system}|#{args.code}" : args.code.to_s
+        if Inferno::Terminology.validate_code(code: args.code, system: args.system, valueset_url: args.valueset)
       in_system = 'is in'
       symbol = "\u2713".encode('utf-8').to_s.green
     else

--- a/lib/tasks/tasks.rake
+++ b/lib/tasks/tasks.rake
@@ -1124,7 +1124,7 @@ namespace :terminology do |_argv|
   task :check_code, [:code, :system, :valueset] do |_t, args|
     args.with_defaults(system: nil, valueset: nil)
     code_display = args.system ? "#{args.system}|#{args.code}" : args.code.to_s
-        if Inferno::Terminology.validate_code(code: args.code, system: args.system, valueset_url: args.valueset)
+    if Inferno::Terminology.validate_code(code: args.code, system: args.system, valueset_url: args.valueset)
       in_system = 'is in'
       symbol = "\u2713".encode('utf-8').to_s.green
     else

--- a/lib/tasks/tasks.rake
+++ b/lib/tasks/tasks.rake
@@ -1119,6 +1119,22 @@ namespace :terminology do |_argv|
     Inferno::Terminology.load_fhir_expansions
     Inferno::Terminology.load_us_core
   end
+
+  desc 'Check if the code is in the specified ValueSet.  Omit the ValueSet to check against CodeSystem'
+  task :check_code, [:code, :system, :valueset] do |t, args|
+    args.with_defaults(:system => nil, :valueset => nil)
+    code_display = args.system ? "#{args.code}" : "#{args.system}|#{args.code}"
+    if Inferno::Terminology.validate_code(code: args.code, system: args.system, valueset_url: args.valueset)
+      in_system = 'is in'
+      symbol = "#{"\u2713".encode('utf-8')}".green
+    else
+      in_system = 'is not in'
+      symbol = "X".red
+    end
+    system_checked = args.valueset || args.system
+
+    puts "#{symbol} #{code_display} #{in_system} #{system_checked}"
+  end
 end
 
 RuboCop::RakeTask.new(:rubocop) do |t|

--- a/lib/tasks/tasks.rake
+++ b/lib/tasks/tasks.rake
@@ -1121,15 +1121,15 @@ namespace :terminology do |_argv|
   end
 
   desc 'Check if the code is in the specified ValueSet.  Omit the ValueSet to check against CodeSystem'
-  task :check_code, [:code, :system, :valueset] do |t, args|
-    args.with_defaults(:system => nil, :valueset => nil)
-    code_display = args.system ? "#{args.code}" : "#{args.system}|#{args.code}"
+  task :check_code, [:code, :system, :valueset] do |_t, args|
+    args.with_defaults(system: nil, valueset: nil)
+    code_display = args.system ? args.code.to_s : "#{args.system}|#{args.code}"
     if Inferno::Terminology.validate_code(code: args.code, system: args.system, valueset_url: args.valueset)
       in_system = 'is in'
-      symbol = "#{"\u2713".encode('utf-8')}".green
+      symbol = "\u2713".encode('utf-8').to_s.green
     else
       in_system = 'is not in'
-      symbol = "X".red
+      symbol = 'X'.red
     end
     system_checked = args.valueset || args.system
 


### PR DESCRIPTION
Adds a rake task for checking for the inclusion of a code in a CodeSystem or ValueSet:

Example of checking against a ValueSet :

```shell
be rake "terminology:check_code[91935009,http://snomed.info/sct, http://hl7.org/fhir/us/core/ValueSet/us-core-allergy-substance]"
X http://snomed.info/sct|91935009  is not in http://hl7.org/fhir/us/core/ValueSet/us-core-allergy-substance
```

Example of checking against a CodeSystem (just omit the ValueSet argument):

```shell
be rake "terminology:check_code[91935009,http://snomed.info/sct]"
✓ http://snomed.info/sct|91935009  is in http://snomed.info/sct
```

**Submitter:**
- [x] This pull request describes why these changes were made
- [x] Internal ticket for this PR:
- [x] Internal ticket links to this PR
- [x] Internal ticket is properly labeled (Community/Program)
- [x] Internal ticket has a justification for its Community/Program label
- [x] Code diff has been reviewed for extraneous/missing code
- [ ] Tests are included and test edge cases
- [x] Tests/code quality metrics have been run locally and pass


**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
