### PR TITLE
FI-934 Add monkey patches to fhir_models to save source_content 

### DIFF
--- a/lib/app/ext/fhir_models.rb
+++ b/lib/app/ext/fhir_models.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+require 'json'
+
+# Extension to FHIR::Model. Prepending this into FHIR::Model (done below)
+# allows us to call super() on initialize when we overriding it,
+# while also defining new methods and attributes
+module InfernoFHIRModelExtensions
+  # These need to be attr_writers so they can be written to from from_json/xml
+  # And so they can be deserialized
+  attr_writer :source_hash, :source_text
+
+  def initialize(hash = {})
+    super(hash)
+    @source_hash = hash
+  end
+
+  def source_contents
+    @source_text || JSON.generate(@source_hash)
+  end
+end
+
+module FHIR
+  class Model
+    prepend ::InfernoFHIRModelExtensions
+  end
+end
+
+# Extension to FHIR::Json. Prepending this into FHIR::Json (done below)
+# allows us to call super() on from_json
+module InfernoJson
+  def from_json(json)
+    resource = super(json)
+    resource.source_text = json
+    resource
+  end
+end
+
+# Extension to FHIR::Xml. Prepending this into FHIR::Xml (done below)
+# allows us to call super() on from_xml
+module InfernoXml
+  def from_xml(xml)
+    resource = super(xml)
+    resource.source_text = xml
+    resource
+  end
+end
+
+module FHIR
+  module Json
+    class << self
+      prepend InfernoJson
+    end
+  end
+end
+
+module FHIR
+  module Xml
+    class << self
+      prepend InfernoXml
+    end
+  end
+end

--- a/lib/app/sequence_base.rb
+++ b/lib/app/sequence_base.rb
@@ -3,6 +3,7 @@
 require_relative 'utils/assertions'
 require_relative 'utils/skip_helpers'
 require_relative 'ext/fhir_client'
+require_relative 'ext/fhir_models'
 require_relative 'utils/logged_rest_client'
 require_relative 'utils/exceptions'
 require_relative 'utils/validation'

--- a/lib/app/utils/hl7_validator.rb
+++ b/lib/app/utils/hl7_validator.rb
@@ -17,7 +17,7 @@ module Inferno
       Inferno.logger.info("Validating #{resource.resourceType} resource with id #{resource.id}")
       Inferno.logger.info("POST #{@validator_url}/validate?profile=#{profile_url}")
 
-      result = RestClient.post "#{@validator_url}/validate", resource.to_json, params: { profile: profile_url }
+      result = RestClient.post "#{@validator_url}/validate", resource.source_contents, params: { profile: profile_url }
       outcome = fhir_models_klass.from_contents(result.body)
       fatals = issues_by_severity(outcome.issue, 'fatal')
       errors = issues_by_severity(outcome.issue, 'error')

