### PR TITLE
FI-925: Display validator version info

### DIFF
--- a/lib/app/utils/hl7_validator.rb
+++ b/lib/app/utils/hl7_validator.rb
@@ -28,13 +28,17 @@ module Inferno
       issues_by_severity(outcome.issue)
     end
 
-    # @return [String] the version of the validator currently being used
+    # @return [String] the version of the validator currently being used or nil
+    #   if unable to reach the /version endpoint
     def version
       Inferno.logger.info('Fetching validator version')
       Inferno.logger.info("GET #{@validator_url}/version")
 
       result = RestClient.get "#{@validator_url}/version"
       result.body
+    rescue StandardError
+      Inferno.logger.error('Unable to reach the /version validator endpoint. Please ensure that the validator is up to date.')
+      nil
     end
 
     private

--- a/lib/app/utils/hl7_validator.rb
+++ b/lib/app/utils/hl7_validator.rb
@@ -28,6 +28,15 @@ module Inferno
       issues_by_severity(outcome.issue)
     end
 
+    # @return [String] the version of the validator currently being used
+    def version
+      Inferno.logger.info('Fetching validator version')
+      Inferno.logger.info("GET #{@validator_url}/version")
+
+      result = RestClient.get "#{@validator_url}/version"
+      result.body
+    end
+
     private
 
     def issues_by_severity(issues)

--- a/lib/app/views/server_state.erb
+++ b/lib/app/views/server_state.erb
@@ -1,6 +1,16 @@
 <div id="server-state">
   <div>
-    <h4>Code Systems and Versions used in Inferno</h4>
+    <h4>Validator Type and Version Currently in Use</h4>
+    <p>
+      <% if settings.resource_validator == 'external' %>
+        The version of the HL7 Validator currently used for validation is <%= Inferno::RESOURCE_VALIDATOR.version %>.
+      <% else %>
+        The version of the FHIR Models Validator currently used for validation is <%= FHIR::Models::VERSION %>.
+      <% end %>
+    </p>
+  </div>
+  <div>
+    <h4>Code System Versions used in Inferno</h4>
     <p>
       The following code systems are derived from the Unified Medical Language System (UMLS)
       developed by the National Library of Medicine.

--- a/lib/app/views/server_state.erb
+++ b/lib/app/views/server_state.erb
@@ -3,7 +3,8 @@
     <h4>Validator Type and Version Currently in Use</h4>
     <p>
       <% if settings.resource_validator == 'external' %>
-        The version of the HL7 Validator currently used for validation is <%= Inferno::RESOURCE_VALIDATOR.version %>.
+        The version of the HL7 Validator currently used for validation is
+        <%= Inferno::RESOURCE_VALIDATOR.version || 'not found. Please ensure that the validator is running and is up to date' %>.
       <% else %>
         The version of the FHIR Models Validator currently used for validation is <%= FHIR::Models::VERSION %>.
       <% end %>

--- a/test/unit/hl7_validator_test.rb
+++ b/test/unit/hl7_validator_test.rb
@@ -56,5 +56,11 @@ describe Inferno::HL7Validator do
 
       assert_equal '5.0.11-SNAPSHOT', @validator.version
     end
+
+    it 'Should return nil if /version is not found' do
+      stub_request(:get, "#{@validator_url}/version")
+        .to_return(status: 404)
+      assert_nil @validator.version
+    end
   end
 end

--- a/test/unit/hl7_validator_test.rb
+++ b/test/unit/hl7_validator_test.rb
@@ -48,4 +48,13 @@ describe Inferno::HL7Validator do
       assert result[:information].length == 5
     end
   end
+
+  describe 'Fetching the validator version' do
+    it 'Should return the version string' do
+      stub_request(:get, "#{@validator_url}/version")
+        .to_return(status: 200, body: '5.0.11-SNAPSHOT')
+
+      assert_equal '5.0.11-SNAPSHOT', @validator.version
+    end
+  end
 end


### PR DESCRIPTION
This PR adds a new section to the "Server Configuration" modal to display the validator version info, which is useful for certification purposes.

**Submitter:**
- [x] This pull request describes why these changes were made
- [x] Internal ticket for this PR: https://oncprojectracking.healthit.gov/support/browse/FI-925
- [x] Internal ticket links to this PR
- [x] Internal ticket is properly labeled (Community/Program)
- [x] Internal ticket has a justification for its Community/Program label
- [x] Code diff has been reviewed for extraneous/missing code
- [x] Tests are included and test edge cases
- [x] Tests/code quality metrics have been run locally and pass


**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
