### PR TITLE
FI-920 Fix verify check.

### DIFF
--- a/generator/uscore/static_test/access_verify_restricted_test.rb
+++ b/generator/uscore/static_test/access_verify_restricted_test.rb
@@ -44,9 +44,9 @@ describe Inferno::Sequence::ONCAccessVerifyRestrictedSequence do
       assert_raises(Inferno::PassException) { @sequence.run_test(@test) }
     end
 
-    it 'passes if PractitionerRole, Location and RelatedPerson scope provided' do
-      @instance.received_scopes = 'patient/PractitionerRole.read patient/Location.read patient/RelatedPerson.read launch/patient openid fhirUser patient/Observation.* '\
-                                  'patient/Condition.* patient/Patient.*'
+    it 'passes if Practitioner, Organization, Encounter, PractitionerRole, Location, RelatedPerson scope provided' do
+      @instance.received_scopes = 'patient/PractitionerRole.read patient/Location.read patient/RelatedPerson.read launch/patient openid fhirUser patient/Observation.read '\
+                                  'patient/Condition.read patient/Patient.read patient/Encounter.read patient/Practitioner.read patient/Organization.read'
       assert_raises(Inferno::PassException) { @sequence.run_test(@test) }
     end
 

--- a/generator/uscore/static_test/access_verify_restricted_test.rb
+++ b/generator/uscore/static_test/access_verify_restricted_test.rb
@@ -1,0 +1,182 @@
+# frozen_string_literal: true
+
+# NOTE: This is a generated file. Any changes made to this file will be
+#       overwritten when it is regenerated
+
+require_relative '../../../../test/test_helper'
+
+describe Inferno::Sequence::ONCAccessVerifyRestrictedSequence do
+  before do
+    @sequence_class = Inferno::Sequence::ONCAccessVerifyRestrictedSequence
+    @base_url = 'http://www.example.com/fhir'
+    @token = 'ABC'
+    @instance = Inferno::Models::TestingInstance.create(url: @base_url, onc_sl_url: @base_url, token: @token, selected_module: 'uscore_v3.1.0')
+    @client = FHIR::Client.for_testing_instance(@instance)
+    @patient_ids = 'example'
+    @instance.patient_id = @instance.patient_ids = @patient_ids
+    @auth_header = { 'Authorization' => "Bearer #{@token}" }
+  end
+
+  describe 'Validate correct scopes granted test' do
+    before do
+      @test = @sequence_class[:validate_right_scopes]
+      @sequence = @sequence_class.new(@instance, @client)
+      @instance.onc_sl_expected_resources = 'Observation, Condition, Patient'
+    end
+
+    it 'passes if only limited scopes received' do
+      @instance.received_scopes = 'launch/patient openid fhirUser patient/Observation.read patient/Condition.read patient/Patient.read'
+      assert_raises(Inferno::PassException) { @sequence.run_test(@test) }
+    end
+
+    it 'fails if wildcard resource scopes returned' do
+      @instance.received_scopes = 'launch/patient openid fhirUser patient/*.read'
+      assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+    end
+
+    it 'passes if wildcard access scopes used' do
+      @instance.received_scopes = 'launch/patient openid fhirUser patient/Observation.* patient/Condition.* patient/Patient.*'
+      assert_raises(Inferno::PassException) { @sequence.run_test(@test) }
+    end
+
+    it 'passes if unknown scope provided' do
+      @instance.received_scopes = 'proprietary_scope launch/patient openid fhirUser patient/Observation.* patient/Condition.* patient/Patient.*'
+      assert_raises(Inferno::PassException) { @sequence.run_test(@test) }
+    end
+
+    it 'passes if PractitionerRole, Location and RelatedPerson scope provided' do
+      @instance.received_scopes = 'patient/PractitionerRole.read patient/Location.read patient/RelatedPerson.read launch/patient openid fhirUser patient/Observation.* '\
+                                  'patient/Condition.* patient/Patient.*'
+      assert_raises(Inferno::PassException) { @sequence.run_test(@test) }
+    end
+
+    it 'fails if additional resource scope provided' do
+      @instance.received_scopes = 'launch/patient openid fhirUser patient/AllergyIntolerance.read patient/Observation.read patient/Condition.read patient/Patient.read'
+      assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+    end
+
+    it 'fails if scope chosen to be included is omitted' do
+      @instance.received_scopes = 'launch/patient openid fhirUser patient/Condition.read patient/Patient.read'
+      assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+    end
+
+    it 'fails if offline_acess received' do
+      @instance.received_scopes = 'launch/patient offline_access openid fhirUser patient/Observation.read patient/Condition.read patient/Patient.read'
+      assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+    end
+  end
+
+  describe 'Validate Patient Authorization' do
+    before do
+      @test = @sequence_class[:validate_patient_authorization]
+      @sequence = @sequence_class.new(@instance, @client)
+      @instance.received_scopes = 'launch/patient openid fhirUser offline_access patient/Medication.read patient/AllergyIntolerance.read patient/CarePlan.read '\
+                                  'patient/CareTeam.read patient/Condition.read patient/Device.read patient/DiagnosticReport.read patient/DocumentReference.read '\
+                                  'patient/Encounter.read patient/Goal.read patient/Immunization.read patient/Location.read patient/MedicationRequest.read '\
+                                  'patient/Observation.read patient/Organization.read patient/Patient.read patient/Practitioner.read patient/PractitionerRole.read '\
+                                  'patient/Procedure.read patient/Provenance.read patient/RelatedPerson.read'
+      @instance.onc_sl_expected_resources = 'Observation, Condition, Patient'
+    end
+
+    it 'passes if success response received' do
+      stub_request(:get, "#{@base_url}/Patient/#{@patient_ids}")
+        .with(headers: @auth_header)
+        .to_return(status: 200)
+
+      assert_raises(Inferno::PassException) { @sequence.run_test(@test) }
+    end
+
+    it 'fails if 401 response received' do
+      stub_request(:get, "#{@base_url}/Patient/#{@patient_ids}")
+        .with(headers: @auth_header)
+        .to_return(status: 401)
+
+      assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+    end
+
+    it 'fails if 403 response received' do
+      stub_request(:get, "#{@base_url}/Patient/#{@patient_ids}")
+        .with(headers: @auth_header)
+        .to_return(status: 403)
+
+      assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+    end
+  end
+  describe 'Validate AllergyIntolerance authorization when not selected' do
+    before do
+      @test = @sequence_class[:validate_allergyintolerance_authorization]
+      @sequence = @sequence_class.new(@instance, @client)
+      @instance.received_scopes = 'launch/patient openid fhirUser offline_access patient/Observation.read patient/Condition.read '\
+                                  'patient/Patient.read'
+      @instance.onc_sl_expected_resources = 'Observation, Condition, Patient'
+    end
+
+    it 'fails if success response received' do
+      stub_request(:get, "#{@base_url}/AllergyIntolerance?patient=#{@patient_ids}")
+        .with(headers: @auth_header)
+        .to_return(status: 200)
+
+      assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+    end
+
+    it 'passes if 401 response received' do
+      stub_request(:get, "#{@base_url}/AllergyIntolerance?patient=#{@patient_ids}")
+        .with(headers: @auth_header)
+        .to_return(status: 401)
+
+      @sequence.run_test(@test)
+    end
+
+    it 'passes if 403 response received' do
+      stub_request(:get, "#{@base_url}/AllergyIntolerance?patient=#{@patient_ids}")
+        .with(headers: @auth_header)
+        .to_return(status: 403)
+
+      @sequence.run_test(@test)
+    end
+  end
+  describe 'Validate AllergyIntolerance authorization when selected by tester' do
+    before do
+      @test = @sequence_class[:validate_allergyintolerance_authorization]
+      @sequence = @sequence_class.new(@instance, @client)
+      @instance.received_scopes = 'launch/patient openid fhirUser offline_access patient/AllergyIntolerance.read patient/Observation.read patient/Condition.read '\
+                                  'patient/Patient.read'
+      @instance.onc_sl_expected_resources = 'AllergyIntolerance,Observation, Condition, Patient'
+    end
+
+    it 'passes if success response received' do
+      stub_request(:get, "#{@base_url}/AllergyIntolerance?patient=#{@patient_ids}")
+        .with(headers: @auth_header)
+        .to_return(status: 200)
+
+      assert_raises(Inferno::PassException) { @sequence.run_test(@test) }
+    end
+
+    it 'passes if 400 received followed by success' do
+      stub_request(:get, "#{@base_url}/AllergyIntolerance?patient=#{@patient_ids}")
+        .with(headers: @auth_header)
+        .to_return(status: 400, body: { resourceType: 'OperationOutcome' }.to_json)
+      stub_request(:get, "#{@base_url}/AllergyIntolerance?patient=#{@patient_ids}&clinical-status=active")
+        .with(headers: @auth_header)
+        .to_return(status: 200)
+
+      assert_raises(Inferno::PassException) { @sequence.run_test(@test) }
+    end
+
+    it 'fails if 401 response received' do
+      stub_request(:get, "#{@base_url}/AllergyIntolerance?patient=#{@patient_ids}")
+        .with(headers: @auth_header)
+        .to_return(status: 401)
+
+      assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+    end
+
+    it 'fails if 403 response received' do
+      stub_request(:get, "#{@base_url}/AllergyIntolerance?patient=#{@patient_ids}")
+        .with(headers: @auth_header)
+        .to_return(status: 403)
+
+      assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+    end
+  end
+end

--- a/generator/uscore/static_test/access_verify_unrestricted_test.rb
+++ b/generator/uscore/static_test/access_verify_unrestricted_test.rb
@@ -51,7 +51,7 @@ describe Inferno::Sequence::ONCAccessVerifyUnrestrictedSequence do
       assert_raises(Inferno::PassException) { @sequence.run_test(@test) }
     end
 
-    it 'passes if Medication, PractitionerRole, Location and Related Person are omitted' do
+    it 'passes if Medication, PractitionerRole, Location and RelatedPerson are omitted' do
       @instance.received_scopes = 'launch/patient openid fhirUser offline_access patient/AllergyIntolerance.read patient/CarePlan.read '\
                                   'patient/CareTeam.read patient/Condition.read patient/Device.read patient/DiagnosticReport.read patient/DocumentReference.read '\
                                   'patient/Encounter.read patient/Goal.read patient/Immunization.read patient/MedicationRequest.read '\

