### PR TITLE
Remove warnings for optional metadata in SMART discovery sequence.

### DIFF
--- a/lib/modules/onc_program/onc_standalone_smart_discovery_sequence.rb
+++ b/lib/modules/onc_program/onc_standalone_smart_discovery_sequence.rb
@@ -21,32 +21,22 @@ module Inferno
 
         The #{title} Sequence test looks for authorization endpoints and SMART
         capabilities as described by the [SMART App Launch
-        Framework](http://hl7.org/fhir/smart-app-launch/conformance/index.html).
-        The SMART launch framework uses OAuth 2.0 to *authorize* apps, like
-        Inferno, to access certain information on a FHIR server. The
-        authorization service accessed at the endpoint allows users to give
-        these apps permission without sharing their credentials with the
-        application itself. Instead, the application receives an access token
-        which allows it to access resources on the server. The access token
-        itself has a limited lifetime and permission scopes associated with it.
-        A refresh token may also be provided to the application in order to
-        obtain another access token. Unlike access tokens, a refresh token is
-        not shared with the resource server. If OpenID Connect is used, an id
-        token may be provided as well. The id token can be used to
-        *authenticate* the user. The id token is digitally signed and allows the
-        identity of the user to be verified.
+        Framework](http://hl7.org/fhir/smart-app-launch/).
 
         # Test Methodology
 
-        This test suite will examine the SMART on FHIR configuration contained
+        This test suite performs two HTTP GETs to examine the SMART on FHIR configuration contained
         in both the `/metadata` and `/.well-known/smart-configuration`
-        endpoints.
+        endpoints.  It ensures that all required fields are present, and that information
+        provided is consistent between the two endpoints.  These tests currently require both endpoints
+        to be implemented to ensure maximum compatibility with existing clients.
 
-        For more information see:
+        Optional fields are not required and these tests do NOT flag warnings if they are not
+        present.
+
+        For more information regarding SMART App Launch discovery, see:
 
         * [SMART App Launch Framework](http://hl7.org/fhir/smart-app-launch/index.html)
-        * [The OAuth 2.0 Authorization Framework](https://tools.ietf.org/html/rfc6749)
-        * [OpenID Connect Core](https://openid.net/specs/openid-connect-core-1_0.html)
       )
 
       def url_property


### PR DESCRIPTION
The SMART discovery sequence current provides warnings when optional fields are not provided in the two metadata endpoints.  These optional fields are unlikely to be implemented by anyone undergoing certification, and it is even less likely they will point to standardized capabilities because there is little to no guidance on how to implement them.  Therefore, do not flag their absence as a warning in the Program Edition.

Note: as an example, our reference implementation does not currently implement them, because it is unclear exactly what is the right way to do so.

**Submitter:**
- [X] This pull request describes why these changes were made
- [X] Internal ticket for this PR:
- [X] Internal ticket links to this PR
- [X] Internal ticket is properly labeled (Community/Program)
- [X] Internal ticket has a justification for its Community/Program label
- [X] Code diff has been reviewed for extraneous/missing code
- n/a Tests are included and test edge cases
- [X] Tests/code quality metrics have been run locally and pass


**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
