### PR TITLE
FI-944 Remove requirement to use a specific FHIR element in visual inspection

### DIFF
--- a/lib/app/views/onc_program.erb
+++ b/lib/app/views/onc_program.erb
@@ -385,19 +385,19 @@
           {
             field: :onc_visual_patient_period,
             notes_field: :onc_visual_patient_period_notes,
-            label: 'Health IT developer demonstrates support for the Patient Demographics Previous Name USCDI v1 element by using the Patient.name.period FHIR element.',
+            label: 'Health IT developer demonstrates support for the Patient Demographics Previous Name USCDI v1 element.',
             description: ''
           },
           {
             field: :onc_visual_patient_suffix,
             notes_field: :onc_visual_patient_suffix_notes,
-            label: 'Health IT developer demonstrates support for the Patient Demographics Suffix USCDI v1 element by using the Patient.name.suffix FHIR element.',
+            label: 'Health IT developer demonstrates support for the Patient Demographics Suffix USCDI v1 element.',
             description: ''
           },
           {
             field: :onc_visual_allergy_reaction,
             notes_field: :onc_visual_allergy_reaction_notes,
-            label: 'Health IT developer demonstrates support for the Allergy and Intolerances Reaction USCDI v1 element by using the AllergyIntolerance.reaction FHIR element.',
+            label: 'Health IT developer demonstrates support for the Allergy and Intolerances Reaction USCDI v1 element.',
             description: ''
           }
             ].each do |field| %>

--- a/lib/modules/onc_program/onc_visual_inspection_sequence.rb
+++ b/lib/modules/onc_program/onc_visual_inspection_sequence.rb
@@ -170,7 +170,7 @@ module Inferno
         pass @instance.onc_visual_jwks_cache_notes if @instance.onc_visual_jwks_cache_notes.present?
       end
 
-      test 'Health IT developer demonstrates support for the Patient Demographics Suffix USCDI v1 element by using the Patient.name.suffix FHIR element.' do
+      test 'Health IT developer demonstrates support for the Patient Demographics Suffix USCDI v1 element.' do
         metadata do
           id '12'
           link 'https://www.healthit.gov/isa/united-states-core-data-interoperability-uscdi'
@@ -186,7 +186,7 @@ module Inferno
         pass @instance.onc_visual_patient_suffix_notes if @instance.onc_visual_patient_suffix_notes.present?
       end
 
-      test 'Health IT developer demonstrates support for the Patient Demographics Previous Name USCDI v1 element by using the Patient.name.period FHIR element.' do
+      test 'Health IT developer demonstrates support for the Patient Demographics Previous Name USCDI v1 element.' do
         metadata do
           id '13'
           link 'https://www.healthit.gov/isa/united-states-core-data-interoperability-uscdi'
@@ -202,7 +202,7 @@ module Inferno
         pass @instance.onc_visual_patient_period_notes if @instance.onc_visual_patient_period_notes.present?
       end
 
-      test 'Health IT developer demonstrates support for the Allergy and Intolerances Reaction USCDI v1 element by using the AllergyIntolerance.reaction FHIR element.' do
+      test 'Health IT developer demonstrates support for the Allergy and Intolerances Reaction USCDI v1 element.' do
         metadata do
           id '14'
           link 'https://www.healthit.gov/isa/united-states-core-data-interoperability-uscdi'


### PR DESCRIPTION
Small fix to remove language requiring specific FHIR elements to be checked.  In the test description we reference the preferred elements.

**Submitter:**
- [x] This pull request describes why these changes were made
- [x] Internal ticket for this PR: FI-944
- [x] Internal ticket links to this PR 
- [x] Internal ticket is properly labeled (Community/Program)
- [x] Internal ticket has a justification for its Community/Program label
- [x] Code diff has been reviewed for extraneous/missing code
- [x] Tests are included and test edge cases
- [x] Tests/code quality metrics have been run locally and pass


**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