--- a/generator/uscore/static_test/access_verify_unrestricted_test.rb
+++ b/generator/uscore/static_test/access_verify_unrestricted_test.rb
@@ -1,0 +1,170 @@
+# frozen_string_literal: true
+
+# NOTE: This is a generated file. Any changes made to this file will be
+#       overwritten when it is regenerated
+
+require_relative '../../../../test/test_helper'
+
+describe Inferno::Sequence::ONCAccessVerifyUnrestrictedSequence do
+  before do
+    @sequence_class = Inferno::Sequence::ONCAccessVerifyUnrestrictedSequence
+    @base_url = 'http://www.example.com/fhir'
+    @token = 'ABC'
+    @instance = Inferno::Models::TestingInstance.create(url: @base_url, onc_sl_url: @base_url, token: @token, selected_module: 'uscore_v3.1.0')
+    @client = FHIR::Client.for_testing_instance(@instance)
+    @patient_ids = 'example'
+    @instance.patient_id = @instance.patient_ids = @patient_ids
+    @auth_header = { 'Authorization' => "Bearer #{@token}" }
+  end
+
+  describe 'Validate correct scopes granted test' do
+    before do
+      @test = @sequence_class[:validate_right_scopes]
+      @sequence = @sequence_class.new(@instance, @client)
+    end
+
+    it 'passes if all scopes are received without any wildcards' do
+      @instance.received_scopes = 'launch/patient openid fhirUser offline_access patient/Medication.read patient/AllergyIntolerance.read patient/CarePlan.read '\
+                                  'patient/CareTeam.read patient/Condition.read patient/Device.read patient/DiagnosticReport.read patient/DocumentReference.read '\
+                                  'patient/Encounter.read patient/Goal.read patient/Immunization.read patient/Location.read patient/MedicationRequest.read '\
+                                  'patient/Observation.read patient/Organization.read patient/Patient.read patient/Practitioner.read patient/PractitionerRole.read '\
+                                  'patient/Procedure.read patient/Provenance.read patient/RelatedPerson.read'
+      assert_raises(Inferno::PassException) { @sequence.run_test(@test) }
+    end
+
+    it 'passes if wildcard resource scopes used' do
+      @instance.received_scopes = 'launch/patient openid fhirUser offline_access patient/*.read'
+      assert_raises(Inferno::PassException) { @sequence.run_test(@test) }
+    end
+
+    it 'passes if wildcard resource and access scopes used' do
+      @instance.received_scopes = 'launch/patient openid fhirUser offline_access patient/*.*'
+      assert_raises(Inferno::PassException) { @sequence.run_test(@test) }
+    end
+
+    it 'passes if wildcard access scopes used' do
+      @instance.received_scopes = 'launch/patient openid fhirUser offline_access patient/Medication.* patient/AllergyIntolerance.* patient/CarePlan.* '\
+                                  'patient/CareTeam.* patient/Condition.* patient/Device.* patient/DiagnosticReport.* patient/DocumentReference.* '\
+                                  'patient/Encounter.* patient/Goal.* patient/Immunization.* patient/Location.* patient/MedicationRequest.* '\
+                                  'patient/Observation.* patient/Organization.* patient/Patient.* patient/Practitioner.* patient/PractitionerRole.* '\
+                                  'patient/Procedure.* patient/Provenance.* patient/RelatedPerson.*'
+      assert_raises(Inferno::PassException) { @sequence.run_test(@test) }
+    end
+
+    it 'passes if Medication, PractitionerRole, Location and Related Person are omitted' do
+      @instance.received_scopes = 'launch/patient openid fhirUser offline_access patient/AllergyIntolerance.read patient/CarePlan.read '\
+                                  'patient/CareTeam.read patient/Condition.read patient/Device.read patient/DiagnosticReport.read patient/DocumentReference.read '\
+                                  'patient/Encounter.read patient/Goal.read patient/Immunization.read patient/MedicationRequest.read '\
+                                  'patient/Observation.read patient/Organization.read patient/Patient.read patient/Practitioner.read '\
+                                  'patient/Procedure.read patient/Provenance.read'
+      assert_raises(Inferno::PassException) { @sequence.run_test(@test) }
+    end
+
+    it 'passes if unknown scope provided' do
+      @instance.received_scopes = 'launch/patient openid fhirUser offline_access patient/Medication.read patient/AllergyIntolerance.read patient/CarePlan.read '\
+                                  'patient/CareTeam.read patient/Condition.read patient/Device.read patient/DiagnosticReport.read patient/DocumentReference.read '\
+                                  'patient/Encounter.read patient/Goal.read patient/Immunization.read patient/Location.read patient/MedicationRequest.read '\
+                                  'patient/Observation.read patient/Organization.read patient/Patient.read patient/Practitioner.read patient/PractitionerRole.read '\
+                                  'patient/Procedure.read patient/Provenance.read patient/RelatedPerson.read proprietary_scope'
+      assert_raises(Inferno::PassException) { @sequence.run_test(@test) }
+    end
+
+    it 'fails if Patient scope is omitted' do
+      @instance.received_scopes = 'launch/patient openid fhirUser offline_access patient/Medication.read patient/AllergyIntolerance.read patient/CarePlan.read '\
+                                  'patient/CareTeam.read patient/Condition.read patient/Device.read patient/DiagnosticReport.read patient/DocumentReference.read '\
+                                  'patient/Encounter.read patient/Goal.read patient/Immunization.read patient/Location.read patient/MedicationRequest.read '\
+                                  'patient/Observation.read patient/Organization.read patient/Practitioner.read patient/PractitionerRole.read '\
+                                  'patient/Procedure.read patient/Provenance.read patient/RelatedPerson.read'
+      assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+    end
+
+    it 'fails if AllergyIntolerance scope is omitted' do
+      @instance.received_scopes = 'launch/patient openid fhirUser offline_access patient/Medication.read patient/CarePlan.read '\
+                                  'patient/CareTeam.read patient/Condition.read patient/Device.read patient/DiagnosticReport.read patient/DocumentReference.read '\
+                                  'patient/Encounter.read patient/Goal.read patient/Immunization.read patient/Location.read patient/MedicationRequest.read '\
+                                  'patient/Observation.read patient/Organization.read patient/Patient.read patient/Practitioner.read patient/PractitionerRole.read '\
+                                  'patient/Procedure.read patient/Provenance.read patient/RelatedPerson.read'
+      assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+    end
+
+    it 'fails if Practitioner scope is omitted' do
+      @instance.received_scopes = 'launch/patient openid fhirUser offline_access patient/Medication.read patient/AllergyIntolerance.read patient/CarePlan.read '\
+                                  'patient/CareTeam.read patient/Condition.read patient/Device.read patient/DiagnosticReport.read patient/DocumentReference.read '\
+                                  'patient/Encounter.read patient/Goal.read patient/Immunization.read patient/Location.read patient/MedicationRequest.read '\
+                                  'patient/Observation.read patient/Organization.read patient/Patient.read patient/PractitionerRole.read '\
+                                  'patient/Procedure.read patient/Provenance.read patient/RelatedPerson.read'
+      assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+    end
+  end
+
+  describe 'Validate Patient Authorization' do
+    before do
+      @test = @sequence_class[:validate_patient_authorization]
+      @sequence = @sequence_class.new(@instance, @client)
+      @instance.received_scopes = 'launch/patient openid fhirUser offline_access patient/Medication.read patient/AllergyIntolerance.read patient/CarePlan.read '\
+                                  'patient/CareTeam.read patient/Condition.read patient/Device.read patient/DiagnosticReport.read patient/DocumentReference.read '\
+                                  'patient/Encounter.read patient/Goal.read patient/Immunization.read patient/Location.read patient/MedicationRequest.read '\
+                                  'patient/Observation.read patient/Organization.read patient/Patient.read patient/Practitioner.read patient/PractitionerRole.read '\
+                                  'patient/Procedure.read patient/Provenance.read patient/RelatedPerson.read'
+    end
+
+    it 'passes if success response received' do
+      stub_request(:get, "#{@base_url}/Patient/#{@patient_ids}")
+        .with(headers: @auth_header)
+        .to_return(status: 200)
+
+      assert_raises(Inferno::PassException) { @sequence.run_test(@test) }
+    end
+
+    it 'fails if 401 response received' do
+      stub_request(:get, "#{@base_url}/Patient/#{@patient_ids}")
+        .with(headers: @auth_header)
+        .to_return(status: 401)
+
+      assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+    end
+
+    it 'fails if 403 response received' do
+      stub_request(:get, "#{@base_url}/Patient/#{@patient_ids}")
+        .with(headers: @auth_header)
+        .to_return(status: 403)
+
+      assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+    end
+  end
+  describe 'Validate AllergyIntolerance Authorization' do
+    before do
+      @test = @sequence_class[:validate_allergyintolerance_authorization]
+      @sequence = @sequence_class.new(@instance, @client)
+      @instance.received_scopes = 'launch/patient openid fhirUser offline_access patient/Medication.read patient/AllergyIntolerance.read patient/CarePlan.read '\
+                                  'patient/CareTeam.read patient/Condition.read patient/Device.read patient/DiagnosticReport.read patient/DocumentReference.read '\
+                                  'patient/Encounter.read patient/Goal.read patient/Immunization.read patient/Location.read patient/MedicationRequest.read '\
+                                  'patient/Observation.read patient/Organization.read patient/Patient.read patient/Practitioner.read patient/PractitionerRole.read '\
+                                  'patient/Procedure.read patient/Provenance.read patient/RelatedPerson.read'
+    end
+
+    it 'passes if success response received' do
+      stub_request(:get, "#{@base_url}/AllergyIntolerance?patient=#{@patient_ids}")
+        .with(headers: @auth_header)
+        .to_return(status: 200)
+
+      assert_raises(Inferno::PassException) { @sequence.run_test(@test) }
+    end
+
+    it 'fails if 401 response received' do
+      stub_request(:get, "#{@base_url}/AllergyIntolerance?patient=#{@patient_ids}")
+        .with(headers: @auth_header)
+        .to_return(status: 401)
+
+      assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+    end
+
+    it 'fails if 403 response received' do
+      stub_request(:get, "#{@base_url}/AllergyIntolerance?patient=#{@patient_ids}")
+        .with(headers: @auth_header)
+        .to_return(status: 403)
+
+      assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+    end
+  end
+end

--- a/generator/uscore/templates/access_verify_sequence.rb.erb
+++ b/generator/uscore/templates/access_verify_sequence.rb.erb
@@ -155,18 +155,18 @@ module Inferno
        assert @instance.received_scopes.split(' ').exclude?('offline_access'), 'This test expects the user to deny offline access to demonstrate that refresh tokens require user approval'
        pass "Resources to be denied: #{denied_resources.join(',')}"
        <% else %>
-        # Consider all directly-mapped USCDI resources, as well as Encounter, Practitioner and Organization
-        # because they have US Core Profile references in the other US Core Profiles.  This excludes
-        # PractionerRole, Location and RelatedPerson because they do not have US Core Profile references
-        # and therefore could be 'contained' and do not have a read interaction requirement.
-        all_resources = [
-        <%= non_delayed_sequences.group_by{|sequence| sequence[:resource]}.values.map(&:first).map{|resource| "'#{resource[:resource]}'"}.join(",\n") %>,
-        'Patient',
-        'Provenance',
-        'Encounter',
-        'Practitioner',
-        'Organization'
-        ]
+       # Consider all directly-mapped USCDI resources, as well as Encounter, Practitioner and Organization
+       # because they have US Core Profile references in the other US Core Profiles.  This excludes
+       # PractionerRole, Location and RelatedPerson because they do not have US Core Profile references
+       # and therefore could be 'contained' and do not have a read interaction requirement.
+       all_resources = [
+       <%= non_delayed_sequences.group_by{|sequence| sequence[:resource]}.values.map(&:first).map{|resource| "'#{resource[:resource]}'"}.join(",\n") %>,
+       'Patient',
+       'Provenance',
+       'Encounter',
+       'Practitioner',
+       'Organization'
+       ]
        allowed_resources = all_resources.select {|resource| scope_granting_access(resource, @instance.received_scopes).present?}
        denied_resources = all_resources - allowed_resources
        assert denied_resources.empty?, "This test requires access to all US Core resources with patient information, but the received scope '#{@instance.received_scopes}' does not grant access to the '#{denied_resources.join(', ')}' resource type(s)."

