### PR TITLE
FI-974 Fix scopes that prefill for bulk data

### DIFF
--- a/lib/app/views/onc_program.erb
+++ b/lib/app/views/onc_program.erb
@@ -673,7 +673,7 @@
               description: 'Bulk Data Scopes provided at registration to the Inferno application.',
               instance: instance,
               type: 'textarea',
-              value: instance.bulk_scope || 'system/Medication.read system/AllergyIntolerance.read system/CarePlan.read system/CareTeam.read system/Condition.read system/Device.read system/DiagnosticReport.read system/DocumentReference.read system/Encounter.read system/Goal.read system/Immunization.read system/Location.read system/MedicationRequest.read system/Observation.read system/Organization.read system/system.read system/Practitioner.read system/PractitionerRole.read system/Procedure.read system/Provenance.read',
+              value: instance.bulk_scope || 'system/Medication.read system/AllergyIntolerance.read system/CarePlan.read system/CareTeam.read system/Condition.read system/Device.read system/DiagnosticReport.read system/DocumentReference.read system/Encounter.read system/Goal.read system/Immunization.read system/Location.read system/MedicationRequest.read system/Observation.read system/Organization.read system/Practitioner.read system/PractitionerRole.read system/Procedure.read system/Provenance.read system/RelatedPerson.read',
               })%>  
 
         <div class="form-group"


### PR DESCRIPTION
The bulk data scope input box defaults to having 'system/system.read' which is invalid, and doesn't include 'system/RelatedPerson.read' which is allowed.

These should align with the resource scopes that auto-fill in the SMART App Launch related tests.

**Submitter:**
- [x] This pull request describes why these changes were made
- [x] Internal ticket for this PR:
- [x] Internal ticket links to this PR
- [x] Internal ticket is properly labeled (Community/Program)
- [x] Internal ticket has a justification for its Community/Program label
- [x] Code diff has been reviewed for extraneous/missing code
- n/a Tests are included and test edge cases
- [x] Tests/code quality metrics have been run locally and pass


**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
