### PR TITLE
Add resource_contains_category method

### DIFF
--- a/lib/app/utils/validation.rb
+++ b/lib/app/utils/validation.rb
@@ -196,7 +196,7 @@ module Inferno
     def self.resource_contains_category(resource, category_code, category_system = nil)
       resource&.category&.any? do |category|
         category.coding&.any? do |coding|
-          coding.code == category_code && (category_system.blank? || category_system == coding.system)
+          coding.code == category_code && (category_system.blank? || coding.system.blank? || category_system == coding.system)
         end
       end
     end

--- a/lib/app/utils/validation.rb
+++ b/lib/app/utils/validation.rb
@@ -162,7 +162,7 @@ module Inferno
       if resource.resourceType == 'Observation'
         return DEFINITIONS[US_CORE_R4_URIS[:smoking_status]] if observation_contains_code(resource, '72166-2')
 
-        return DEFINITIONS[US_CORE_R4_URIS[:lab_results]] if resource_contains_category(resource, 'laboratory')
+        return DEFINITIONS[US_CORE_R4_URIS[:lab_results]] if resource_contains_category(resource, 'laboratory', 'http://terminology.hl7.org/CodeSystem/observation-category')
 
         return DEFINITIONS[US_CORE_R4_URIS[:pediatric_bmi_age]] if observation_contains_code(resource, '59576-9')
 
@@ -181,7 +181,7 @@ module Inferno
         # if none of the US Core profile matches, use FHIR base profile
         return
       elsif resource.resourceType == 'DiagnosticReport'
-        return DEFINITIONS[US_CORE_R4_URIS[:diagnostic_report_lab]] if resource_contains_category(resource, 'LAB')
+        return DEFINITIONS[US_CORE_R4_URIS[:diagnostic_report_lab]] if resource_contains_category(resource, 'LAB', 'http://terminology.hl7.org/CodeSystem/v2-0074')
 
         return DEFINITIONS[US_CORE_R4_URIS[:diagnostic_report_note]]
       end
@@ -193,18 +193,10 @@ module Inferno
       observation_resource&.code&.coding&.any? { |coding| coding&.code == code }
     end
 
-    def self.resource_contains_category(resource, category_code)
-      category_system = if resource.resourceType == 'Observation'
-                          'http://terminology.hl7.org/CodeSystem/observation-category'
-                        elsif resource.resourceType == 'DiagnosticReport'
-                          'http://terminology.hl7.org/CodeSystem/v2-0074'
-                        else
-                          ''
-                        end
-
+    def self.resource_contains_category(resource, category_code, category_system = nil)
       resource&.category&.any? do |category|
         category.coding&.any? do |coding|
-          coding.code == category_code && (category_system.empty? || category_system == coding.system)
+          coding.code == category_code && (category_system.blank? || category_system == coding.system)
         end
       end
     end


### PR DESCRIPTION
Create method resource_contains_categroy in validation.rb to check if a resource has required category.code and categroy.system

**Submitter:**
- [x] This pull request describes why these changes were made
- [x] Internal ticket for this PR:
- [x] Internal ticket links to this PR
- [x] Internal ticket is properly labeled (Community/Program)
- [x] Internal ticket has a justification for its Community/Program label
- [x] Code diff has been reviewed for extraneous/missing code
- [x] Tests are included and test edge cases
- [x] Tests/code quality metrics have been run locally and pass


**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