--- a/generator/uscore/templates/access_verify_sequence.rb.erb
+++ b/generator/uscore/templates/access_verify_sequence.rb.erb
@@ -66,8 +66,8 @@ module Inferno
         resource type is accessed by queries through other resource types. These resources types are accessed in the more
         comprehensive Single Patient Query tests.
 
-        However, the authorization system must indicate that access is granted to the Encounter, Practitioner and Location
-        resource types because they are required to support the read interaction. 
+        However, the authorization system must indicate that access is granted to the Encounter, Practitioner and Organization
+        resource types by providing them in the returned scopes because they are required to support the read interaction. 
       )
       <% end %>
       requires :onc_sl_url, :token, :patient_id, :received_scopes<% if access_verify_restriction == 'restricted' %>, :onc_sl_expected_resources<% end %>

--- a/generator/uscore/templates/access_verify_sequence.rb.erb
+++ b/generator/uscore/templates/access_verify_sequence.rb.erb
@@ -108,7 +108,7 @@ module Inferno
 
       def scope_granting_access(resource, scopes)
         scopes.split(' ').find do |scope| 
-          scope.start_with?("patient/#{resource}.", 'patient/*.') && scope.end_with?('.*', '.read')
+          ['patient/*.read', 'patient/*.*', "patient/#{resource}.read", "patient/#{resource}.*"].include? scope
         end
       end
 

--- a/generator/uscore/templates/access_verify_sequence.rb.erb
+++ b/generator/uscore/templates/access_verify_sequence.rb.erb
@@ -124,17 +124,19 @@ module Inferno
         'Patient'
         ]
 
-
+       <% if access_verify_restriction == 'restricted' %>
        allowed_resources = all_resources.select {|resource| scope_granting_access(resource, resource_access_as_scope)}
        denied_resources = all_resources - allowed_resources
-
-       <% if access_verify_restriction == 'restricted' %>
        assert denied_resources.present?, "This test requires at least one resource to be denied, but the provided scope '#{@instance.received_scopes}' grants access to all resource types."
        received_scope_resources = all_resources.select{|resource| scope_granting_access(resource, @instance.received_scopes)}
        unexpected_resources = received_scope_resources - allowed_resources
        assert unexpected_resources.empty?, "This test expected the user to deny access to the following resources that are present in scopes received during token exchange response: #{unexpected_resources.join(', ')}"
+       improperly_denied_resources = allowed_resources.reject { |resource| scope_granting_access(resource, @instance.received_scopes).present? }
+       assert improperly_denied_resources.empty?, "This test expected the user to grant access to the following resources that are not received during token exhange response: #{improperly_denied_resources.join(', ')}"
        pass "Resources to be denied: #{denied_resources.join(',')}"
        <% else %>
+       allowed_resources = all_resources.select {|resource| scope_granting_access(resource, @instance.received_scopes)}
+       denied_resources = all_resources - allowed_resources
        assert denied_resources.empty?, "This test requires access to all US Core resources with patient information, but the received scope '#{@instance.received_scopes}' does not grant access to the '#{denied_resources.join(', ')}' resource type(s)."
        pass 'Scopes received indicate access to all necessary resources.'
        <% end %>

--- a/generator/uscore/templates/access_verify_sequence.rb.erb
+++ b/generator/uscore/templates/access_verify_sequence.rb.erb
@@ -133,6 +133,28 @@ module Inferno
         skip_if @instance.received_scopes.nil?, 'A list of granted scopes was not provided to this test as required.'
 
 
+       <% if access_verify_restriction == 'restricted' %>
+        # Consider all directly-mapped USCDI resources only.  Do not fail based on the inclusion/Exclusion of Encounter, Practitioner
+        # PractitionerRole, Location, Organization, or RelatedPerson because the SUT has flexibility to decide if those
+        # should be included or not based on whether other resources are selected (e.g. if Observation then maybe it makes
+        # sense to include Encounter scope) without having the user be in charge of that particular choice.
+        
+        all_resources = [
+        <%= non_delayed_sequences.group_by{|sequence| sequence[:resource]}.values.map(&:first).map{|resource| "'#{resource[:resource]}'"}.join(",\n") %>,
+        'Patient',
+        'Provenance'
+        ]
+       allowed_resources = all_resources.select {|resource| scope_granting_access(resource, resource_access_as_scope).present?}
+       denied_resources = all_resources - allowed_resources
+       assert denied_resources.present?, "This test requires at least one resource to be denied, but the provided scope '#{@instance.received_scopes}' grants access to all resource types."
+       received_scope_resources = all_resources.select{|resource| scope_granting_access(resource, @instance.received_scopes).present?}
+       unexpected_resources = received_scope_resources - allowed_resources
+       assert unexpected_resources.empty?, "This test expected the user to deny access to the following resources that are present in scopes received during token exchange response: #{unexpected_resources.join(', ')}"
+       improperly_denied_resources = allowed_resources.reject { |resource| scope_granting_access(resource, @instance.received_scopes).present? }
+       assert improperly_denied_resources.empty?, "This test expected the user to grant access to the following resources that are not received during token exhange response: #{improperly_denied_resources.join(', ')}"
+       assert @instance.received_scopes.split(' ').exclude?('offline_access'), 'This test expects the user to deny offline access to demonstrate that refresh tokens require user approval'
+       pass "Resources to be denied: #{denied_resources.join(',')}"
+       <% else %>
         # Consider all directly-mapped USCDI resources, as well as Encounter, Practitioner and Organization
         # because they have US Core Profile references in the other US Core Profiles.  This excludes
         # PractionerRole, Location and RelatedPerson because they do not have US Core Profile references
@@ -145,19 +167,6 @@ module Inferno
         'Practitioner',
         'Organization'
         ]
-
-       <% if access_verify_restriction == 'restricted' %>
-       allowed_resources = all_resources.select {|resource| scope_granting_access(resource, resource_access_as_scope).present?}
-       denied_resources = all_resources - allowed_resources
-       assert denied_resources.present?, "This test requires at least one resource to be denied, but the provided scope '#{@instance.received_scopes}' grants access to all resource types."
-       received_scope_resources = all_resources.select{|resource| scope_granting_access(resource, @instance.received_scopes).present?}
-       unexpected_resources = received_scope_resources - allowed_resources
-       assert unexpected_resources.empty?, "This test expected the user to deny access to the following resources that are present in scopes received during token exchange response: #{unexpected_resources.join(', ')}"
-       improperly_denied_resources = allowed_resources.reject { |resource| scope_granting_access(resource, @instance.received_scopes).present? }
-       assert improperly_denied_resources.empty?, "This test expected the user to grant access to the following resources that are not received during token exhange response: #{improperly_denied_resources.join(', ')}"
-       assert @instance.received_scopes.split(' ').exclude?('offline_access'), 'This test expects the user to deny offline access to demonstrate that refresh tokens require user approval'
-       pass "Resources to be denied: #{denied_resources.join(',')}"
-       <% else %>
        allowed_resources = all_resources.select {|resource| scope_granting_access(resource, @instance.received_scopes).present?}
        denied_resources = all_resources - allowed_resources
        assert denied_resources.empty?, "This test requires access to all US Core resources with patient information, but the received scope '#{@instance.received_scopes}' does not grant access to the '#{denied_resources.join(', ')}' resource type(s)."

--- a/generator/uscore/templates/access_verify_sequence.rb.erb
+++ b/generator/uscore/templates/access_verify_sequence.rb.erb
@@ -8,7 +8,7 @@ module Inferno
 
       <% if access_verify_restriction == 'restricted' %>
       <%# METADATA FOR RESTRICTED ACCESS TEST%>
-      description 'Verify that access to resource types can be restricted to app.'
+      description 'Verify that patients have control over which resource types can be accessed.'
       test_id_prefix 'AVR'
       details %(
         This test ensures that patients are able to grant or deny access to a subset of resources to an app.
@@ -40,7 +40,7 @@ module Inferno
       )
       <% else %>
       <%# METADATA FOR FULL ACCESS TEST %>
-      description 'Verify that all resource types can be accessed by apps with appropriate scopes.'
+      description 'Verify that patients can grant access to all necessary resource types.'
       test_id_prefix 'AVU'
       details %(
         This test ensures that apps have full access to USCDI resources if granted access by the tester.
@@ -48,6 +48,11 @@ module Inferno
         and this test ensures they all can be accessed:
         <% non_delayed_sequences.group_by{|sequence| sequence[:resource]}.values.map(&:first).each do |resource| %>
           * <%= resource[:resource] %><% end %>
+          * Patient
+          * Provenance
+          * Encounter
+          * Practitioner
+          * Organization
 
         For each of the resource types that can be mapped to USCDI data class or elements, this set of tests
         performs a minimum number of requests to determine that the resource type can be accessed given the
@@ -60,6 +65,9 @@ module Inferno
         Organization, Practitioner, PractionerRole, and RelatedPerson.  It also does not test Provenance, as this
         resource type is accessed by queries through other resource types. These resources types are accessed in the more
         comprehensive Single Patient Query tests.
+
+        However, the authorization system must indicate that access is granted to the Encounter, Practitioner and Location
+        resource types because they are required to support the read interaction. 
       )
       <% end %>
       requires :onc_sl_url, :token, :patient_id, :received_scopes<% if access_verify_restriction == 'restricted' %>, :onc_sl_expected_resources<% end %>
@@ -100,7 +108,7 @@ module Inferno
 
       def scope_granting_access(resource, scopes)
         scopes.split(' ').find do |scope| 
-          scope.start_with?("patient/#{resource}", 'patient/*') && scope.end_with?('*', 'read')
+          scope.start_with?("patient/#{resource}.", 'patient/*.') && scope.end_with?('.*', '.read')
         end
       end
 
@@ -112,30 +120,45 @@ module Inferno
           <% end %>
           link 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient'
           description %(
-            This test confirms that the scopes received during authorization match those that
-            expected for this launch.
+            <% if access_verify_restriction == 'unrestricted' %>
+            This test confirms that the scopes granted during authorization are sufficient to access
+            all relevant US Core resources.
+            <% else %>
+            This test confirms that the scopes granted during authorization match those that
+            were expected for this launch based on input provided by the tester. 
+            <% end %>
           )
         end
 
-        skip_if @instance.received_scopes.nil?, 'No SMART scopes were provided to the test.'
+        skip_if @instance.received_scopes.nil?, 'A list of granted scopes was not provided to this test as required.'
 
+
+        # Consider all directly-mapped USCDI resources, as well as Encounter, Practitioner and Organization
+        # because they have US Core Profile references in the other US Core Profiles.  This excludes
+        # PractionerRole, Location and RelatedPerson because they do not have US Core Profile references
+        # and therefore could be 'contained' and do not have a read interaction requirement.
         all_resources = [
         <%= non_delayed_sequences.group_by{|sequence| sequence[:resource]}.values.map(&:first).map{|resource| "'#{resource[:resource]}'"}.join(",\n") %>,
-        'Patient'
+        'Patient',
+        'Provenance',
+        'Encounter',
+        'Practitioner',
+        'Organization'
         ]
 
        <% if access_verify_restriction == 'restricted' %>
