### PR TITLE
FI-945 Remove resource references from report.

### DIFF
--- a/lib/app/views/report.erb
+++ b/lib/app/views/report.erb
@@ -33,14 +33,6 @@
             </div>
             <div class="col">
               <div class="metrics-value-small">
-                <%=report_summary[:resource_references]%>
-              </div>
-              <div>
-                Resource References
-              </div>
-            </div>
-            <div class="col">
-              <div class="metrics-value-small">
                 <%=report_summary[:app_version]%>
               </div>
               <div>


### PR DESCRIPTION
The "Resource References" in the report may no longer be accurate because this data is cleared on each new launch.  Since we now have another launch in the 'other' section, under the regular workflow of the tool you will clear out the references just prior to completion of the tests.  For now, remove the references so that this misleading information is no longer provided.  A larger task of revisiting what is useful in the report may be done in the future.

**Before:**
![Screen Shot 2020-08-20 at 4 35 15 PM](https://user-images.githubusercontent.com/412901/90823723-542f9400-e304-11ea-9c29-3a81d2f4c650.png)


**After:**
![Screen Shot 2020-08-20 at 4 44 29 PM](https://user-images.githubusercontent.com/412901/90823803-71646280-e304-11ea-8f28-5345de4dc4f7.png)

**Submitter:**
- [x] This pull request describes why these changes were made
- [x] Internal ticket for this PR: fi945
- [x] Internal ticket links to this PR
- [x] Internal ticket is properly labeled (Community/Program)
- [x] Internal ticket has a justification for its Community/Program label
- [x] Code diff has been reviewed for extraneous/missing code
- n/a Tests are included and test edge cases
- [x] Tests/code quality metrics have been run locally and pass


**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