--- a/test/fixtures/bundle_primitive_extensions.json
+++ b/test/fixtures/bundle_primitive_extensions.json
@@ -1,0 +1,40 @@
+{
+  "resourceType": "Bundle",
+  "type": "collection",
+  "entry": [
+    {
+      "resource": {
+        "resourceType": "Patient",
+        "id": "1",
+        "_deceasedDateTime": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
+              "valueCode": "unknown"
+            }
+          ]
+        }
+      }
+    },
+    {
+      "resource": {
+        "resourceType": "Procedure",
+        "id": "2",
+        "_performedDateTime": {
+          "extension": [
+            {
+              "url": "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
+              "valueCode": "unknown"
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "link": [
+    {
+      "relation": "next",
+      "url": "http://www.example.com/2"
+    }
+  ]
+}

--- a/test/fixtures/contained_resource.json
+++ b/test/fixtures/contained_resource.json
@@ -1,0 +1,26 @@
+{
+  "resourceType": "Condition",
+  "contained": [
+    {
+      "resourceType": "Practitioner",
+      "id": "p1",
+      "name": [
+        {
+          "family": "Person",
+          "given": ["Patricia"]
+        }
+      ],
+      "_birthDate": {
+        "extension": [
+          {
+            "url": "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
+            "valueCode": "unknown"
+          }
+        ]
+      }
+    }
+  ],
+  "asserter": {
+    "reference": "#p1"
+  }
+}

--- a/test/fixtures/procedure_primitive_extension.json
+++ b/test/fixtures/procedure_primitive_extension.json
@@ -1,0 +1,12 @@
+{
+  "resourceType": "Procedure",
+  "id": "PrimitiveProcedure1",
+  "_performedDateTime": {
+    "extension": [
+      {
+        "url": "http://hl7.org/fhir/StructureDefinition/data-absent-reason",
+        "valueCode": "unknown"
+      }
+    ]
+  }
+}

--- a/test/unit/fhir_models_test.rb
+++ b/test/unit/fhir_models_test.rb
@@ -14,6 +14,13 @@ describe FHIR::Models do
         assert_instance_of String, entry.resource.source_contents
       end
     end
+
+    it 'should preserve primitive extensions in source_contents' do
+      procedure_json = File.read('test/fixtures/procedure_primitive_extension.json')
+      procedure_resource = FHIR.from_contents(procedure_json)
+      assert procedure_resource.source_contents.include?('_performedDateTime'), 'Primitive extension key was lost'
+      assert procedure_resource.source_contents.include?('http://hl7.org/fhir/StructureDefinition/data-absent-reason'), 'Primitive extension URL was lost'
+    end
   end
 
   describe '#initialize' do

--- a/test/unit/fhir_models_test.rb
+++ b/test/unit/fhir_models_test.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require File.expand_path '../test_helper.rb', __dir__
+
+describe FHIR::Models do
+  describe '#from_contents' do
+    it 'should set source_contents' do
+      bundle_json = File.read('test/fixtures/bundle_1.json')
+      bundle_resource = FHIR.from_contents(bundle_json)
+      bundle_resource.entry.each do |entry|
+        assert entry.source_contents.present?, "entry.source_contents not populated for #{entry}"
+        assert_instance_of String, entry.source_contents
+        assert entry.resource.source_contents.present?, "entry.resource.source_contents not populated for #{entry}"
+        assert_instance_of String, entry.resource.source_contents
+      end
+    end
+  end
+
+  describe '#initialize' do
+    it 'should set source_contents' do
+      bundle_resource = FHIR::Bundle.new(
+        {
+          resourceType: 'Bundle', entry:
+          [
+            { resource: { resourceType: 'Patient', id: 'a' } },
+            { resource: { resourceType: 'Patient', id: 'b' } }
+          ]
+        }
+      )
+      bundle_resource.entry.each do |entry|
+        assert entry.source_contents.present?, "entry.source_contents not populated for #{entry}"
+        assert_instance_of String, entry.source_contents
+        assert entry.resource.source_contents.present?, "entry.resource.source_contents not populated for #{entry}"
+        assert_instance_of String, entry.resource.source_contents
+      end
+    end
+  end
+end

--- a/test/unit/fhir_models_test.rb
+++ b/test/unit/fhir_models_test.rb
@@ -24,7 +24,7 @@ describe FHIR::Models do
       assert procedure_resource.source_contents.include?('http://hl7.org/fhir/StructureDefinition/data-absent-reason'), 'Primitive extension URL was lost'
     end
 
-    it 'should preserve primitive extensions in contained resources in a bundle' do
+    it 'should preserve primitive extensions in bundled resources' do
       bundle_json = File.read('test/fixtures/bundle_primitive_extensions.json')
       bundle_resource = FHIR.from_contents(bundle_json)
       contained_patient = bundle_resource.entry.find { |e| e.resource.id == '1' }.resource
@@ -34,6 +34,18 @@ describe FHIR::Models do
       assert contained_patient.source_contents.include?('http://hl7.org/fhir/StructureDefinition/data-absent-reason'), 'Primitive extension URL was lost'
       assert contained_procedure.source_contents.include?('_performedDateTime'), 'Primitive extension key was lost'
       assert contained_procedure.source_contents.include?('http://hl7.org/fhir/StructureDefinition/data-absent-reason'), 'Primitive extension URL was lost'
+    end
+
+    it 'should preserve primitive extensions in contained resources' do
+      contained_json = File.read('test/fixtures/contained_resource.json')
+      full_resource = FHIR.from_contents(contained_json)
+      practitioner = full_resource.contained.first
+
+      assert full_resource.source_contents.include?('_birthDate'), 'Primitive extension key was lost'
+      assert full_resource.source_contents.include?('http://hl7.org/fhir/StructureDefinition/data-absent-reason'), 'Primitive extension URL was lost'
+
+      assert practitioner.source_contents.include?('_birthDate'), 'Primitive extension key was lost'
+      assert practitioner.source_contents.include?('http://hl7.org/fhir/StructureDefinition/data-absent-reason'), 'Primitive extension URL was lost'
     end
   end
 

--- a/test/unit/hl7_validator_test.rb
+++ b/test/unit/hl7_validator_test.rb
@@ -14,7 +14,7 @@ describe Inferno::HL7Validator do
       stub_request(:post, "#{@validator_url}/validate")
         .with(
           query: { profile: 'http://hl7.org/fhir/StructureDefinition/Patient' },
-          body: patient.to_json
+          body: patient.source_contents
         )
         .to_return(status: 200, body: load_fixture('validator_good_response'))
       result = @validator.validate(patient, FHIR)
@@ -29,7 +29,7 @@ describe Inferno::HL7Validator do
       stub_request(:post, "#{@validator_url}/validate")
         .with(
           query: { profile: 'http://hl7.org/fhir/StructureDefinition/Patient' },
-          body: patient.to_json
+          body: patient.source_contents
         )
         .to_return(status: 200, body: load_fixture('validator_invalid_code_response'))
       result = @validator.validate(patient, FHIR)
@@ -47,7 +47,7 @@ describe Inferno::HL7Validator do
       stub_request(:post, "#{@validator_url}/validate")
         .with(
           query: { profile: 'http://hl7.org/fhir/StructureDefinition/Patient' },
-          body: patient.to_json
+          body: patient.source_contents
         )
         .to_return(status: 200, body: load_fixture('validator_bad_response'))
       result = @validator.validate(patient, FHIR)


### PR DESCRIPTION
Closes #143. 
This PR solves an issue where parsing resources into `fhir_models` would "drop" data that `fhir_models` doesn't support (the specific instance was with primitive extensions). 

The way this is solved is by adding in a pair of attributes on the `FHIR::Model` base class, called `source_text` and `source_hash`.

When parsing a FHIR Object out of JSON or XML, (using `from_contents`, `from_json`, or `from_xml`), the text used for that parsing will be serialized onto `source_text`.

When creating a FHIR Object out of a hash (as when creating nested FHIR Resources), the hash used to create the object will be serialized onto `source_hash`.

We also added a `source_contents` method to the `FHIR::Model` class. This method will return either: `@source_text`, if it isn't `nil`, or a JSON-ified `source_hash`, if `@source_text` is `nil`.

Pull requests into Inferno require the following items to be completed. Submitter and reviewer 
should check the relevant check boxes when the associated item is done. For items that are not 
applicable, note it's not applicable ("N/A") and check the box. For example, external Pull 
Requests do not require ticket links.

**Submitter:**
- [x] This pull request describes why these changes were made
- [x] Internal ticket for this PR: FI-934
- [x] Internal ticket links to this PR
- [x] Internal ticket is properly labeled (Community/Program)
- [x] Internal ticket has a justification for its Community/Program label
- [x] Code diff has been reviewed for extraneous/missing code
- [x] Tests are included and test edge cases
- [x] Tests/code quality metrics have been run locally and pass


**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