-       allowed_resources = all_resources.select {|resource| scope_granting_access(resource, resource_access_as_scope)}
+       allowed_resources = all_resources.select {|resource| scope_granting_access(resource, resource_access_as_scope).present?}
        denied_resources = all_resources - allowed_resources
        assert denied_resources.present?, "This test requires at least one resource to be denied, but the provided scope '#{@instance.received_scopes}' grants access to all resource types."
-       received_scope_resources = all_resources.select{|resource| scope_granting_access(resource, @instance.received_scopes)}
+       received_scope_resources = all_resources.select{|resource| scope_granting_access(resource, @instance.received_scopes).present?}
        unexpected_resources = received_scope_resources - allowed_resources
        assert unexpected_resources.empty?, "This test expected the user to deny access to the following resources that are present in scopes received during token exchange response: #{unexpected_resources.join(', ')}"
        improperly_denied_resources = allowed_resources.reject { |resource| scope_granting_access(resource, @instance.received_scopes).present? }
        assert improperly_denied_resources.empty?, "This test expected the user to grant access to the following resources that are not received during token exhange response: #{improperly_denied_resources.join(', ')}"
+       assert @instance.received_scopes.split(' ').exclude?('offline_access'), 'This test expects the user to deny offline access to demonstrate that refresh tokens require user approval'
        pass "Resources to be denied: #{denied_resources.join(',')}"
        <% else %>
-       allowed_resources = all_resources.select {|resource| scope_granting_access(resource, @instance.received_scopes)}
+       allowed_resources = all_resources.select {|resource| scope_granting_access(resource, @instance.received_scopes).present?}
        denied_resources = all_resources - allowed_resources
        assert denied_resources.empty?, "This test requires access to all US Core resources with patient information, but the received scope '#{@instance.received_scopes}' does not grant access to the '#{denied_resources.join(', ')}' resource type(s)."
        pass 'Scopes received indicate access to all necessary resources.'
@@ -145,10 +168,11 @@ module Inferno
       test :validate_patient_authorization do
         metadata do
           id '02'
-          name 'Patient resources on the FHIR server follow the US Core Implementation Guide'
-          link 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient'
+          name 'Access to Patient resource granted and patient resource can be read.'
+          link 'http://www.hl7.org/fhir/smart-app-launch/scopes-and-launch-context/index.html'
           description %(
-            This test checks if the resources returned from bulk data export conform to the US Core profiles. This includes checking for missing data elements and valueset verification.
+            This test ensures that the authorization service has granted access to the Patient resource
+            and that the patient resource can be read without an authorization error.
           )
         end
         skip_if @instance.patient_id.nil?, 'Patient ID not provided to test. The patient ID is typically provided during in a SMART launch context.'
@@ -180,6 +204,12 @@ module Inferno
           name 'Access to <%=sequence[:resource]%> resources are restricted properly based on patient-selected scope'
           link 'http://www.hl7.org/fhir/smart-app-launch/scopes-and-launch-context/index.html'
           description %(
+            This test ensures that access to the <%=sequence[:resource] %> is granted or denied based on the 
+            selection by the tester prior to the execution of the test.  If the tester indicated that access
+            will be granted to this resource, this test verifies that
+            a search by patient in this resource does not result in an access denied result.  If the tester indicated that
+            access will be denied for this resource, this verifies that
+            search by patient in the resource results in an access denied result.
           )
         end
 

--- a/lib/modules/onc_program/onc_standalone_restricted_launch_sequence.rb
+++ b/lib/modules/onc_program/onc_standalone_restricted_launch_sequence.rb
@@ -211,8 +211,10 @@ module Inferno
         expected_denied_resources = all_resources - expected_resources
 
         improperly_granted_resources = expected_denied_resources.select { |resource| scope_granting_access(resource, received_scopes).present? }
+        improperly_denied_resources = expected_resources.reject { |resource| scope_granting_access(resource, received_scopes).present? }
 
         assert improperly_granted_resources.empty?, "User expected to deny the following resources that were granted: #{improperly_granted_resources.join(', ')}"
+        assert improperly_denied_resources.empty?, "User expected to grant access to the following resources: #{improperly_denied_resources.join(', ')}"
 
         assert !received_scopes.split(' ').include?('offline_access'), 'Scopes returned in access token response contained offline_access.  User must deny this scope to pass this test.'
       end

--- a/lib/modules/uscore_v3.1.0/access_verify_restricted_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/access_verify_restricted_sequence.rb
@@ -75,7 +75,7 @@ module Inferno
 
       def scope_granting_access(resource, scopes)
         scopes.split(' ').find do |scope|
-          scope.start_with?("patient/#{resource}.", 'patient/*.') && scope.end_with?('.*', '.read')
+          ['patient/*.read', 'patient/*.*', "patient/#{resource}.read", "patient/#{resource}.*"].include? scope
         end
       end
 

--- a/lib/modules/uscore_v3.1.0/access_verify_restricted_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/access_verify_restricted_sequence.rb
@@ -5,7 +5,7 @@ module Inferno
     class ONCAccessVerifyRestrictedSequence < SequenceBase
       title 'Restricted Resource Type Access'
 
-      description 'Verify that access to resource types can be restricted to app.'
+      description 'Verify that patients have control over which resource types can be accessed.'
       test_id_prefix 'AVR'
       details %(
         This test ensures that patients are able to grant or deny access to a subset of resources to an app.
@@ -75,7 +75,7 @@ module Inferno
 
       def scope_granting_access(resource, scopes)
         scopes.split(' ').find do |scope|
-          scope.start_with?("patient/#{resource}", 'patient/*') && scope.end_with?('*', 'read')
+          scope.start_with?("patient/#{resource}.", 'patient/*.') && scope.end_with?('.*', '.read')
         end
       end
 
@@ -86,13 +86,19 @@ module Inferno
 
           link 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient'
           description %(
-            This test confirms that the scopes received during authorization match those that
-            expected for this launch.
+
+            This test confirms that the scopes granted during authorization match those that
+            were expected for this launch based on input provided by the tester.
+
           )
         end
 
-        skip_if @instance.received_scopes.nil?, 'No SMART scopes were provided to the test.'
+        skip_if @instance.received_scopes.nil?, 'A list of granted scopes was not provided to this test as required.'
 
+        # Consider all directly-mapped USCDI resources, as well as Encounter, Practitioner and Organization
+        # because they have US Core Profile references in the other US Core Profiles.  This excludes
+        # PractionerRole, Location and RelatedPerson because they do not have US Core Profile references
+        # and therefore could be 'contained' and do not have a read interaction requirement.
         all_resources = [
           'AllergyIntolerance',
           'CarePlan',
@@ -106,27 +112,33 @@ module Inferno
           'MedicationRequest',
           'Observation',
           'Procedure',
-          'Patient'
+          'Patient',
+          'Provenance',
+          'Encounter',
+          'Practitioner',
+          'Organization'
         ]
 
-        allowed_resources = all_resources.select { |resource| scope_granting_access(resource, resource_access_as_scope) }
+        allowed_resources = all_resources.select { |resource| scope_granting_access(resource, resource_access_as_scope).present? }
         denied_resources = all_resources - allowed_resources
         assert denied_resources.present?, "This test requires at least one resource to be denied, but the provided scope '#{@instance.received_scopes}' grants access to all resource types."
-        received_scope_resources = all_resources.select { |resource| scope_granting_access(resource, @instance.received_scopes) }
+        received_scope_resources = all_resources.select { |resource| scope_granting_access(resource, @instance.received_scopes).present? }
         unexpected_resources = received_scope_resources - allowed_resources
         assert unexpected_resources.empty?, "This test expected the user to deny access to the following resources that are present in scopes received during token exchange response: #{unexpected_resources.join(', ')}"
         improperly_denied_resources = allowed_resources.reject { |resource| scope_granting_access(resource, @instance.received_scopes).present? }
         assert improperly_denied_resources.empty?, "This test expected the user to grant access to the following resources that are not received during token exhange response: #{improperly_denied_resources.join(', ')}"
+        assert @instance.received_scopes.split(' ').exclude?('offline_access'), 'This test expects the user to deny offline access to demonstrate that refresh tokens require user approval'
         pass "Resources to be denied: #{denied_resources.join(',')}"
       end
 
       test :validate_patient_authorization do
         metadata do
           id '02'
-          name 'Patient resources on the FHIR server follow the US Core Implementation Guide'
-          link 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient'
+          name 'Access to Patient resource granted and patient resource can be read.'
+          link 'http://www.hl7.org/fhir/smart-app-launch/scopes-and-launch-context/index.html'
           description %(
-            This test checks if the resources returned from bulk data export conform to the US Core profiles. This includes checking for missing data elements and valueset verification.
+            This test ensures that the authorization service has granted access to the Patient resource
+            and that the patient resource can be read without an authorization error.
           )
         end
         skip_if @instance.patient_id.nil?, 'Patient ID not provided to test. The patient ID is typically provided during in a SMART launch context.'
@@ -156,6 +168,12 @@ module Inferno
           name 'Access to AllergyIntolerance resources are restricted properly based on patient-selected scope'
           link 'http://www.hl7.org/fhir/smart-app-launch/scopes-and-launch-context/index.html'
           description %(
+            This test ensures that access to the AllergyIntolerance is granted or denied based on the
+            selection by the tester prior to the execution of the test.  If the tester indicated that access
+            will be granted to this resource, this test verifies that
+            a search by patient in this resource does not result in an access denied result.  If the tester indicated that
+            access will be denied for this resource, this verifies that
+            search by patient in the resource results in an access denied result.
           )
         end
 
@@ -206,6 +224,12 @@ module Inferno
           name 'Access to CarePlan resources are restricted properly based on patient-selected scope'
           link 'http://www.hl7.org/fhir/smart-app-launch/scopes-and-launch-context/index.html'
           description %(
+            This test ensures that access to the CarePlan is granted or denied based on the
+            selection by the tester prior to the execution of the test.  If the tester indicated that access
+            will be granted to this resource, this test verifies that
+            a search by patient in this resource does not result in an access denied result.  If the tester indicated that
+            access will be denied for this resource, this verifies that
+            search by patient in the resource results in an access denied result.
           )
         end
 
@@ -257,6 +281,12 @@ module Inferno
           name 'Access to CareTeam resources are restricted properly based on patient-selected scope'
           link 'http://www.hl7.org/fhir/smart-app-launch/scopes-and-launch-context/index.html'
           description %(
+            This test ensures that access to the CareTeam is granted or denied based on the
+            selection by the tester prior to the execution of the test.  If the tester indicated that access
+            will be granted to this resource, this test verifies that
+            a search by patient in this resource does not result in an access denied result.  If the tester indicated that
+            access will be denied for this resource, this verifies that
+            search by patient in the resource results in an access denied result.
           )
         end
 
@@ -308,6 +338,12 @@ module Inferno
           name 'Access to Condition resources are restricted properly based on patient-selected scope'
           link 'http://www.hl7.org/fhir/smart-app-launch/scopes-and-launch-context/index.html'
           description %(
+            This test ensures that access to the Condition is granted or denied based on the
+            selection by the tester prior to the execution of the test.  If the tester indicated that access
+            will be granted to this resource, this test verifies that
+            a search by patient in this resource does not result in an access denied result.  If the tester indicated that
+            access will be denied for this resource, this verifies that
+            search by patient in the resource results in an access denied result.
           )
         end
 
@@ -358,6 +394,12 @@ module Inferno
           name 'Access to Device resources are restricted properly based on patient-selected scope'
           link 'http://www.hl7.org/fhir/smart-app-launch/scopes-and-launch-context/index.html'
           description %(
+            This test ensures that access to the Device is granted or denied based on the
+            selection by the tester prior to the execution of the test.  If the tester indicated that access
+            will be granted to this resource, this test verifies that
+            a search by patient in this resource does not result in an access denied result.  If the tester indicated that
+            access will be denied for this resource, this verifies that
+            search by patient in the resource results in an access denied result.
           )
         end
 
@@ -394,6 +436,12 @@ module Inferno
           name 'Access to DiagnosticReport resources are restricted properly based on patient-selected scope'
           link 'http://www.hl7.org/fhir/smart-app-launch/scopes-and-launch-context/index.html'
           description %(
+            This test ensures that access to the DiagnosticReport is granted or denied based on the
+            selection by the tester prior to the execution of the test.  If the tester indicated that access
+            will be granted to this resource, this test verifies that
+            a search by patient in this resource does not result in an access denied result.  If the tester indicated that
+            access will be denied for this resource, this verifies that
+            search by patient in the resource results in an access denied result.
           )
         end
 
@@ -445,6 +493,12 @@ module Inferno
           name 'Access to DocumentReference resources are restricted properly based on patient-selected scope'
           link 'http://www.hl7.org/fhir/smart-app-launch/scopes-and-launch-context/index.html'
           description %(
+            This test ensures that access to the DocumentReference is granted or denied based on the
+            selection by the tester prior to the execution of the test.  If the tester indicated that access
+            will be granted to this resource, this test verifies that
+            a search by patient in this resource does not result in an access denied result.  If the tester indicated that
+            access will be denied for this resource, this verifies that
+            search by patient in the resource results in an access denied result.
           )
         end
 
@@ -495,6 +549,12 @@ module Inferno
           name 'Access to Goal resources are restricted properly based on patient-selected scope'
           link 'http://www.hl7.org/fhir/smart-app-launch/scopes-and-launch-context/index.html'
           description %(
+            This test ensures that access to the Goal is granted or denied based on the
+            selection by the tester prior to the execution of the test.  If the tester indicated that access
+            will be granted to this resource, this test verifies that
+            a search by patient in this resource does not result in an access denied result.  If the tester indicated that
+            access will be denied for this resource, this verifies that
+            search by patient in the resource results in an access denied result.
           )
         end
 
@@ -545,6 +605,12 @@ module Inferno
           name 'Access to Immunization resources are restricted properly based on patient-selected scope'
           link 'http://www.hl7.org/fhir/smart-app-launch/scopes-and-launch-context/index.html'
           description %(
+            This test ensures that access to the Immunization is granted or denied based on the
+            selection by the tester prior to the execution of the test.  If the tester indicated that access
+            will be granted to this resource, this test verifies that
+            a search by patient in this resource does not result in an access denied result.  If the tester indicated that
+            access will be denied for this resource, this verifies that
+            search by patient in the resource results in an access denied result.
           )
         end
 
@@ -595,6 +661,12 @@ module Inferno
           name 'Access to MedicationRequest resources are restricted properly based on patient-selected scope'
           link 'http://www.hl7.org/fhir/smart-app-launch/scopes-and-launch-context/index.html'
           description %(
+            This test ensures that access to the MedicationRequest is granted or denied based on the
+            selection by the tester prior to the execution of the test.  If the tester indicated that access
+            will be granted to this resource, this test verifies that
+            a search by patient in this resource does not result in an access denied result.  If the tester indicated that
+            access will be denied for this resource, this verifies that
+            search by patient in the resource results in an access denied result.
           )
         end
 
@@ -646,6 +718,12 @@ module Inferno
           name 'Access to Observation resources are restricted properly based on patient-selected scope'
           link 'http://www.hl7.org/fhir/smart-app-launch/scopes-and-launch-context/index.html'
           description %(
+            This test ensures that access to the Observation is granted or denied based on the
+            selection by the tester prior to the execution of the test.  If the tester indicated that access
+            will be granted to this resource, this test verifies that
+            a search by patient in this resource does not result in an access denied result.  If the tester indicated that
+            access will be denied for this resource, this verifies that
+            search by patient in the resource results in an access denied result.
           )
         end
 
@@ -697,6 +775,12 @@ module Inferno
           name 'Access to Procedure resources are restricted properly based on patient-selected scope'
           link 'http://www.hl7.org/fhir/smart-app-launch/scopes-and-launch-context/index.html'
           description %(
+            This test ensures that access to the Procedure is granted or denied based on the
+            selection by the tester prior to the execution of the test.  If the tester indicated that access
+            will be granted to this resource, this test verifies that
+            a search by patient in this resource does not result in an access denied result.  If the tester indicated that
+            access will be denied for this resource, this verifies that
+            search by patient in the resource results in an access denied result.
           )
         end
 

--- a/lib/modules/uscore_v3.1.0/access_verify_restricted_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/access_verify_restricted_sequence.rb
@@ -95,10 +95,11 @@ module Inferno
 
         skip_if @instance.received_scopes.nil?, 'A list of granted scopes was not provided to this test as required.'
 
-        # Consider all directly-mapped USCDI resources, as well as Encounter, Practitioner and Organization
-        # because they have US Core Profile references in the other US Core Profiles.  This excludes
-        # PractionerRole, Location and RelatedPerson because they do not have US Core Profile references
-        # and therefore could be 'contained' and do not have a read interaction requirement.
+        # Consider all directly-mapped USCDI resources only.  Do not fail based on the inclusion/Exclusion of Encounter, Practitioner
+        # PractitionerRole, Location, Organization, or RelatedPerson because the SUT has flexibility to decide if those
+        # should be included or not based on whether other resources are selected (e.g. if Observation then maybe it makes
+        # sense to include Encounter scope) without having the user be in charge of that particular choice.
+
         all_resources = [
           'AllergyIntolerance',
           'CarePlan',
@@ -113,12 +114,8 @@ module Inferno
           'Observation',
           'Procedure',
           'Patient',
-          'Provenance',
-          'Encounter',
-          'Practitioner',
-          'Organization'
+          'Provenance'
         ]
-
         allowed_resources = all_resources.select { |resource| scope_granting_access(resource, resource_access_as_scope).present? }
         denied_resources = all_resources - allowed_resources
         assert denied_resources.present?, "This test requires at least one resource to be denied, but the provided scope '#{@instance.received_scopes}' grants access to all resource types."

--- a/lib/modules/uscore_v3.1.0/access_verify_restricted_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/access_verify_restricted_sequence.rb
@@ -111,11 +111,12 @@ module Inferno
 
         allowed_resources = all_resources.select { |resource| scope_granting_access(resource, resource_access_as_scope) }
         denied_resources = all_resources - allowed_resources
-
         assert denied_resources.present?, "This test requires at least one resource to be denied, but the provided scope '#{@instance.received_scopes}' grants access to all resource types."
         received_scope_resources = all_resources.select { |resource| scope_granting_access(resource, @instance.received_scopes) }
         unexpected_resources = received_scope_resources - allowed_resources
         assert unexpected_resources.empty?, "This test expected the user to deny access to the following resources that are present in scopes received during token exchange response: #{unexpected_resources.join(', ')}"
+        improperly_denied_resources = allowed_resources.reject { |resource| scope_granting_access(resource, @instance.received_scopes).present? }
+        assert improperly_denied_resources.empty?, "This test expected the user to grant access to the following resources that are not received during token exhange response: #{improperly_denied_resources.join(', ')}"
         pass "Resources to be denied: #{denied_resources.join(',')}"
       end
 

--- a/lib/modules/uscore_v3.1.0/access_verify_unrestricted_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/access_verify_unrestricted_sequence.rb
@@ -42,8 +42,8 @@ module Inferno
         resource type is accessed by queries through other resource types. These resources types are accessed in the more
         comprehensive Single Patient Query tests.
 
-        However, the authorization system must indicate that access is granted to the Encounter, Practitioner and Location
-        resource types because they are required to support the read interaction.
+        However, the authorization system must indicate that access is granted to the Encounter, Practitioner and Organization
+        resource types by providing them in the returned scopes because they are required to support the read interaction.
       )
 
       requires :onc_sl_url, :token, :patient_id, :received_scopes

--- a/lib/modules/uscore_v3.1.0/access_verify_unrestricted_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/access_verify_unrestricted_sequence.rb
@@ -115,9 +115,8 @@ module Inferno
           'Patient'
         ]
 
-        allowed_resources = all_resources.select { |resource| scope_granting_access(resource, resource_access_as_scope) }
+        allowed_resources = all_resources.select { |resource| scope_granting_access(resource, @instance.received_scopes) }
         denied_resources = all_resources - allowed_resources
-
         assert denied_resources.empty?, "This test requires access to all US Core resources with patient information, but the received scope '#{@instance.received_scopes}' does not grant access to the '#{denied_resources.join(', ')}' resource type(s)."
         pass 'Scopes received indicate access to all necessary resources.'
       end

--- a/lib/modules/uscore_v3.1.0/access_verify_unrestricted_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/access_verify_unrestricted_sequence.rb
@@ -132,7 +132,6 @@ module Inferno
           'Practitioner',
           'Organization'
         ]
-
         allowed_resources = all_resources.select { |resource| scope_granting_access(resource, @instance.received_scopes).present? }
         denied_resources = all_resources - allowed_resources
         assert denied_resources.empty?, "This test requires access to all US Core resources with patient information, but the received scope '#{@instance.received_scopes}' does not grant access to the '#{denied_resources.join(', ')}' resource type(s)."

--- a/lib/modules/uscore_v3.1.0/access_verify_unrestricted_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/access_verify_unrestricted_sequence.rb
@@ -5,7 +5,7 @@ module Inferno
     class ONCAccessVerifyUnrestrictedSequence < SequenceBase
       title 'Unrestricted Resource Type Access'
 
-      description 'Verify that all resource types can be accessed by apps with appropriate scopes.'
+      description 'Verify that patients can grant access to all necessary resource types.'
       test_id_prefix 'AVU'
       details %(
         This test ensures that apps have full access to USCDI resources if granted access by the tester.
@@ -24,6 +24,11 @@ module Inferno
           * MedicationRequest
           * Observation
           * Procedure
+          * Patient
+          * Provenance
+          * Encounter
+          * Practitioner
+          * Organization
 
         For each of the resource types that can be mapped to USCDI data class or elements, this set of tests
         performs a minimum number of requests to determine that the resource type can be accessed given the
@@ -36,6 +41,9 @@ module Inferno
         Organization, Practitioner, PractionerRole, and RelatedPerson.  It also does not test Provenance, as this
         resource type is accessed by queries through other resource types. These resources types are accessed in the more
         comprehensive Single Patient Query tests.
+
+        However, the authorization system must indicate that access is granted to the Encounter, Practitioner and Location
+        resource types because they are required to support the read interaction.
       )
 
       requires :onc_sl_url, :token, :patient_id, :received_scopes
@@ -81,7 +89,7 @@ module Inferno
 
       def scope_granting_access(resource, scopes)
         scopes.split(' ').find do |scope|
-          scope.start_with?("patient/#{resource}", 'patient/*') && scope.end_with?('*', 'read')
+          scope.start_with?("patient/#{resource}.", 'patient/*.') && scope.end_with?('.*', '.read')
         end
       end
 
@@ -92,13 +100,19 @@ module Inferno
 
           link 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient'
           description %(
-            This test confirms that the scopes received during authorization match those that
-            expected for this launch.
+
+            This test confirms that the scopes granted during authorization are sufficient to access
+            all relevant US Core resources.
+
           )
         end
 
-        skip_if @instance.received_scopes.nil?, 'No SMART scopes were provided to the test.'
+        skip_if @instance.received_scopes.nil?, 'A list of granted scopes was not provided to this test as required.'
 
+        # Consider all directly-mapped USCDI resources, as well as Encounter, Practitioner and Organization
+        # because they have US Core Profile references in the other US Core Profiles.  This excludes
+        # PractionerRole, Location and RelatedPerson because they do not have US Core Profile references
+        # and therefore could be 'contained' and do not have a read interaction requirement.
         all_resources = [
           'AllergyIntolerance',
           'CarePlan',
@@ -112,10 +126,14 @@ module Inferno
           'MedicationRequest',
           'Observation',
           'Procedure',
-          'Patient'
+          'Patient',
+          'Provenance',
+          'Encounter',
+          'Practitioner',
+          'Organization'
         ]
 
-        allowed_resources = all_resources.select { |resource| scope_granting_access(resource, @instance.received_scopes) }
+        allowed_resources = all_resources.select { |resource| scope_granting_access(resource, @instance.received_scopes).present? }
         denied_resources = all_resources - allowed_resources
         assert denied_resources.empty?, "This test requires access to all US Core resources with patient information, but the received scope '#{@instance.received_scopes}' does not grant access to the '#{denied_resources.join(', ')}' resource type(s)."
         pass 'Scopes received indicate access to all necessary resources.'
@@ -124,10 +142,11 @@ module Inferno
       test :validate_patient_authorization do
         metadata do
           id '02'
-          name 'Patient resources on the FHIR server follow the US Core Implementation Guide'
-          link 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient'
+          name 'Access to Patient resource granted and patient resource can be read.'
+          link 'http://www.hl7.org/fhir/smart-app-launch/scopes-and-launch-context/index.html'
           description %(
-            This test checks if the resources returned from bulk data export conform to the US Core profiles. This includes checking for missing data elements and valueset verification.
+            This test ensures that the authorization service has granted access to the Patient resource
+            and that the patient resource can be read without an authorization error.
           )
         end
         skip_if @instance.patient_id.nil?, 'Patient ID not provided to test. The patient ID is typically provided during in a SMART launch context.'
@@ -157,6 +176,12 @@ module Inferno
           name 'Access to AllergyIntolerance resources are restricted properly based on patient-selected scope'
           link 'http://www.hl7.org/fhir/smart-app-launch/scopes-and-launch-context/index.html'
           description %(
+            This test ensures that access to the AllergyIntolerance is granted or denied based on the
+            selection by the tester prior to the execution of the test.  If the tester indicated that access
+            will be granted to this resource, this test verifies that
+            a search by patient in this resource does not result in an access denied result.  If the tester indicated that
+            access will be denied for this resource, this verifies that
+            search by patient in the resource results in an access denied result.
           )
         end
 
@@ -207,6 +232,12 @@ module Inferno
           name 'Access to CarePlan resources are restricted properly based on patient-selected scope'
           link 'http://www.hl7.org/fhir/smart-app-launch/scopes-and-launch-context/index.html'
           description %(
+            This test ensures that access to the CarePlan is granted or denied based on the
+            selection by the tester prior to the execution of the test.  If the tester indicated that access
+            will be granted to this resource, this test verifies that
+            a search by patient in this resource does not result in an access denied result.  If the tester indicated that
+            access will be denied for this resource, this verifies that
+            search by patient in the resource results in an access denied result.
           )
         end
 
@@ -258,6 +289,12 @@ module Inferno
           name 'Access to CareTeam resources are restricted properly based on patient-selected scope'
           link 'http://www.hl7.org/fhir/smart-app-launch/scopes-and-launch-context/index.html'
           description %(
+            This test ensures that access to the CareTeam is granted or denied based on the
+            selection by the tester prior to the execution of the test.  If the tester indicated that access
+            will be granted to this resource, this test verifies that
+            a search by patient in this resource does not result in an access denied result.  If the tester indicated that
+            access will be denied for this resource, this verifies that
+            search by patient in the resource results in an access denied result.
           )
         end
 
@@ -309,6 +346,12 @@ module Inferno
           name 'Access to Condition resources are restricted properly based on patient-selected scope'
           link 'http://www.hl7.org/fhir/smart-app-launch/scopes-and-launch-context/index.html'
           description %(
+            This test ensures that access to the Condition is granted or denied based on the
+            selection by the tester prior to the execution of the test.  If the tester indicated that access
+            will be granted to this resource, this test verifies that
+            a search by patient in this resource does not result in an access denied result.  If the tester indicated that
+            access will be denied for this resource, this verifies that
+            search by patient in the resource results in an access denied result.
           )
         end
 
@@ -359,6 +402,12 @@ module Inferno
           name 'Access to Device resources are restricted properly based on patient-selected scope'
           link 'http://www.hl7.org/fhir/smart-app-launch/scopes-and-launch-context/index.html'
           description %(
+            This test ensures that access to the Device is granted or denied based on the
+            selection by the tester prior to the execution of the test.  If the tester indicated that access
+            will be granted to this resource, this test verifies that
+            a search by patient in this resource does not result in an access denied result.  If the tester indicated that
+            access will be denied for this resource, this verifies that
+            search by patient in the resource results in an access denied result.
           )
         end
 
@@ -395,6 +444,12 @@ module Inferno
           name 'Access to DiagnosticReport resources are restricted properly based on patient-selected scope'
           link 'http://www.hl7.org/fhir/smart-app-launch/scopes-and-launch-context/index.html'
           description %(
+            This test ensures that access to the DiagnosticReport is granted or denied based on the
+            selection by the tester prior to the execution of the test.  If the tester indicated that access
+            will be granted to this resource, this test verifies that
+            a search by patient in this resource does not result in an access denied result.  If the tester indicated that
+            access will be denied for this resource, this verifies that
+            search by patient in the resource results in an access denied result.
           )
         end
 
@@ -446,6 +501,12 @@ module Inferno
           name 'Access to DocumentReference resources are restricted properly based on patient-selected scope'
           link 'http://www.hl7.org/fhir/smart-app-launch/scopes-and-launch-context/index.html'
           description %(
+            This test ensures that access to the DocumentReference is granted or denied based on the
+            selection by the tester prior to the execution of the test.  If the tester indicated that access
+            will be granted to this resource, this test verifies that
+            a search by patient in this resource does not result in an access denied result.  If the tester indicated that
+            access will be denied for this resource, this verifies that
+            search by patient in the resource results in an access denied result.
           )
         end
 
@@ -496,6 +557,12 @@ module Inferno
           name 'Access to Goal resources are restricted properly based on patient-selected scope'
           link 'http://www.hl7.org/fhir/smart-app-launch/scopes-and-launch-context/index.html'
           description %(
+            This test ensures that access to the Goal is granted or denied based on the
+            selection by the tester prior to the execution of the test.  If the tester indicated that access
+            will be granted to this resource, this test verifies that
+            a search by patient in this resource does not result in an access denied result.  If the tester indicated that
+            access will be denied for this resource, this verifies that
+            search by patient in the resource results in an access denied result.
           )
         end
 
@@ -546,6 +613,12 @@ module Inferno
           name 'Access to Immunization resources are restricted properly based on patient-selected scope'
           link 'http://www.hl7.org/fhir/smart-app-launch/scopes-and-launch-context/index.html'
           description %(
+            This test ensures that access to the Immunization is granted or denied based on the
+            selection by the tester prior to the execution of the test.  If the tester indicated that access
+            will be granted to this resource, this test verifies that
+            a search by patient in this resource does not result in an access denied result.  If the tester indicated that
+            access will be denied for this resource, this verifies that
+            search by patient in the resource results in an access denied result.
           )
         end
 
@@ -596,6 +669,12 @@ module Inferno
           name 'Access to MedicationRequest resources are restricted properly based on patient-selected scope'
           link 'http://www.hl7.org/fhir/smart-app-launch/scopes-and-launch-context/index.html'
           description %(
+            This test ensures that access to the MedicationRequest is granted or denied based on the
+            selection by the tester prior to the execution of the test.  If the tester indicated that access
+            will be granted to this resource, this test verifies that
+            a search by patient in this resource does not result in an access denied result.  If the tester indicated that
+            access will be denied for this resource, this verifies that
+            search by patient in the resource results in an access denied result.
           )
         end
 
@@ -647,6 +726,12 @@ module Inferno
           name 'Access to Observation resources are restricted properly based on patient-selected scope'
           link 'http://www.hl7.org/fhir/smart-app-launch/scopes-and-launch-context/index.html'
           description %(
+            This test ensures that access to the Observation is granted or denied based on the
+            selection by the tester prior to the execution of the test.  If the tester indicated that access
+            will be granted to this resource, this test verifies that
+            a search by patient in this resource does not result in an access denied result.  If the tester indicated that
+            access will be denied for this resource, this verifies that
+            search by patient in the resource results in an access denied result.
           )
         end
 
@@ -698,6 +783,12 @@ module Inferno
           name 'Access to Procedure resources are restricted properly based on patient-selected scope'
           link 'http://www.hl7.org/fhir/smart-app-launch/scopes-and-launch-context/index.html'
           description %(
+            This test ensures that access to the Procedure is granted or denied based on the
+            selection by the tester prior to the execution of the test.  If the tester indicated that access
+            will be granted to this resource, this test verifies that
+            a search by patient in this resource does not result in an access denied result.  If the tester indicated that
+            access will be denied for this resource, this verifies that
+            search by patient in the resource results in an access denied result.
           )
         end
 

--- a/lib/modules/uscore_v3.1.0/access_verify_unrestricted_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/access_verify_unrestricted_sequence.rb
@@ -89,7 +89,7 @@ module Inferno
 
       def scope_granting_access(resource, scopes)
         scopes.split(' ').find do |scope|
-          scope.start_with?("patient/#{resource}.", 'patient/*.') && scope.end_with?('.*', '.read')
+          ['patient/*.read', 'patient/*.*', "patient/#{resource}.read", "patient/#{resource}.*"].include? scope
         end
       end
 

--- a/lib/modules/uscore_v3.1.0/test/access_verify_restricted_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/access_verify_restricted_test.rb
@@ -44,9 +44,9 @@ describe Inferno::Sequence::ONCAccessVerifyRestrictedSequence do
       assert_raises(Inferno::PassException) { @sequence.run_test(@test) }
     end
 
-    it 'passes if PractitionerRole, Location and RelatedPerson scope provided' do
-      @instance.received_scopes = 'patient/PractitionerRole.read patient/Location.read patient/RelatedPerson.read launch/patient openid fhirUser patient/Observation.* '\
-                                  'patient/Condition.* patient/Patient.*'
+    it 'passes if Practitioner, Organization, Encounter, PractitionerRole, Location, RelatedPerson scope provided' do
+      @instance.received_scopes = 'patient/PractitionerRole.read patient/Location.read patient/RelatedPerson.read launch/patient openid fhirUser patient/Observation.read '\
+                                  'patient/Condition.read patient/Patient.read patient/Encounter.read patient/Practitioner.read patient/Organization.read'
       assert_raises(Inferno::PassException) { @sequence.run_test(@test) }
     end
 

--- a/lib/modules/uscore_v3.1.0/test/access_verify_restricted_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/access_verify_restricted_test.rb
@@ -1,0 +1,182 @@
+# frozen_string_literal: true
+
+# NOTE: This is a generated file. Any changes made to this file will be
+#       overwritten when it is regenerated
+
+require_relative '../../../../test/test_helper'
+
+describe Inferno::Sequence::ONCAccessVerifyRestrictedSequence do
+  before do
+    @sequence_class = Inferno::Sequence::ONCAccessVerifyRestrictedSequence
+    @base_url = 'http://www.example.com/fhir'
+    @token = 'ABC'
+    @instance = Inferno::Models::TestingInstance.create(url: @base_url, onc_sl_url: @base_url, token: @token, selected_module: 'uscore_v3.1.0')
+    @client = FHIR::Client.for_testing_instance(@instance)
+    @patient_ids = 'example'
+    @instance.patient_id = @instance.patient_ids = @patient_ids
+    @auth_header = { 'Authorization' => "Bearer #{@token}" }
+  end
+
+  describe 'Validate correct scopes granted test' do
+    before do
+      @test = @sequence_class[:validate_right_scopes]
+      @sequence = @sequence_class.new(@instance, @client)
+      @instance.onc_sl_expected_resources = 'Observation, Condition, Patient'
+    end
+
+    it 'passes if only limited scopes received' do
+      @instance.received_scopes = 'launch/patient openid fhirUser patient/Observation.read patient/Condition.read patient/Patient.read'
+      assert_raises(Inferno::PassException) { @sequence.run_test(@test) }
+    end
+
+    it 'fails if wildcard resource scopes returned' do
+      @instance.received_scopes = 'launch/patient openid fhirUser patient/*.read'
+      assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+    end
+
+    it 'passes if wildcard access scopes used' do
+      @instance.received_scopes = 'launch/patient openid fhirUser patient/Observation.* patient/Condition.* patient/Patient.*'
+      assert_raises(Inferno::PassException) { @sequence.run_test(@test) }
+    end
+
+    it 'passes if unknown scope provided' do
+      @instance.received_scopes = 'proprietary_scope launch/patient openid fhirUser patient/Observation.* patient/Condition.* patient/Patient.*'
+      assert_raises(Inferno::PassException) { @sequence.run_test(@test) }
+    end
+
+    it 'passes if PractitionerRole, Location and RelatedPerson scope provided' do
+      @instance.received_scopes = 'patient/PractitionerRole.read patient/Location.read patient/RelatedPerson.read launch/patient openid fhirUser patient/Observation.* '\
+                                  'patient/Condition.* patient/Patient.*'
+      assert_raises(Inferno::PassException) { @sequence.run_test(@test) }
+    end
+
+    it 'fails if additional resource scope provided' do
+      @instance.received_scopes = 'launch/patient openid fhirUser patient/AllergyIntolerance.read patient/Observation.read patient/Condition.read patient/Patient.read'
+      assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+    end
+
+    it 'fails if scope chosen to be included is omitted' do
+      @instance.received_scopes = 'launch/patient openid fhirUser patient/Condition.read patient/Patient.read'
+      assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+    end
+
+    it 'fails if offline_acess received' do
+      @instance.received_scopes = 'launch/patient offline_access openid fhirUser patient/Observation.read patient/Condition.read patient/Patient.read'
+      assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+    end
+  end
+
+  describe 'Validate Patient Authorization' do
+    before do
+      @test = @sequence_class[:validate_patient_authorization]
+      @sequence = @sequence_class.new(@instance, @client)
+      @instance.received_scopes = 'launch/patient openid fhirUser offline_access patient/Medication.read patient/AllergyIntolerance.read patient/CarePlan.read '\
+                                  'patient/CareTeam.read patient/Condition.read patient/Device.read patient/DiagnosticReport.read patient/DocumentReference.read '\
+                                  'patient/Encounter.read patient/Goal.read patient/Immunization.read patient/Location.read patient/MedicationRequest.read '\
+                                  'patient/Observation.read patient/Organization.read patient/Patient.read patient/Practitioner.read patient/PractitionerRole.read '\
+                                  'patient/Procedure.read patient/Provenance.read patient/RelatedPerson.read'
+      @instance.onc_sl_expected_resources = 'Observation, Condition, Patient'
+    end
+
+    it 'passes if success response received' do
+      stub_request(:get, "#{@base_url}/Patient/#{@patient_ids}")
+        .with(headers: @auth_header)
+        .to_return(status: 200)
+
+      assert_raises(Inferno::PassException) { @sequence.run_test(@test) }
+    end
+
+    it 'fails if 401 response received' do
+      stub_request(:get, "#{@base_url}/Patient/#{@patient_ids}")
+        .with(headers: @auth_header)
+        .to_return(status: 401)
+
+      assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+    end
+
+    it 'fails if 403 response received' do
+      stub_request(:get, "#{@base_url}/Patient/#{@patient_ids}")
+        .with(headers: @auth_header)
+        .to_return(status: 403)
+
+      assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+    end
+  end
+  describe 'Validate AllergyIntolerance authorization when not selected' do
+    before do
+      @test = @sequence_class[:validate_allergyintolerance_authorization]
+      @sequence = @sequence_class.new(@instance, @client)
+      @instance.received_scopes = 'launch/patient openid fhirUser offline_access patient/Observation.read patient/Condition.read '\
+                                  'patient/Patient.read'
+      @instance.onc_sl_expected_resources = 'Observation, Condition, Patient'
+    end
+
+    it 'fails if success response received' do
+      stub_request(:get, "#{@base_url}/AllergyIntolerance?patient=#{@patient_ids}")
+        .with(headers: @auth_header)
+        .to_return(status: 200)
+
+      assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+    end
+
+    it 'passes if 401 response received' do
+      stub_request(:get, "#{@base_url}/AllergyIntolerance?patient=#{@patient_ids}")
+        .with(headers: @auth_header)
+        .to_return(status: 401)
+
+      @sequence.run_test(@test)
+    end
+
+    it 'passes if 403 response received' do
+      stub_request(:get, "#{@base_url}/AllergyIntolerance?patient=#{@patient_ids}")
+        .with(headers: @auth_header)
+        .to_return(status: 403)
+
+      @sequence.run_test(@test)
+    end
+  end
+  describe 'Validate AllergyIntolerance authorization when selected by tester' do
+    before do
+      @test = @sequence_class[:validate_allergyintolerance_authorization]
+      @sequence = @sequence_class.new(@instance, @client)
+      @instance.received_scopes = 'launch/patient openid fhirUser offline_access patient/AllergyIntolerance.read patient/Observation.read patient/Condition.read '\
+                                  'patient/Patient.read'
+      @instance.onc_sl_expected_resources = 'AllergyIntolerance,Observation, Condition, Patient'
+    end
+
+    it 'passes if success response received' do
+      stub_request(:get, "#{@base_url}/AllergyIntolerance?patient=#{@patient_ids}")
+        .with(headers: @auth_header)
+        .to_return(status: 200)
+
+      assert_raises(Inferno::PassException) { @sequence.run_test(@test) }
+    end
+
+    it 'passes if 400 received followed by success' do
+      stub_request(:get, "#{@base_url}/AllergyIntolerance?patient=#{@patient_ids}")
+        .with(headers: @auth_header)
+        .to_return(status: 400, body: { resourceType: 'OperationOutcome' }.to_json)
+      stub_request(:get, "#{@base_url}/AllergyIntolerance?patient=#{@patient_ids}&clinical-status=active")
+        .with(headers: @auth_header)
+        .to_return(status: 200)
+
+      assert_raises(Inferno::PassException) { @sequence.run_test(@test) }
+    end
+
+    it 'fails if 401 response received' do
+      stub_request(:get, "#{@base_url}/AllergyIntolerance?patient=#{@patient_ids}")
+        .with(headers: @auth_header)
+        .to_return(status: 401)
+
+      assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+    end
+
+    it 'fails if 403 response received' do
+      stub_request(:get, "#{@base_url}/AllergyIntolerance?patient=#{@patient_ids}")
+        .with(headers: @auth_header)
+        .to_return(status: 403)
+
+      assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+    end
+  end
+end

--- a/lib/modules/uscore_v3.1.0/test/access_verify_unrestricted_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/access_verify_unrestricted_test.rb
@@ -51,7 +51,7 @@ describe Inferno::Sequence::ONCAccessVerifyUnrestrictedSequence do
       assert_raises(Inferno::PassException) { @sequence.run_test(@test) }
     end
 
-    it 'passes if Medication, PractitionerRole, Location and Related Person are omitted' do
+    it 'passes if Medication, PractitionerRole, Location and RelatedPerson are omitted' do
       @instance.received_scopes = 'launch/patient openid fhirUser offline_access patient/AllergyIntolerance.read patient/CarePlan.read '\
                                   'patient/CareTeam.read patient/Condition.read patient/Device.read patient/DiagnosticReport.read patient/DocumentReference.read '\
                                   'patient/Encounter.read patient/Goal.read patient/Immunization.read patient/MedicationRequest.read '\

--- a/lib/modules/uscore_v3.1.0/test/access_verify_unrestricted_test.rb
+++ b/lib/modules/uscore_v3.1.0/test/access_verify_unrestricted_test.rb
@@ -1,0 +1,170 @@
+# frozen_string_literal: true
+
+# NOTE: This is a generated file. Any changes made to this file will be
+#       overwritten when it is regenerated
+
+require_relative '../../../../test/test_helper'
+
+describe Inferno::Sequence::ONCAccessVerifyUnrestrictedSequence do
+  before do
+    @sequence_class = Inferno::Sequence::ONCAccessVerifyUnrestrictedSequence
+    @base_url = 'http://www.example.com/fhir'
+    @token = 'ABC'
+    @instance = Inferno::Models::TestingInstance.create(url: @base_url, onc_sl_url: @base_url, token: @token, selected_module: 'uscore_v3.1.0')
+    @client = FHIR::Client.for_testing_instance(@instance)
+    @patient_ids = 'example'
+    @instance.patient_id = @instance.patient_ids = @patient_ids
+    @auth_header = { 'Authorization' => "Bearer #{@token}" }
+  end
+
+  describe 'Validate correct scopes granted test' do
+    before do
+      @test = @sequence_class[:validate_right_scopes]
+      @sequence = @sequence_class.new(@instance, @client)
+    end
+
+    it 'passes if all scopes are received without any wildcards' do
+      @instance.received_scopes = 'launch/patient openid fhirUser offline_access patient/Medication.read patient/AllergyIntolerance.read patient/CarePlan.read '\
+                                  'patient/CareTeam.read patient/Condition.read patient/Device.read patient/DiagnosticReport.read patient/DocumentReference.read '\
+                                  'patient/Encounter.read patient/Goal.read patient/Immunization.read patient/Location.read patient/MedicationRequest.read '\
+                                  'patient/Observation.read patient/Organization.read patient/Patient.read patient/Practitioner.read patient/PractitionerRole.read '\
+                                  'patient/Procedure.read patient/Provenance.read patient/RelatedPerson.read'
+      assert_raises(Inferno::PassException) { @sequence.run_test(@test) }
+    end
+
+    it 'passes if wildcard resource scopes used' do
+      @instance.received_scopes = 'launch/patient openid fhirUser offline_access patient/*.read'
+      assert_raises(Inferno::PassException) { @sequence.run_test(@test) }
+    end
+
+    it 'passes if wildcard resource and access scopes used' do
+      @instance.received_scopes = 'launch/patient openid fhirUser offline_access patient/*.*'
+      assert_raises(Inferno::PassException) { @sequence.run_test(@test) }
+    end
+
+    it 'passes if wildcard access scopes used' do
+      @instance.received_scopes = 'launch/patient openid fhirUser offline_access patient/Medication.* patient/AllergyIntolerance.* patient/CarePlan.* '\
+                                  'patient/CareTeam.* patient/Condition.* patient/Device.* patient/DiagnosticReport.* patient/DocumentReference.* '\
+                                  'patient/Encounter.* patient/Goal.* patient/Immunization.* patient/Location.* patient/MedicationRequest.* '\
+                                  'patient/Observation.* patient/Organization.* patient/Patient.* patient/Practitioner.* patient/PractitionerRole.* '\
+                                  'patient/Procedure.* patient/Provenance.* patient/RelatedPerson.*'
+      assert_raises(Inferno::PassException) { @sequence.run_test(@test) }
+    end
+
+    it 'passes if Medication, PractitionerRole, Location and Related Person are omitted' do
+      @instance.received_scopes = 'launch/patient openid fhirUser offline_access patient/AllergyIntolerance.read patient/CarePlan.read '\
+                                  'patient/CareTeam.read patient/Condition.read patient/Device.read patient/DiagnosticReport.read patient/DocumentReference.read '\
+                                  'patient/Encounter.read patient/Goal.read patient/Immunization.read patient/MedicationRequest.read '\
+                                  'patient/Observation.read patient/Organization.read patient/Patient.read patient/Practitioner.read '\
+                                  'patient/Procedure.read patient/Provenance.read'
+      assert_raises(Inferno::PassException) { @sequence.run_test(@test) }
+    end
+
+    it 'passes if unknown scope provided' do
+      @instance.received_scopes = 'launch/patient openid fhirUser offline_access patient/Medication.read patient/AllergyIntolerance.read patient/CarePlan.read '\
+                                  'patient/CareTeam.read patient/Condition.read patient/Device.read patient/DiagnosticReport.read patient/DocumentReference.read '\
+                                  'patient/Encounter.read patient/Goal.read patient/Immunization.read patient/Location.read patient/MedicationRequest.read '\
+                                  'patient/Observation.read patient/Organization.read patient/Patient.read patient/Practitioner.read patient/PractitionerRole.read '\
+                                  'patient/Procedure.read patient/Provenance.read patient/RelatedPerson.read proprietary_scope'
+      assert_raises(Inferno::PassException) { @sequence.run_test(@test) }
+    end
+
+    it 'fails if Patient scope is omitted' do
+      @instance.received_scopes = 'launch/patient openid fhirUser offline_access patient/Medication.read patient/AllergyIntolerance.read patient/CarePlan.read '\
+                                  'patient/CareTeam.read patient/Condition.read patient/Device.read patient/DiagnosticReport.read patient/DocumentReference.read '\
+                                  'patient/Encounter.read patient/Goal.read patient/Immunization.read patient/Location.read patient/MedicationRequest.read '\
+                                  'patient/Observation.read patient/Organization.read patient/Practitioner.read patient/PractitionerRole.read '\
+                                  'patient/Procedure.read patient/Provenance.read patient/RelatedPerson.read'
+      assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+    end
+
+    it 'fails if AllergyIntolerance scope is omitted' do
+      @instance.received_scopes = 'launch/patient openid fhirUser offline_access patient/Medication.read patient/CarePlan.read '\
+                                  'patient/CareTeam.read patient/Condition.read patient/Device.read patient/DiagnosticReport.read patient/DocumentReference.read '\
+                                  'patient/Encounter.read patient/Goal.read patient/Immunization.read patient/Location.read patient/MedicationRequest.read '\
+                                  'patient/Observation.read patient/Organization.read patient/Patient.read patient/Practitioner.read patient/PractitionerRole.read '\
+                                  'patient/Procedure.read patient/Provenance.read patient/RelatedPerson.read'
+      assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+    end
+
+    it 'fails if Practitioner scope is omitted' do
+      @instance.received_scopes = 'launch/patient openid fhirUser offline_access patient/Medication.read patient/AllergyIntolerance.read patient/CarePlan.read '\
+                                  'patient/CareTeam.read patient/Condition.read patient/Device.read patient/DiagnosticReport.read patient/DocumentReference.read '\
+                                  'patient/Encounter.read patient/Goal.read patient/Immunization.read patient/Location.read patient/MedicationRequest.read '\
+                                  'patient/Observation.read patient/Organization.read patient/Patient.read patient/PractitionerRole.read '\
+                                  'patient/Procedure.read patient/Provenance.read patient/RelatedPerson.read'
+      assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+    end
+  end
+
+  describe 'Validate Patient Authorization' do
+    before do
+      @test = @sequence_class[:validate_patient_authorization]
+      @sequence = @sequence_class.new(@instance, @client)
+      @instance.received_scopes = 'launch/patient openid fhirUser offline_access patient/Medication.read patient/AllergyIntolerance.read patient/CarePlan.read '\
+                                  'patient/CareTeam.read patient/Condition.read patient/Device.read patient/DiagnosticReport.read patient/DocumentReference.read '\
+                                  'patient/Encounter.read patient/Goal.read patient/Immunization.read patient/Location.read patient/MedicationRequest.read '\
+                                  'patient/Observation.read patient/Organization.read patient/Patient.read patient/Practitioner.read patient/PractitionerRole.read '\
+                                  'patient/Procedure.read patient/Provenance.read patient/RelatedPerson.read'
+    end
+
+    it 'passes if success response received' do
+      stub_request(:get, "#{@base_url}/Patient/#{@patient_ids}")
+        .with(headers: @auth_header)
+        .to_return(status: 200)
+
+      assert_raises(Inferno::PassException) { @sequence.run_test(@test) }
+    end
+
+    it 'fails if 401 response received' do
+      stub_request(:get, "#{@base_url}/Patient/#{@patient_ids}")
+        .with(headers: @auth_header)
+        .to_return(status: 401)
+
+      assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+    end
+
+    it 'fails if 403 response received' do
+      stub_request(:get, "#{@base_url}/Patient/#{@patient_ids}")
+        .with(headers: @auth_header)
+        .to_return(status: 403)
+
+      assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+    end
+  end
+  describe 'Validate AllergyIntolerance Authorization' do
+    before do
+      @test = @sequence_class[:validate_allergyintolerance_authorization]
+      @sequence = @sequence_class.new(@instance, @client)
+      @instance.received_scopes = 'launch/patient openid fhirUser offline_access patient/Medication.read patient/AllergyIntolerance.read patient/CarePlan.read '\
+                                  'patient/CareTeam.read patient/Condition.read patient/Device.read patient/DiagnosticReport.read patient/DocumentReference.read '\
+                                  'patient/Encounter.read patient/Goal.read patient/Immunization.read patient/Location.read patient/MedicationRequest.read '\
+                                  'patient/Observation.read patient/Organization.read patient/Patient.read patient/Practitioner.read patient/PractitionerRole.read '\
+                                  'patient/Procedure.read patient/Provenance.read patient/RelatedPerson.read'
+    end
+
+    it 'passes if success response received' do
+      stub_request(:get, "#{@base_url}/AllergyIntolerance?patient=#{@patient_ids}")
+        .with(headers: @auth_header)
+        .to_return(status: 200)
+
+      assert_raises(Inferno::PassException) { @sequence.run_test(@test) }
+    end
+
+    it 'fails if 401 response received' do
+      stub_request(:get, "#{@base_url}/AllergyIntolerance?patient=#{@patient_ids}")
+        .with(headers: @auth_header)
+        .to_return(status: 401)
+
+      assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+    end
+
+    it 'fails if 403 response received' do
+      stub_request(:get, "#{@base_url}/AllergyIntolerance?patient=#{@patient_ids}")
+        .with(headers: @auth_header)
+        .to_return(status: 403)
+
+      assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+    end
+  end
+end


### PR DESCRIPTION
This update refines our 'Access verify' set of tests.  The intent of these tests are to ensure that patients have control over what scopes are granted to the application.  We accomplish this by having one sequence that requires full scopes, and verifies that the scopes returned by the server have all the required scopes to get all USCDI references.  And another sequence that prompts the tester to choose a subset of scopes (defaulting to Observation, Condition and Patient), and then the tester is supposed to only grant those scopes, and Inferno verifies that is the case for what is returned.

Previously, these tests passed more than they should have (you could allow for extra scopes in certain cases).  This PR much more thoroughly ensures that the logic is correct, and contains a number of self-tests to ensure that they are.

To try it out, on the 'Single Patient App' set of tests, it should pass if you allow all scopes.  It should pass if you deny 'PractitionerRole, Location, RelatedPerson, Medication' on our reference server as well, because implementations could technically NOT implement 'read' for those resources so we provide flexibility there.  But it should fail if you uncheck any others.

Then, try out the Limited Patient App set of tests.  For this, it should pass if you deny everything except patient/launch and the resources you selected (by default Condition, Observation, Patient).  It should also pass if you allow those that you chose as well as Practitioner, PractitionerRole, Location, RelatedPerson, Encounter and Medication, because it is up to the SUT to decide if those other resources are needed and there doesn't ahve to be an explicit user option to allow/deny them.  Also, it should fail if you do not check off `offline_access`, because we are checking to make sure that it is there in this scenario.

Pull requests into Inferno require the following items to be completed. Submitter and reviewer 
should check the relevant check boxes when the associated item is done. For items that are not 
applicable, note it's not applicable ("N/A") and check the box. For example, external Pull 
Requests do not require ticket links.

**Submitter:**
- [x] This pull request describes why these changes were made
- [x] Internal ticket for this PR: FI-920
- [x] Internal ticket links to this PR
- [x] Internal ticket is properly labeled (Community/Program)
- [x] Internal ticket has a justification for its Community/Program label
- [x] Code diff has been reviewed for extraneous/missing code
- [x] Tests are included and test edge cases
- [x] Tests/code quality metrics have been run locally and pass


**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
