### PR TITLE
Fi 971 must support reference types

### DIFF
--- a/generator/uscore/metadata_extractor.rb
+++ b/generator/uscore/metadata_extractor.rb
@@ -86,6 +86,7 @@ module Inferno
           must_supports: {
             extensions: [],
             slices: [],
+            references: [],
             elements: []
           },
           mandatory_elements: [],
@@ -283,7 +284,6 @@ module Inferno
                 id: element['id'],
                 url: element['type'].first['profile'].first
               }
-            next
           elsif element['sliceName'].present?
             array_el = profile_elements.find { |el| el['id'] == element['path'] }
             discriminators = array_el['slicing']['discriminator']
@@ -330,23 +330,34 @@ module Inferno
               end
             end
             sequence[:must_supports][:slices] << must_support_element
-            next
+          elsif element['type'].any? { |type| type['code'] == 'Reference' }
+            reference_type = element['type'].find { |type| type['code'] == 'Reference' }
+            profiles = reference_type['targetProfile']
+            resource_types = profiles
+              .select { |profile| resources_by_type['StructureDefinition'].find { |stdef| stdef['url'] == profile } }
+              .map { |profile| resources_by_type['StructureDefinition'].find { |stdef| stdef['url'] == profile }['type'] }
+            must_support_element = {
+              path: element['path'].gsub(sequence[:resource] + '.', ''),
+              resource_types: resource_types
+            }
+            sequence[:must_supports][:references] << must_support_element
+          else
+            path = element['path'].gsub(sequence[:resource] + '.', '')
+            must_support_element = { path: path }
+            if element['fixedUri'].present?
+              must_support_element[:fixed_value] = element['fixedUri']
+            elsif element['patternCodeableConcept'].present?
+              must_support_element[:fixed_value] = element['patternCodeableConcept']['coding'].first['code']
+              must_support_element[:path] += '.coding.code'
+            elsif element['fixedCode'].present?
+              must_support_element[:fixed_value] = element['fixedCode']
+            elsif element['patternIdentifier'].present?
+              must_support_element[:fixed_value] = element['patternIdentifier']['system']
+              must_support_element[:path] += '.system'
+            end
+            sequence[:must_supports][:elements].delete_if { |must_support| must_support[:path] == must_support_element[:path] && must_support[:fixed_value].blank? }
+            sequence[:must_supports][:elements] << must_support_element
           end
-          path = element['path'].gsub(sequence[:resource] + '.', '')
-          must_support_element = { path: path }
-          if element['fixedUri'].present?
-            must_support_element[:fixed_value] = element['fixedUri']
-          elsif element['patternCodeableConcept'].present?
-            must_support_element[:fixed_value] = element['patternCodeableConcept']['coding'].first['code']
-            must_support_element[:path] += '.coding.code'
-          elsif element['fixedCode'].present?
-            must_support_element[:fixed_value] = element['fixedCode']
-          elsif element['patternIdentifier'].present?
-            must_support_element[:fixed_value] = element['patternIdentifier']['system']
-            must_support_element[:path] += '.system'
-          end
-          sequence[:must_supports][:elements].delete_if { |must_support| must_support[:path] == must_support_element[:path] && must_support[:fixed_value].blank? }
-          sequence[:must_supports][:elements] << must_support_element
         end
       end
 
@@ -485,7 +496,7 @@ module Inferno
           sequence[:searches].each do |search|
             search[:names_not_must_support_or_mandatory] = search[:names].reject do |name|
               path = sequence[:search_param_descriptions][name.to_sym][:path]
-              any_must_support_elements = sequence[:must_supports][:elements].any? do |element|
+              any_must_support_elements = (sequence[:must_supports][:elements] + sequence[:must_supports][:references]).any? do |element|
                 full_must_support_path = "#{sequence[:resource]}.#{element[:path]}"
 
                 # allow for non-choice, choice types, and _id

--- a/generator/uscore/uscore_generator.rb
+++ b/generator/uscore/uscore_generator.rb
@@ -579,6 +579,12 @@ module Inferno
                             sequence[:must_supports][:extensions].map { |extension| "* #{extension[:id]}" } +
                             sequence[:must_supports][:slices].map { |slice| "* #{slice[:name]}" } +
                             sequence[:must_supports][:references].map { |reference| "* #{reference[:path]}" }
+
+        must_suport_reference_description = %(
+          For elements of type 'reference' with one or more target profiles from US Core, this test will ensure that at least one of each resource type
+          associated with each US Core target profile is provided as a reference.  This test will not validate those references against their associated
+          US Core profile to reduce test complexity.)
+
         test = {
           tests_that: "All must support elements are provided in the #{sequence[:resource]} resources returned.",
           index: sequence[:tests].length + 1,
@@ -588,12 +594,9 @@ module Inferno
             US Core Responders SHALL be capable of populating all data elements as part of the query results as specified by the US Core Server Capability Statement.
             This will look through the #{sequence[:resource]} resources found previously for the following must support elements:
 
-            #{must_support_list.join("\n            ")}
+            #{must_support_list.sort.join("\n            ")}
 
-
-            For elements of type 'reference' with one or more target profiles from US Core, this test will ensure that at least one of each resource type
-            associated with each US Core target profile is provided as a reference.  This test will not validate those references against their associated
-            US Core profile to reduce test complexity.
+            #{must_suport_reference_description if sequence[:must_supports][:references].present?}
           )
         }
         must_support_extensions = sequence[:must_supports][:extensions]

--- a/lib/modules/onc_program/bulk_data_group_validation_sequence.rb
+++ b/lib/modules/onc_program/bulk_data_group_validation_sequence.rb
@@ -213,6 +213,16 @@ module Inferno
         must_support_info[:slices].reject! do |ms_slice|
           find_slice(resource, ms_slice[:path], ms_slice[:discriminator])
         end
+
+        must_support_info[:references].each do |ms_reference|
+          ms_reference[:resource_types].reject! do |resource_type|
+            value_found = resolve_element_from_path(resource, ms_reference[:path]) do |value|
+              value.is_a?(FHIR::Reference) && value.reference.include?("#{resource_type}/")
+            end
+            value_found.present?
+          end
+        end
+        must_support_info[:references].delete_if { |ms_reference| ms_reference[:resource_types].empty? }
       end
 
       def validate_bindings(bindings, resources)
@@ -294,6 +304,9 @@ module Inferno
 
           missing_extensions_list = missing_must_supports[:extensions].map { |extension| extension[:id] }
           skip_if missing_extensions_list.present?, format(error_string, 'extensions', missing_extensions_list.join(', '))
+
+          missing_references_list = missing_must_supports[:references].map { |reference| "#{reference[:path]}: #{reference[:resource_types].join(',')}" }
+          skip_if missing_references_list.present?, format(error_string, 'reference elements', missing_references_list.join(';'))
         end
       end
 

--- a/lib/modules/onc_program/test/bulk_group_validation_sequence_test.rb
+++ b/lib/modules/onc_program/test/bulk_group_validation_sequence_test.rb
@@ -349,6 +349,7 @@ describe Inferno::Sequence::BulkDataGroupExportValidationSequence do
           must_support_info: {
             extensions: [],
             slices: [],
+            references: [],
             elements: [
               {
                 path: 'name'
@@ -376,6 +377,7 @@ describe Inferno::Sequence::BulkDataGroupExportValidationSequence do
           must_support_info: {
             extensions: [],
             slices: [],
+            references: [],
             elements: [
               {
                 path: 'name'

--- a/lib/modules/uscore_v3.1.0/bodyheight_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/bodyheight_sequence.rb
@@ -595,7 +595,6 @@ module Inferno
             * category.coding.system
             * category.coding.code
             * code
-            * subject
             * effective[x]
             * value[x]
             * value[x].value
@@ -605,6 +604,7 @@ module Inferno
             * dataAbsentReason
             * Observation.category:VSCat
             * Observation.value[x]:valueQuantity
+            * subject
           )
           versions :r4
         end
@@ -619,6 +619,18 @@ module Inferno
           end
         end
 
+        missing_must_support_references = must_supports[:references].each_with_object({}) do |reference, missing_types_by_path|
+          missing_resource_types = reference[:resource_types].reject do |resource_type|
+            @observation_ary&.values&.flatten&.any? do |resource|
+              value_found = resolve_element_from_path(resource, reference[:path]) do |value|
+                value.is_a?(FHIR::Reference) && value.reference.include?("#{resource_type}/")
+              end
+              value_found.present?
+            end
+          end
+          missing_types_by_path[reference[:path]] = missing_resource_types if missing_resource_types.present?
+        end
+
         missing_must_support_elements = must_supports[:elements].reject do |element|
           @observation_ary&.values&.flatten&.any? do |resource|
             value_found = resolve_element_from_path(resource, element[:path]) { |value| element[:fixed_value].blank? || value == element[:fixed_value] }
@@ -631,6 +643,9 @@ module Inferno
 
         skip_if missing_must_support_elements.present?,
                 "Could not find #{missing_must_support_elements.join(', ')} in the #{@observation_ary&.values&.flatten&.length} provided Observation resource(s)"
+        skip_if missing_must_support_references.present?,
+                "Could not find the following resource type references: #{missing_must_support_references.map { |k, v| k + ':' + v.join(',') }.join(';')}"
+
         @instance.save!
       end
 

--- a/lib/modules/uscore_v3.1.0/bodyheight_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/bodyheight_sequence.rb
@@ -605,6 +605,12 @@ module Inferno
             * Observation.category:VSCat
             * Observation.value[x]:valueQuantity
             * subject
+
+
+            For elements of type 'reference' with one or more target profiles from US Core, this test will ensure that at least one of each resource type
+            associated with each US Core target profile is provided as a reference.  This test will not validate those references against their associated
+            US Core profile to reduce test complexity.
+
           )
           versions :r4
         end
@@ -644,7 +650,7 @@ module Inferno
         skip_if missing_must_support_elements.present?,
                 "Could not find #{missing_must_support_elements.join(', ')} in the #{@observation_ary&.values&.flatten&.length} provided Observation resource(s)"
         skip_if missing_must_support_references.present?,
-                "Could not find the following resource type references: #{missing_must_support_references.map { |k, v| k + ':' + v.join(',') }.join(';')}"
+                "Could not find the following resource type references:#{missing_must_support_references.map { |path, resource_types| path + ':' + resource_types.join(',') }.join(';')}"
 
         @instance.save!
       end

--- a/lib/modules/uscore_v3.1.0/bodyheight_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/bodyheight_sequence.rb
@@ -589,27 +589,27 @@ module Inferno
             US Core Responders SHALL be capable of populating all data elements as part of the query results as specified by the US Core Server Capability Statement.
             This will look through the Observation resources found previously for the following must support elements:
 
-            * status
-            * category
-            * category.coding
-            * category.coding.system
-            * category.coding.code
-            * code
-            * effective[x]
-            * value[x]
-            * value[x].value
-            * value[x].unit
-            * value[x].system
-            * value[x].code
-            * dataAbsentReason
             * Observation.category:VSCat
             * Observation.value[x]:valueQuantity
+            * category
+            * category.coding
+            * category.coding.code
+            * category.coding.system
+            * code
+            * dataAbsentReason
+            * effective[x]
+            * status
             * subject
+            * value[x]
+            * value[x].code
+            * value[x].system
+            * value[x].unit
+            * value[x].value
 
 
-            For elements of type 'reference' with one or more target profiles from US Core, this test will ensure that at least one of each resource type
-            associated with each US Core target profile is provided as a reference.  This test will not validate those references against their associated
-            US Core profile to reduce test complexity.
+          For elements of type 'reference' with one or more target profiles from US Core, this test will ensure that at least one of each resource type
+          associated with each US Core target profile is provided as a reference.  This test will not validate those references against their associated
+          US Core profile to reduce test complexity.
 
           )
           versions :r4

--- a/lib/modules/uscore_v3.1.0/bodytemp_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/bodytemp_sequence.rb
@@ -595,7 +595,6 @@ module Inferno
             * category.coding.system
             * category.coding.code
             * code
-            * subject
             * effective[x]
             * value[x]
             * value[x].value
@@ -605,6 +604,7 @@ module Inferno
             * dataAbsentReason
             * Observation.category:VSCat
             * Observation.value[x]:valueQuantity
+            * subject
           )
           versions :r4
         end
@@ -619,6 +619,18 @@ module Inferno
           end
         end
 
+        missing_must_support_references = must_supports[:references].each_with_object({}) do |reference, missing_types_by_path|
+          missing_resource_types = reference[:resource_types].reject do |resource_type|
+            @observation_ary&.values&.flatten&.any? do |resource|
+              value_found = resolve_element_from_path(resource, reference[:path]) do |value|
+                value.is_a?(FHIR::Reference) && value.reference.include?("#{resource_type}/")
+              end
+              value_found.present?
+            end
+          end
+          missing_types_by_path[reference[:path]] = missing_resource_types if missing_resource_types.present?
+        end
+
         missing_must_support_elements = must_supports[:elements].reject do |element|
           @observation_ary&.values&.flatten&.any? do |resource|
             value_found = resolve_element_from_path(resource, element[:path]) { |value| element[:fixed_value].blank? || value == element[:fixed_value] }
@@ -631,6 +643,9 @@ module Inferno
 
         skip_if missing_must_support_elements.present?,
                 "Could not find #{missing_must_support_elements.join(', ')} in the #{@observation_ary&.values&.flatten&.length} provided Observation resource(s)"
+        skip_if missing_must_support_references.present?,
+                "Could not find the following resource type references: #{missing_must_support_references.map { |k, v| k + ':' + v.join(',') }.join(';')}"
+
         @instance.save!
       end
 

--- a/lib/modules/uscore_v3.1.0/bodytemp_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/bodytemp_sequence.rb
@@ -605,6 +605,12 @@ module Inferno
             * Observation.category:VSCat
             * Observation.value[x]:valueQuantity
             * subject
+
+
+            For elements of type 'reference' with one or more target profiles from US Core, this test will ensure that at least one of each resource type
+            associated with each US Core target profile is provided as a reference.  This test will not validate those references against their associated
+            US Core profile to reduce test complexity.
+
           )
           versions :r4
         end
@@ -644,7 +650,7 @@ module Inferno
         skip_if missing_must_support_elements.present?,
                 "Could not find #{missing_must_support_elements.join(', ')} in the #{@observation_ary&.values&.flatten&.length} provided Observation resource(s)"
         skip_if missing_must_support_references.present?,
-                "Could not find the following resource type references: #{missing_must_support_references.map { |k, v| k + ':' + v.join(',') }.join(';')}"
+                "Could not find the following resource type references:#{missing_must_support_references.map { |path, resource_types| path + ':' + resource_types.join(',') }.join(';')}"
 
         @instance.save!
       end

--- a/lib/modules/uscore_v3.1.0/bodytemp_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/bodytemp_sequence.rb
@@ -589,27 +589,27 @@ module Inferno
             US Core Responders SHALL be capable of populating all data elements as part of the query results as specified by the US Core Server Capability Statement.
             This will look through the Observation resources found previously for the following must support elements:
 
-            * status
-            * category
-            * category.coding
-            * category.coding.system
-            * category.coding.code
-            * code
-            * effective[x]
-            * value[x]
-            * value[x].value
-            * value[x].unit
-            * value[x].system
-            * value[x].code
-            * dataAbsentReason
             * Observation.category:VSCat
             * Observation.value[x]:valueQuantity
+            * category
+            * category.coding
+            * category.coding.code
+            * category.coding.system
+            * code
+            * dataAbsentReason
+            * effective[x]
+            * status
             * subject
+            * value[x]
+            * value[x].code
+            * value[x].system
+            * value[x].unit
+            * value[x].value
 
 
-            For elements of type 'reference' with one or more target profiles from US Core, this test will ensure that at least one of each resource type
-            associated with each US Core target profile is provided as a reference.  This test will not validate those references against their associated
-            US Core profile to reduce test complexity.
+          For elements of type 'reference' with one or more target profiles from US Core, this test will ensure that at least one of each resource type
+          associated with each US Core target profile is provided as a reference.  This test will not validate those references against their associated
+          US Core profile to reduce test complexity.
 
           )
           versions :r4

--- a/lib/modules/uscore_v3.1.0/bodyweight_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/bodyweight_sequence.rb
@@ -595,7 +595,6 @@ module Inferno
             * category.coding.system
             * category.coding.code
             * code
-            * subject
             * effective[x]
             * value[x]
             * value[x].value
@@ -605,6 +604,7 @@ module Inferno
             * dataAbsentReason
             * Observation.category:VSCat
             * Observation.value[x]:valueQuantity
+            * subject
           )
           versions :r4
         end
@@ -619,6 +619,18 @@ module Inferno
           end
         end
 
+        missing_must_support_references = must_supports[:references].each_with_object({}) do |reference, missing_types_by_path|
+          missing_resource_types = reference[:resource_types].reject do |resource_type|
+            @observation_ary&.values&.flatten&.any? do |resource|
+              value_found = resolve_element_from_path(resource, reference[:path]) do |value|
+                value.is_a?(FHIR::Reference) && value.reference.include?("#{resource_type}/")
+              end
+              value_found.present?
+            end
+          end
+          missing_types_by_path[reference[:path]] = missing_resource_types if missing_resource_types.present?
+        end
+
         missing_must_support_elements = must_supports[:elements].reject do |element|
           @observation_ary&.values&.flatten&.any? do |resource|
             value_found = resolve_element_from_path(resource, element[:path]) { |value| element[:fixed_value].blank? || value == element[:fixed_value] }
@@ -631,6 +643,9 @@ module Inferno
 
         skip_if missing_must_support_elements.present?,
                 "Could not find #{missing_must_support_elements.join(', ')} in the #{@observation_ary&.values&.flatten&.length} provided Observation resource(s)"
+        skip_if missing_must_support_references.present?,
+                "Could not find the following resource type references: #{missing_must_support_references.map { |k, v| k + ':' + v.join(',') }.join(';')}"
+
         @instance.save!
       end
 

--- a/lib/modules/uscore_v3.1.0/bodyweight_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/bodyweight_sequence.rb
@@ -605,6 +605,12 @@ module Inferno
             * Observation.category:VSCat
             * Observation.value[x]:valueQuantity
             * subject
+
+
+            For elements of type 'reference' with one or more target profiles from US Core, this test will ensure that at least one of each resource type
+            associated with each US Core target profile is provided as a reference.  This test will not validate those references against their associated
+            US Core profile to reduce test complexity.
+
           )
           versions :r4
         end
@@ -644,7 +650,7 @@ module Inferno
         skip_if missing_must_support_elements.present?,
                 "Could not find #{missing_must_support_elements.join(', ')} in the #{@observation_ary&.values&.flatten&.length} provided Observation resource(s)"
         skip_if missing_must_support_references.present?,
-                "Could not find the following resource type references: #{missing_must_support_references.map { |k, v| k + ':' + v.join(',') }.join(';')}"
+                "Could not find the following resource type references:#{missing_must_support_references.map { |path, resource_types| path + ':' + resource_types.join(',') }.join(';')}"
 
         @instance.save!
       end

--- a/lib/modules/uscore_v3.1.0/bodyweight_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/bodyweight_sequence.rb
@@ -589,27 +589,27 @@ module Inferno
             US Core Responders SHALL be capable of populating all data elements as part of the query results as specified by the US Core Server Capability Statement.
             This will look through the Observation resources found previously for the following must support elements:
 
-            * status
-            * category
-            * category.coding
-            * category.coding.system
-            * category.coding.code
-            * code
-            * effective[x]
-            * value[x]
-            * value[x].value
-            * value[x].unit
-            * value[x].system
-            * value[x].code
-            * dataAbsentReason
             * Observation.category:VSCat
             * Observation.value[x]:valueQuantity
+            * category
+            * category.coding
+            * category.coding.code
+            * category.coding.system
+            * code
+            * dataAbsentReason
+            * effective[x]
+            * status
             * subject
+            * value[x]
+            * value[x].code
+            * value[x].system
+            * value[x].unit
+            * value[x].value
 
 
-            For elements of type 'reference' with one or more target profiles from US Core, this test will ensure that at least one of each resource type
-            associated with each US Core target profile is provided as a reference.  This test will not validate those references against their associated
-            US Core profile to reduce test complexity.
+          For elements of type 'reference' with one or more target profiles from US Core, this test will ensure that at least one of each resource type
+          associated with each US Core target profile is provided as a reference.  This test will not validate those references against their associated
+          US Core profile to reduce test complexity.
 
           )
           versions :r4

--- a/lib/modules/uscore_v3.1.0/bp_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/bp_sequence.rb
@@ -589,21 +589,21 @@ module Inferno
             US Core Responders SHALL be capable of populating all data elements as part of the query results as specified by the US Core Server Capability Statement.
             This will look through the Observation resources found previously for the following must support elements:
 
-            * status
+            * Observation.category:VSCat
             * category
             * category.coding
-            * category.coding.system
             * category.coding.code
+            * category.coding.system
             * code
-            * effective[x]
             * dataAbsentReason
-            * Observation.category:VSCat
+            * effective[x]
+            * status
             * subject
 
 
-            For elements of type 'reference' with one or more target profiles from US Core, this test will ensure that at least one of each resource type
-            associated with each US Core target profile is provided as a reference.  This test will not validate those references against their associated
-            US Core profile to reduce test complexity.
+          For elements of type 'reference' with one or more target profiles from US Core, this test will ensure that at least one of each resource type
+          associated with each US Core target profile is provided as a reference.  This test will not validate those references against their associated
+          US Core profile to reduce test complexity.
 
           )
           versions :r4

--- a/lib/modules/uscore_v3.1.0/bp_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/bp_sequence.rb
@@ -599,6 +599,12 @@ module Inferno
             * dataAbsentReason
             * Observation.category:VSCat
             * subject
+
+
+            For elements of type 'reference' with one or more target profiles from US Core, this test will ensure that at least one of each resource type
+            associated with each US Core target profile is provided as a reference.  This test will not validate those references against their associated
+            US Core profile to reduce test complexity.
+
           )
           versions :r4
         end
@@ -638,7 +644,7 @@ module Inferno
         skip_if missing_must_support_elements.present?,
                 "Could not find #{missing_must_support_elements.join(', ')} in the #{@observation_ary&.values&.flatten&.length} provided Observation resource(s)"
         skip_if missing_must_support_references.present?,
-                "Could not find the following resource type references: #{missing_must_support_references.map { |k, v| k + ':' + v.join(',') }.join(';')}"
+                "Could not find the following resource type references:#{missing_must_support_references.map { |path, resource_types| path + ':' + resource_types.join(',') }.join(';')}"
 
         @instance.save!
       end

--- a/lib/modules/uscore_v3.1.0/bp_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/bp_sequence.rb
@@ -595,10 +595,10 @@ module Inferno
             * category.coding.system
             * category.coding.code
             * code
-            * subject
             * effective[x]
             * dataAbsentReason
             * Observation.category:VSCat
+            * subject
           )
           versions :r4
         end
@@ -613,6 +613,18 @@ module Inferno
           end
         end
 
+        missing_must_support_references = must_supports[:references].each_with_object({}) do |reference, missing_types_by_path|
+          missing_resource_types = reference[:resource_types].reject do |resource_type|
+            @observation_ary&.values&.flatten&.any? do |resource|
+              value_found = resolve_element_from_path(resource, reference[:path]) do |value|
+                value.is_a?(FHIR::Reference) && value.reference.include?("#{resource_type}/")
+              end
+              value_found.present?
+            end
+          end
+          missing_types_by_path[reference[:path]] = missing_resource_types if missing_resource_types.present?
+        end
+
         missing_must_support_elements = must_supports[:elements].reject do |element|
           @observation_ary&.values&.flatten&.any? do |resource|
             value_found = resolve_element_from_path(resource, element[:path]) { |value| element[:fixed_value].blank? || value == element[:fixed_value] }
@@ -625,6 +637,9 @@ module Inferno
 
         skip_if missing_must_support_elements.present?,
                 "Could not find #{missing_must_support_elements.join(', ')} in the #{@observation_ary&.values&.flatten&.length} provided Observation resource(s)"
+        skip_if missing_must_support_references.present?,
+                "Could not find the following resource type references: #{missing_must_support_references.map { |k, v| k + ':' + v.join(',') }.join(';')}"
+
         @instance.save!
       end
 

--- a/lib/modules/uscore_v3.1.0/headcircum_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/headcircum_sequence.rb
@@ -595,7 +595,6 @@ module Inferno
             * category.coding.system
             * category.coding.code
             * code
-            * subject
             * effective[x]
             * value[x]
             * value[x].value
@@ -605,6 +604,7 @@ module Inferno
             * dataAbsentReason
             * Observation.category:VSCat
             * Observation.value[x]:valueQuantity
+            * subject
           )
           versions :r4
         end
@@ -619,6 +619,18 @@ module Inferno
           end
         end
 
+        missing_must_support_references = must_supports[:references].each_with_object({}) do |reference, missing_types_by_path|
+          missing_resource_types = reference[:resource_types].reject do |resource_type|
+            @observation_ary&.values&.flatten&.any? do |resource|
+              value_found = resolve_element_from_path(resource, reference[:path]) do |value|
+                value.is_a?(FHIR::Reference) && value.reference.include?("#{resource_type}/")
+              end
+              value_found.present?
+            end
+          end
+          missing_types_by_path[reference[:path]] = missing_resource_types if missing_resource_types.present?
+        end
+
         missing_must_support_elements = must_supports[:elements].reject do |element|
           @observation_ary&.values&.flatten&.any? do |resource|
             value_found = resolve_element_from_path(resource, element[:path]) { |value| element[:fixed_value].blank? || value == element[:fixed_value] }
@@ -631,6 +643,9 @@ module Inferno
 
         skip_if missing_must_support_elements.present?,
                 "Could not find #{missing_must_support_elements.join(', ')} in the #{@observation_ary&.values&.flatten&.length} provided Observation resource(s)"
+        skip_if missing_must_support_references.present?,
+                "Could not find the following resource type references: #{missing_must_support_references.map { |k, v| k + ':' + v.join(',') }.join(';')}"
+
         @instance.save!
       end
 

--- a/lib/modules/uscore_v3.1.0/headcircum_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/headcircum_sequence.rb
@@ -605,6 +605,12 @@ module Inferno
             * Observation.category:VSCat
             * Observation.value[x]:valueQuantity
             * subject
+
+
+            For elements of type 'reference' with one or more target profiles from US Core, this test will ensure that at least one of each resource type
+            associated with each US Core target profile is provided as a reference.  This test will not validate those references against their associated
+            US Core profile to reduce test complexity.
+
           )
           versions :r4
         end
@@ -644,7 +650,7 @@ module Inferno
         skip_if missing_must_support_elements.present?,
                 "Could not find #{missing_must_support_elements.join(', ')} in the #{@observation_ary&.values&.flatten&.length} provided Observation resource(s)"
         skip_if missing_must_support_references.present?,
-                "Could not find the following resource type references: #{missing_must_support_references.map { |k, v| k + ':' + v.join(',') }.join(';')}"
+                "Could not find the following resource type references:#{missing_must_support_references.map { |path, resource_types| path + ':' + resource_types.join(',') }.join(';')}"
 
         @instance.save!
       end

--- a/lib/modules/uscore_v3.1.0/headcircum_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/headcircum_sequence.rb
@@ -589,27 +589,27 @@ module Inferno
             US Core Responders SHALL be capable of populating all data elements as part of the query results as specified by the US Core Server Capability Statement.
             This will look through the Observation resources found previously for the following must support elements:
 
-            * status
-            * category
-            * category.coding
-            * category.coding.system
-            * category.coding.code
-            * code
-            * effective[x]
-            * value[x]
-            * value[x].value
-            * value[x].unit
-            * value[x].system
-            * value[x].code
-            * dataAbsentReason
             * Observation.category:VSCat
             * Observation.value[x]:valueQuantity
+            * category
+            * category.coding
+            * category.coding.code
+            * category.coding.system
+            * code
+            * dataAbsentReason
+            * effective[x]
+            * status
             * subject
+            * value[x]
+            * value[x].code
+            * value[x].system
+            * value[x].unit
+            * value[x].value
 
 
-            For elements of type 'reference' with one or more target profiles from US Core, this test will ensure that at least one of each resource type
-            associated with each US Core target profile is provided as a reference.  This test will not validate those references against their associated
-            US Core profile to reduce test complexity.
+          For elements of type 'reference' with one or more target profiles from US Core, this test will ensure that at least one of each resource type
+          associated with each US Core target profile is provided as a reference.  This test will not validate those references against their associated
+          US Core profile to reduce test complexity.
 
           )
           versions :r4

--- a/lib/modules/uscore_v3.1.0/heartrate_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/heartrate_sequence.rb
@@ -595,7 +595,6 @@ module Inferno
             * category.coding.system
             * category.coding.code
             * code
-            * subject
             * effective[x]
             * value[x]
             * value[x].value
@@ -605,6 +604,7 @@ module Inferno
             * dataAbsentReason
             * Observation.category:VSCat
             * Observation.value[x]:valueQuantity
+            * subject
           )
           versions :r4
         end
@@ -619,6 +619,18 @@ module Inferno
           end
         end
 
+        missing_must_support_references = must_supports[:references].each_with_object({}) do |reference, missing_types_by_path|
+          missing_resource_types = reference[:resource_types].reject do |resource_type|
+            @observation_ary&.values&.flatten&.any? do |resource|
+              value_found = resolve_element_from_path(resource, reference[:path]) do |value|
+                value.is_a?(FHIR::Reference) && value.reference.include?("#{resource_type}/")
+              end
+              value_found.present?
+            end
+          end
+          missing_types_by_path[reference[:path]] = missing_resource_types if missing_resource_types.present?
+        end
+
         missing_must_support_elements = must_supports[:elements].reject do |element|
           @observation_ary&.values&.flatten&.any? do |resource|
             value_found = resolve_element_from_path(resource, element[:path]) { |value| element[:fixed_value].blank? || value == element[:fixed_value] }
@@ -631,6 +643,9 @@ module Inferno
 
         skip_if missing_must_support_elements.present?,
                 "Could not find #{missing_must_support_elements.join(', ')} in the #{@observation_ary&.values&.flatten&.length} provided Observation resource(s)"
+        skip_if missing_must_support_references.present?,
+                "Could not find the following resource type references: #{missing_must_support_references.map { |k, v| k + ':' + v.join(',') }.join(';')}"
+
         @instance.save!
       end
 

--- a/lib/modules/uscore_v3.1.0/heartrate_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/heartrate_sequence.rb
@@ -605,6 +605,12 @@ module Inferno
             * Observation.category:VSCat
             * Observation.value[x]:valueQuantity
             * subject
+
+
+            For elements of type 'reference' with one or more target profiles from US Core, this test will ensure that at least one of each resource type
+            associated with each US Core target profile is provided as a reference.  This test will not validate those references against their associated
+            US Core profile to reduce test complexity.
+
           )
           versions :r4
         end
@@ -644,7 +650,7 @@ module Inferno
         skip_if missing_must_support_elements.present?,
                 "Could not find #{missing_must_support_elements.join(', ')} in the #{@observation_ary&.values&.flatten&.length} provided Observation resource(s)"
         skip_if missing_must_support_references.present?,
-                "Could not find the following resource type references: #{missing_must_support_references.map { |k, v| k + ':' + v.join(',') }.join(';')}"
+                "Could not find the following resource type references:#{missing_must_support_references.map { |path, resource_types| path + ':' + resource_types.join(',') }.join(';')}"
 
         @instance.save!
       end

--- a/lib/modules/uscore_v3.1.0/heartrate_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/heartrate_sequence.rb
@@ -589,27 +589,27 @@ module Inferno
             US Core Responders SHALL be capable of populating all data elements as part of the query results as specified by the US Core Server Capability Statement.
             This will look through the Observation resources found previously for the following must support elements:
 
-            * status
-            * category
-            * category.coding
-            * category.coding.system
-            * category.coding.code
-            * code
-            * effective[x]
-            * value[x]
-            * value[x].value
-            * value[x].unit
-            * value[x].system
-            * value[x].code
-            * dataAbsentReason
             * Observation.category:VSCat
             * Observation.value[x]:valueQuantity
+            * category
+            * category.coding
+            * category.coding.code
+            * category.coding.system
+            * code
+            * dataAbsentReason
+            * effective[x]
+            * status
             * subject
+            * value[x]
+            * value[x].code
+            * value[x].system
+            * value[x].unit
+            * value[x].value
 
 
-            For elements of type 'reference' with one or more target profiles from US Core, this test will ensure that at least one of each resource type
-            associated with each US Core target profile is provided as a reference.  This test will not validate those references against their associated
-            US Core profile to reduce test complexity.
+          For elements of type 'reference' with one or more target profiles from US Core, this test will ensure that at least one of each resource type
+          associated with each US Core target profile is provided as a reference.  This test will not validate those references against their associated
+          US Core profile to reduce test complexity.
 
           )
           versions :r4

--- a/lib/modules/uscore_v3.1.0/pediatric_bmi_for_age_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/pediatric_bmi_for_age_sequence.rb
@@ -602,6 +602,12 @@ module Inferno
             * value[x].code
             * Observation.category:VSCat
             * subject
+
+
+            For elements of type 'reference' with one or more target profiles from US Core, this test will ensure that at least one of each resource type
+            associated with each US Core target profile is provided as a reference.  This test will not validate those references against their associated
+            US Core profile to reduce test complexity.
+
           )
           versions :r4
         end
@@ -641,7 +647,7 @@ module Inferno
         skip_if missing_must_support_elements.present?,
                 "Could not find #{missing_must_support_elements.join(', ')} in the #{@observation_ary&.values&.flatten&.length} provided Observation resource(s)"
         skip_if missing_must_support_references.present?,
-                "Could not find the following resource type references: #{missing_must_support_references.map { |k, v| k + ':' + v.join(',') }.join(';')}"
+                "Could not find the following resource type references:#{missing_must_support_references.map { |path, resource_types| path + ':' + resource_types.join(',') }.join(';')}"
 
         @instance.save!
       end

--- a/lib/modules/uscore_v3.1.0/pediatric_bmi_for_age_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/pediatric_bmi_for_age_sequence.rb
@@ -594,7 +594,6 @@ module Inferno
             * category.coding
             * category.coding.system
             * category.coding.code
-            * subject
             * effective[x]
             * value[x]
             * value[x].value
@@ -602,6 +601,7 @@ module Inferno
             * value[x].system
             * value[x].code
             * Observation.category:VSCat
+            * subject
           )
           versions :r4
         end
@@ -616,6 +616,18 @@ module Inferno
           end
         end
 
+        missing_must_support_references = must_supports[:references].each_with_object({}) do |reference, missing_types_by_path|
+          missing_resource_types = reference[:resource_types].reject do |resource_type|
+            @observation_ary&.values&.flatten&.any? do |resource|
+              value_found = resolve_element_from_path(resource, reference[:path]) do |value|
+                value.is_a?(FHIR::Reference) && value.reference.include?("#{resource_type}/")
+              end
+              value_found.present?
+            end
+          end
+          missing_types_by_path[reference[:path]] = missing_resource_types if missing_resource_types.present?
+        end
+
         missing_must_support_elements = must_supports[:elements].reject do |element|
           @observation_ary&.values&.flatten&.any? do |resource|
             value_found = resolve_element_from_path(resource, element[:path]) { |value| element[:fixed_value].blank? || value == element[:fixed_value] }
@@ -628,6 +640,9 @@ module Inferno
 
         skip_if missing_must_support_elements.present?,
                 "Could not find #{missing_must_support_elements.join(', ')} in the #{@observation_ary&.values&.flatten&.length} provided Observation resource(s)"
+        skip_if missing_must_support_references.present?,
+                "Could not find the following resource type references: #{missing_must_support_references.map { |k, v| k + ':' + v.join(',') }.join(';')}"
+
         @instance.save!
       end
 

--- a/lib/modules/uscore_v3.1.0/pediatric_bmi_for_age_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/pediatric_bmi_for_age_sequence.rb
@@ -589,24 +589,24 @@ module Inferno
             US Core Responders SHALL be capable of populating all data elements as part of the query results as specified by the US Core Server Capability Statement.
             This will look through the Observation resources found previously for the following must support elements:
 
-            * status
+            * Observation.category:VSCat
             * category
             * category.coding
-            * category.coding.system
             * category.coding.code
+            * category.coding.system
             * effective[x]
-            * value[x]
-            * value[x].value
-            * value[x].unit
-            * value[x].system
-            * value[x].code
-            * Observation.category:VSCat
+            * status
             * subject
+            * value[x]
+            * value[x].code
+            * value[x].system
+            * value[x].unit
+            * value[x].value
 
 
-            For elements of type 'reference' with one or more target profiles from US Core, this test will ensure that at least one of each resource type
-            associated with each US Core target profile is provided as a reference.  This test will not validate those references against their associated
-            US Core profile to reduce test complexity.
+          For elements of type 'reference' with one or more target profiles from US Core, this test will ensure that at least one of each resource type
+          associated with each US Core target profile is provided as a reference.  This test will not validate those references against their associated
+          US Core profile to reduce test complexity.
 
           )
           versions :r4

--- a/lib/modules/uscore_v3.1.0/pediatric_weight_for_height_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/pediatric_weight_for_height_sequence.rb
@@ -602,6 +602,12 @@ module Inferno
             * value[x].code
             * Observation.category:VSCat
             * subject
+
+
+            For elements of type 'reference' with one or more target profiles from US Core, this test will ensure that at least one of each resource type
+            associated with each US Core target profile is provided as a reference.  This test will not validate those references against their associated
+            US Core profile to reduce test complexity.
+
           )
           versions :r4
         end
@@ -641,7 +647,7 @@ module Inferno
         skip_if missing_must_support_elements.present?,
                 "Could not find #{missing_must_support_elements.join(', ')} in the #{@observation_ary&.values&.flatten&.length} provided Observation resource(s)"
         skip_if missing_must_support_references.present?,
-                "Could not find the following resource type references: #{missing_must_support_references.map { |k, v| k + ':' + v.join(',') }.join(';')}"
+                "Could not find the following resource type references:#{missing_must_support_references.map { |path, resource_types| path + ':' + resource_types.join(',') }.join(';')}"
 
         @instance.save!
       end

--- a/lib/modules/uscore_v3.1.0/pediatric_weight_for_height_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/pediatric_weight_for_height_sequence.rb
@@ -594,7 +594,6 @@ module Inferno
             * category.coding
             * category.coding.system
             * category.coding.code
-            * subject
             * effective[x]
             * value[x]
             * value[x].value
@@ -602,6 +601,7 @@ module Inferno
             * value[x].system
             * value[x].code
             * Observation.category:VSCat
+            * subject
           )
           versions :r4
         end
@@ -616,6 +616,18 @@ module Inferno
           end
         end
 
+        missing_must_support_references = must_supports[:references].each_with_object({}) do |reference, missing_types_by_path|
+          missing_resource_types = reference[:resource_types].reject do |resource_type|
+            @observation_ary&.values&.flatten&.any? do |resource|
+              value_found = resolve_element_from_path(resource, reference[:path]) do |value|
+                value.is_a?(FHIR::Reference) && value.reference.include?("#{resource_type}/")
+              end
+              value_found.present?
+            end
+          end
+          missing_types_by_path[reference[:path]] = missing_resource_types if missing_resource_types.present?
+        end
+
         missing_must_support_elements = must_supports[:elements].reject do |element|
           @observation_ary&.values&.flatten&.any? do |resource|
             value_found = resolve_element_from_path(resource, element[:path]) { |value| element[:fixed_value].blank? || value == element[:fixed_value] }
@@ -628,6 +640,9 @@ module Inferno
 
         skip_if missing_must_support_elements.present?,
                 "Could not find #{missing_must_support_elements.join(', ')} in the #{@observation_ary&.values&.flatten&.length} provided Observation resource(s)"
+        skip_if missing_must_support_references.present?,
+                "Could not find the following resource type references: #{missing_must_support_references.map { |k, v| k + ':' + v.join(',') }.join(';')}"
+
         @instance.save!
       end
 

--- a/lib/modules/uscore_v3.1.0/pediatric_weight_for_height_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/pediatric_weight_for_height_sequence.rb
@@ -589,24 +589,24 @@ module Inferno
             US Core Responders SHALL be capable of populating all data elements as part of the query results as specified by the US Core Server Capability Statement.
             This will look through the Observation resources found previously for the following must support elements:
 
-            * status
+            * Observation.category:VSCat
             * category
             * category.coding
-            * category.coding.system
             * category.coding.code
+            * category.coding.system
             * effective[x]
-            * value[x]
-            * value[x].value
-            * value[x].unit
-            * value[x].system
-            * value[x].code
-            * Observation.category:VSCat
+            * status
             * subject
+            * value[x]
+            * value[x].code
+            * value[x].system
+            * value[x].unit
+            * value[x].value
 
 
-            For elements of type 'reference' with one or more target profiles from US Core, this test will ensure that at least one of each resource type
-            associated with each US Core target profile is provided as a reference.  This test will not validate those references against their associated
-            US Core profile to reduce test complexity.
+          For elements of type 'reference' with one or more target profiles from US Core, this test will ensure that at least one of each resource type
+          associated with each US Core target profile is provided as a reference.  This test will not validate those references against their associated
+          US Core profile to reduce test complexity.
 
           )
           versions :r4

--- a/lib/modules/uscore_v3.1.0/profile_definitions/bodyheight_definitions.rb
+++ b/lib/modules/uscore_v3.1.0/profile_definitions/bodyheight_definitions.rb
@@ -32,6 +32,12 @@ module Inferno
             }
           }
         ],
+        references: [
+          {
+            path: 'subject',
+            resource_types: []
+          }
+        ],
         elements: [
           {
             path: 'status'
@@ -52,9 +58,6 @@ module Inferno
           },
           {
             path: 'code'
-          },
-          {
-            path: 'subject'
           },
           {
             path: 'effective'

--- a/lib/modules/uscore_v3.1.0/profile_definitions/bodytemp_definitions.rb
+++ b/lib/modules/uscore_v3.1.0/profile_definitions/bodytemp_definitions.rb
@@ -32,6 +32,12 @@ module Inferno
             }
           }
         ],
+        references: [
+          {
+            path: 'subject',
+            resource_types: []
+          }
+        ],
         elements: [
           {
             path: 'status'
@@ -52,9 +58,6 @@ module Inferno
           },
           {
             path: 'code'
-          },
-          {
-            path: 'subject'
           },
           {
             path: 'effective'

--- a/lib/modules/uscore_v3.1.0/profile_definitions/bodyweight_definitions.rb
+++ b/lib/modules/uscore_v3.1.0/profile_definitions/bodyweight_definitions.rb
@@ -32,6 +32,12 @@ module Inferno
             }
           }
         ],
+        references: [
+          {
+            path: 'subject',
+            resource_types: []
+          }
+        ],
         elements: [
           {
             path: 'status'
@@ -52,9 +58,6 @@ module Inferno
           },
           {
             path: 'code'
-          },
-          {
-            path: 'subject'
           },
           {
             path: 'effective'

--- a/lib/modules/uscore_v3.1.0/profile_definitions/bp_definitions.rb
+++ b/lib/modules/uscore_v3.1.0/profile_definitions/bp_definitions.rb
@@ -24,6 +24,12 @@ module Inferno
             }
           }
         ],
+        references: [
+          {
+            path: 'subject',
+            resource_types: []
+          }
+        ],
         elements: [
           {
             path: 'status'
@@ -44,9 +50,6 @@ module Inferno
           },
           {
             path: 'code'
-          },
-          {
-            path: 'subject'
           },
           {
             path: 'effective'

--- a/lib/modules/uscore_v3.1.0/profile_definitions/headcircum_definitions.rb
+++ b/lib/modules/uscore_v3.1.0/profile_definitions/headcircum_definitions.rb
@@ -32,6 +32,12 @@ module Inferno
             }
           }
         ],
+        references: [
+          {
+            path: 'subject',
+            resource_types: []
+          }
+        ],
         elements: [
           {
             path: 'status'
@@ -52,9 +58,6 @@ module Inferno
           },
           {
             path: 'code'
-          },
-          {
-            path: 'subject'
           },
           {
             path: 'effective'

--- a/lib/modules/uscore_v3.1.0/profile_definitions/heartrate_definitions.rb
+++ b/lib/modules/uscore_v3.1.0/profile_definitions/heartrate_definitions.rb
@@ -32,6 +32,12 @@ module Inferno
             }
           }
         ],
+        references: [
+          {
+            path: 'subject',
+            resource_types: []
+          }
+        ],
         elements: [
           {
             path: 'status'
@@ -52,9 +58,6 @@ module Inferno
           },
           {
             path: 'code'
-          },
-          {
-            path: 'subject'
           },
           {
             path: 'effective'

--- a/lib/modules/uscore_v3.1.0/profile_definitions/pediatric_bmi_for_age_definitions.rb
+++ b/lib/modules/uscore_v3.1.0/profile_definitions/pediatric_bmi_for_age_definitions.rb
@@ -24,6 +24,12 @@ module Inferno
             }
           }
         ],
+        references: [
+          {
+            path: 'subject',
+            resource_types: []
+          }
+        ],
         elements: [
           {
             path: 'status'
@@ -41,9 +47,6 @@ module Inferno
           {
             path: 'category.coding.code',
             fixed_value: 'vital-signs'
-          },
-          {
-            path: 'subject'
           },
           {
             path: 'effective'

--- a/lib/modules/uscore_v3.1.0/profile_definitions/pediatric_weight_for_height_definitions.rb
+++ b/lib/modules/uscore_v3.1.0/profile_definitions/pediatric_weight_for_height_definitions.rb
@@ -24,6 +24,12 @@ module Inferno
             }
           }
         ],
+        references: [
+          {
+            path: 'subject',
+            resource_types: []
+          }
+        ],
         elements: [
           {
             path: 'status'
@@ -41,9 +47,6 @@ module Inferno
           {
             path: 'category.coding.code',
             fixed_value: 'vital-signs'
-          },
-          {
-            path: 'subject'
           },
           {
             path: 'effective'

--- a/lib/modules/uscore_v3.1.0/profile_definitions/resprate_definitions.rb
+++ b/lib/modules/uscore_v3.1.0/profile_definitions/resprate_definitions.rb
@@ -32,6 +32,12 @@ module Inferno
             }
           }
         ],
+        references: [
+          {
+            path: 'subject',
+            resource_types: []
+          }
+        ],
         elements: [
           {
             path: 'status'
@@ -52,9 +58,6 @@ module Inferno
           },
           {
             path: 'code'
-          },
-          {
-            path: 'subject'
           },
           {
             path: 'effective'

--- a/lib/modules/uscore_v3.1.0/profile_definitions/us_core_allergyintolerance_definitions.rb
+++ b/lib/modules/uscore_v3.1.0/profile_definitions/us_core_allergyintolerance_definitions.rb
@@ -6,6 +6,14 @@ module Inferno
       MUST_SUPPORTS = {
         extensions: [],
         slices: [],
+        references: [
+          {
+            path: 'patient',
+            resource_types: [
+              'Patient'
+            ]
+          }
+        ],
         elements: [
           {
             path: 'clinicalStatus'
@@ -15,9 +23,6 @@ module Inferno
           },
           {
             path: 'code'
-          },
-          {
-            path: 'patient'
           }
         ]
       }.freeze

--- a/lib/modules/uscore_v3.1.0/profile_definitions/us_core_careplan_definitions.rb
+++ b/lib/modules/uscore_v3.1.0/profile_definitions/us_core_careplan_definitions.rb
@@ -17,6 +17,14 @@ module Inferno
             }
           }
         ],
+        references: [
+          {
+            path: 'subject',
+            resource_types: [
+              'Patient'
+            ]
+          }
+        ],
         elements: [
           {
             path: 'text'
@@ -32,9 +40,6 @@ module Inferno
           },
           {
             path: 'category'
-          },
-          {
-            path: 'subject'
           }
         ]
       }.freeze

--- a/lib/modules/uscore_v3.1.0/profile_definitions/us_core_careteam_definitions.rb
+++ b/lib/modules/uscore_v3.1.0/profile_definitions/us_core_careteam_definitions.rb
@@ -6,21 +6,31 @@ module Inferno
       MUST_SUPPORTS = {
         extensions: [],
         slices: [],
+        references: [
+          {
+            path: 'subject',
+            resource_types: [
+              'Patient'
+            ]
+          },
+          {
+            path: 'participant.member',
+            resource_types: [
+              'Patient',
+              'Practitioner',
+              'Organization'
+            ]
+          }
+        ],
         elements: [
           {
             path: 'status'
-          },
-          {
-            path: 'subject'
           },
           {
             path: 'participant'
           },
           {
             path: 'participant.role'
-          },
-          {
-            path: 'participant.member'
           }
         ]
       }.freeze

--- a/lib/modules/uscore_v3.1.0/profile_definitions/us_core_condition_definitions.rb
+++ b/lib/modules/uscore_v3.1.0/profile_definitions/us_core_condition_definitions.rb
@@ -6,6 +6,14 @@ module Inferno
       MUST_SUPPORTS = {
         extensions: [],
         slices: [],
+        references: [
+          {
+            path: 'subject',
+            resource_types: [
+              'Patient'
+            ]
+          }
+        ],
         elements: [
           {
             path: 'clinicalStatus'
@@ -18,9 +26,6 @@ module Inferno
           },
           {
             path: 'code'
-          },
-          {
-            path: 'subject'
           }
         ]
       }.freeze

--- a/lib/modules/uscore_v3.1.0/profile_definitions/us_core_diagnosticreport_lab_definitions.rb
+++ b/lib/modules/uscore_v3.1.0/profile_definitions/us_core_diagnosticreport_lab_definitions.rb
@@ -17,6 +17,27 @@ module Inferno
             }
           }
         ],
+        references: [
+          {
+            path: 'subject',
+            resource_types: [
+              'Patient'
+            ]
+          },
+          {
+            path: 'performer',
+            resource_types: [
+              'Practitioner',
+              'Organization'
+            ]
+          },
+          {
+            path: 'result',
+            resource_types: [
+              'Observation'
+            ]
+          }
+        ],
         elements: [
           {
             path: 'status'
@@ -28,19 +49,10 @@ module Inferno
             path: 'code'
           },
           {
-            path: 'subject'
-          },
-          {
             path: 'effective'
           },
           {
             path: 'issued'
-          },
-          {
-            path: 'performer'
-          },
-          {
-            path: 'result'
           }
         ]
       }.freeze

--- a/lib/modules/uscore_v3.1.0/profile_definitions/us_core_diagnosticreport_note_definitions.rb
+++ b/lib/modules/uscore_v3.1.0/profile_definitions/us_core_diagnosticreport_note_definitions.rb
@@ -6,6 +6,27 @@ module Inferno
       MUST_SUPPORTS = {
         extensions: [],
         slices: [],
+        references: [
+          {
+            path: 'subject',
+            resource_types: [
+              'Patient'
+            ]
+          },
+          {
+            path: 'encounter',
+            resource_types: [
+              'Encounter'
+            ]
+          },
+          {
+            path: 'performer',
+            resource_types: [
+              'Practitioner',
+              'Organization'
+            ]
+          }
+        ],
         elements: [
           {
             path: 'status'
@@ -17,19 +38,10 @@ module Inferno
             path: 'code'
           },
           {
-            path: 'subject'
-          },
-          {
-            path: 'encounter'
-          },
-          {
             path: 'effective'
           },
           {
             path: 'issued'
-          },
-          {
-            path: 'performer'
           },
           {
             path: 'presentedForm'

--- a/lib/modules/uscore_v3.1.0/profile_definitions/us_core_documentreference_definitions.rb
+++ b/lib/modules/uscore_v3.1.0/profile_definitions/us_core_documentreference_definitions.rb
@@ -6,6 +6,34 @@ module Inferno
       MUST_SUPPORTS = {
         extensions: [],
         slices: [],
+        references: [
+          {
+            path: 'subject',
+            resource_types: [
+              'Patient'
+            ]
+          },
+          {
+            path: 'author',
+            resource_types: [
+              'Practitioner',
+              'Organization',
+              'Patient'
+            ]
+          },
+          {
+            path: 'custodian',
+            resource_types: [
+              'Organization'
+            ]
+          },
+          {
+            path: 'context.encounter',
+            resource_types: [
+              'Encounter'
+            ]
+          }
+        ],
         elements: [
           {
             path: 'identifier'
@@ -20,16 +48,7 @@ module Inferno
             path: 'category'
           },
           {
-            path: 'subject'
-          },
-          {
             path: 'date'
-          },
-          {
-            path: 'author'
-          },
-          {
-            path: 'custodian'
           },
           {
             path: 'content'
@@ -51,9 +70,6 @@ module Inferno
           },
           {
             path: 'context'
-          },
-          {
-            path: 'context.encounter'
           },
           {
             path: 'context.period'

--- a/lib/modules/uscore_v3.1.0/profile_definitions/us_core_encounter_definitions.rb
+++ b/lib/modules/uscore_v3.1.0/profile_definitions/us_core_encounter_definitions.rb
@@ -6,6 +6,24 @@ module Inferno
       MUST_SUPPORTS = {
         extensions: [],
         slices: [],
+        references: [
+          {
+            path: 'subject',
+            resource_types: [
+              'Patient'
+            ]
+          },
+          {
+            path: 'participant.individual',
+            resource_types: [
+              'Practitioner'
+            ]
+          },
+          {
+            path: 'location.location',
+            resource_types: []
+          }
+        ],
         elements: [
           {
             path: 'identifier'
@@ -26,9 +44,6 @@ module Inferno
             path: 'type'
           },
           {
-            path: 'subject'
-          },
-          {
             path: 'participant'
           },
           {
@@ -36,9 +51,6 @@ module Inferno
           },
           {
             path: 'participant.period'
-          },
-          {
-            path: 'participant.individual'
           },
           {
             path: 'period'
@@ -54,9 +66,6 @@ module Inferno
           },
           {
             path: 'location'
-          },
-          {
-            path: 'location.location'
           }
         ]
       }.freeze

--- a/lib/modules/uscore_v3.1.0/profile_definitions/us_core_encounter_definitions.rb
+++ b/lib/modules/uscore_v3.1.0/profile_definitions/us_core_encounter_definitions.rb
@@ -38,7 +38,7 @@ module Inferno
             path: 'status'
           },
           {
-            path: 'local_class'
+            path: 'class'
           },
           {
             path: 'type'

--- a/lib/modules/uscore_v3.1.0/profile_definitions/us_core_goal_definitions.rb
+++ b/lib/modules/uscore_v3.1.0/profile_definitions/us_core_goal_definitions.rb
@@ -15,15 +15,20 @@ module Inferno
             }
           }
         ],
+        references: [
+          {
+            path: 'subject',
+            resource_types: [
+              'Patient'
+            ]
+          }
+        ],
         elements: [
           {
             path: 'lifecycleStatus'
           },
           {
             path: 'description'
-          },
-          {
-            path: 'subject'
           },
           {
             path: 'target'

--- a/lib/modules/uscore_v3.1.0/profile_definitions/us_core_immunization_definitions.rb
+++ b/lib/modules/uscore_v3.1.0/profile_definitions/us_core_immunization_definitions.rb
@@ -6,6 +6,14 @@ module Inferno
       MUST_SUPPORTS = {
         extensions: [],
         slices: [],
+        references: [
+          {
+            path: 'patient',
+            resource_types: [
+              'Patient'
+            ]
+          }
+        ],
         elements: [
           {
             path: 'status'
@@ -15,9 +23,6 @@ module Inferno
           },
           {
             path: 'vaccineCode'
-          },
-          {
-            path: 'patient'
           },
           {
             path: 'occurrence'

--- a/lib/modules/uscore_v3.1.0/profile_definitions/us_core_implantable_device_definitions.rb
+++ b/lib/modules/uscore_v3.1.0/profile_definitions/us_core_implantable_device_definitions.rb
@@ -6,6 +6,14 @@ module Inferno
       MUST_SUPPORTS = {
         extensions: [],
         slices: [],
+        references: [
+          {
+            path: 'patient',
+            resource_types: [
+              'Patient'
+            ]
+          }
+        ],
         elements: [
           {
             path: 'udiCarrier'
@@ -36,9 +44,6 @@ module Inferno
           },
           {
             path: 'type'
-          },
-          {
-            path: 'patient'
           }
         ]
       }.freeze

--- a/lib/modules/uscore_v3.1.0/profile_definitions/us_core_location_definitions.rb
+++ b/lib/modules/uscore_v3.1.0/profile_definitions/us_core_location_definitions.rb
@@ -6,6 +6,14 @@ module Inferno
       MUST_SUPPORTS = {
         extensions: [],
         slices: [],
+        references: [
+          {
+            path: 'managingOrganization',
+            resource_types: [
+              'Organization'
+            ]
+          }
+        ],
         elements: [
           {
             path: 'status'
@@ -30,9 +38,6 @@ module Inferno
           },
           {
             path: 'address.postalCode'
-          },
-          {
-            path: 'managingOrganization'
           }
         ]
       }.freeze

--- a/lib/modules/uscore_v3.1.0/profile_definitions/us_core_medicationrequest_definitions.rb
+++ b/lib/modules/uscore_v3.1.0/profile_definitions/us_core_medicationrequest_definitions.rb
@@ -6,6 +6,41 @@ module Inferno
       MUST_SUPPORTS = {
         extensions: [],
         slices: [],
+        references: [
+          {
+            path: 'reported',
+            resource_types: [
+              'Patient',
+              'Practitioner',
+              'Organization'
+            ]
+          },
+          {
+            path: 'medication',
+            resource_types: [
+              'Medication'
+            ]
+          },
+          {
+            path: 'subject',
+            resource_types: [
+              'Patient'
+            ]
+          },
+          {
+            path: 'encounter',
+            resource_types: []
+          },
+          {
+            path: 'requester',
+            resource_types: [
+              'Practitioner',
+              'Organization',
+              'Patient',
+              'Device'
+            ]
+          }
+        ],
         elements: [
           {
             path: 'status'
@@ -14,22 +49,7 @@ module Inferno
             path: 'intent'
           },
           {
-            path: 'reported'
-          },
-          {
-            path: 'medication'
-          },
-          {
-            path: 'subject'
-          },
-          {
-            path: 'encounter'
-          },
-          {
             path: 'authoredOn'
-          },
-          {
-            path: 'requester'
           },
           {
             path: 'dosageInstruction'

--- a/lib/modules/uscore_v3.1.0/profile_definitions/us_core_observation_lab_definitions.rb
+++ b/lib/modules/uscore_v3.1.0/profile_definitions/us_core_observation_lab_definitions.rb
@@ -17,6 +17,14 @@ module Inferno
             }
           }
         ],
+        references: [
+          {
+            path: 'subject',
+            resource_types: [
+              'Patient'
+            ]
+          }
+        ],
         elements: [
           {
             path: 'status'
@@ -26,9 +34,6 @@ module Inferno
           },
           {
             path: 'code'
-          },
-          {
-            path: 'subject'
           },
           {
             path: 'effective'

--- a/lib/modules/uscore_v3.1.0/profile_definitions/us_core_organization_definitions.rb
+++ b/lib/modules/uscore_v3.1.0/profile_definitions/us_core_organization_definitions.rb
@@ -25,6 +25,7 @@ module Inferno
             }
           }
         ],
+        references: [],
         elements: [
           {
             path: 'identifier'

--- a/lib/modules/uscore_v3.1.0/profile_definitions/us_core_patient_definitions.rb
+++ b/lib/modules/uscore_v3.1.0/profile_definitions/us_core_patient_definitions.rb
@@ -19,6 +19,7 @@ module Inferno
           }
         ],
         slices: [],
+        references: [],
         elements: [
           {
             path: 'identifier'

--- a/lib/modules/uscore_v3.1.0/profile_definitions/us_core_practitioner_definitions.rb
+++ b/lib/modules/uscore_v3.1.0/profile_definitions/us_core_practitioner_definitions.rb
@@ -16,6 +16,7 @@ module Inferno
             }
           }
         ],
+        references: [],
         elements: [
           {
             path: 'identifier'

--- a/lib/modules/uscore_v3.1.0/profile_definitions/us_core_practitionerrole_definitions.rb
+++ b/lib/modules/uscore_v3.1.0/profile_definitions/us_core_practitionerrole_definitions.rb
@@ -6,21 +6,34 @@ module Inferno
       MUST_SUPPORTS = {
         extensions: [],
         slices: [],
+        references: [
+          {
+            path: 'practitioner',
+            resource_types: [
+              'Practitioner'
+            ]
+          },
+          {
+            path: 'organization',
+            resource_types: [
+              'Organization'
+            ]
+          },
+          {
+            path: 'location',
+            resource_types: []
+          },
+          {
+            path: 'endpoint',
+            resource_types: []
+          }
+        ],
         elements: [
-          {
-            path: 'practitioner'
-          },
-          {
-            path: 'organization'
-          },
           {
             path: 'code'
           },
           {
             path: 'specialty'
-          },
-          {
-            path: 'location'
           },
           {
             path: 'telecom'
@@ -30,9 +43,6 @@ module Inferno
           },
           {
             path: 'telecom.value'
-          },
-          {
-            path: 'endpoint'
           }
         ]
       }.freeze

--- a/lib/modules/uscore_v3.1.0/profile_definitions/us_core_procedure_definitions.rb
+++ b/lib/modules/uscore_v3.1.0/profile_definitions/us_core_procedure_definitions.rb
@@ -6,15 +6,20 @@ module Inferno
       MUST_SUPPORTS = {
         extensions: [],
         slices: [],
+        references: [
+          {
+            path: 'subject',
+            resource_types: [
+              'Patient'
+            ]
+          }
+        ],
         elements: [
           {
             path: 'status'
           },
           {
             path: 'code'
-          },
-          {
-            path: 'subject'
           },
           {
             path: 'performed'

--- a/lib/modules/uscore_v3.1.0/profile_definitions/us_core_provenance_definitions.rb
+++ b/lib/modules/uscore_v3.1.0/profile_definitions/us_core_provenance_definitions.rb
@@ -27,10 +27,27 @@ module Inferno
             }
           }
         ],
-        elements: [
+        references: [
           {
-            path: 'target'
+            path: 'target',
+            resource_types: []
           },
+          {
+            path: 'agent.who',
+            resource_types: [
+              'Practitioner',
+              'Patient',
+              'Organization'
+            ]
+          },
+          {
+            path: 'agent.onBehalfOf',
+            resource_types: [
+              'Organization'
+            ]
+          }
+        ],
+        elements: [
           {
             path: 'recorded'
           },
@@ -39,12 +56,6 @@ module Inferno
           },
           {
             path: 'agent.type'
-          },
-          {
-            path: 'agent.who'
-          },
-          {
-            path: 'agent.onBehalfOf'
           },
           {
             path: 'agent.type.coding.code',

--- a/lib/modules/uscore_v3.1.0/profile_definitions/us_core_pulse_oximetry_definitions.rb
+++ b/lib/modules/uscore_v3.1.0/profile_definitions/us_core_pulse_oximetry_definitions.rb
@@ -69,6 +69,12 @@ module Inferno
             }
           }
         ],
+        references: [
+          {
+            path: 'subject',
+            resource_types: []
+          }
+        ],
         elements: [
           {
             path: 'status'
@@ -100,9 +106,6 @@ module Inferno
           {
             path: 'code.coding.code',
             fixed_value: '59408-5'
-          },
-          {
-            path: 'subject'
           },
           {
             path: 'effective'

--- a/lib/modules/uscore_v3.1.0/profile_definitions/us_core_smokingstatus_definitions.rb
+++ b/lib/modules/uscore_v3.1.0/profile_definitions/us_core_smokingstatus_definitions.rb
@@ -15,15 +15,20 @@ module Inferno
             }
           }
         ],
+        references: [
+          {
+            path: 'subject',
+            resource_types: [
+              'Patient'
+            ]
+          }
+        ],
         elements: [
           {
             path: 'status'
           },
           {
             path: 'code'
-          },
-          {
-            path: 'subject'
           },
           {
             path: 'issued'

--- a/lib/modules/uscore_v3.1.0/resprate_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/resprate_sequence.rb
@@ -595,7 +595,6 @@ module Inferno
             * category.coding.system
             * category.coding.code
             * code
-            * subject
             * effective[x]
             * value[x]
             * value[x].value
@@ -605,6 +604,7 @@ module Inferno
             * dataAbsentReason
             * Observation.category:VSCat
             * Observation.value[x]:valueQuantity
+            * subject
           )
           versions :r4
         end
@@ -619,6 +619,18 @@ module Inferno
           end
         end
 
+        missing_must_support_references = must_supports[:references].each_with_object({}) do |reference, missing_types_by_path|
+          missing_resource_types = reference[:resource_types].reject do |resource_type|
+            @observation_ary&.values&.flatten&.any? do |resource|
+              value_found = resolve_element_from_path(resource, reference[:path]) do |value|
+                value.is_a?(FHIR::Reference) && value.reference.include?("#{resource_type}/")
+              end
+              value_found.present?
+            end
+          end
+          missing_types_by_path[reference[:path]] = missing_resource_types if missing_resource_types.present?
+        end
+
         missing_must_support_elements = must_supports[:elements].reject do |element|
           @observation_ary&.values&.flatten&.any? do |resource|
             value_found = resolve_element_from_path(resource, element[:path]) { |value| element[:fixed_value].blank? || value == element[:fixed_value] }
@@ -631,6 +643,9 @@ module Inferno
 
         skip_if missing_must_support_elements.present?,
                 "Could not find #{missing_must_support_elements.join(', ')} in the #{@observation_ary&.values&.flatten&.length} provided Observation resource(s)"
+        skip_if missing_must_support_references.present?,
+                "Could not find the following resource type references: #{missing_must_support_references.map { |k, v| k + ':' + v.join(',') }.join(';')}"
+
         @instance.save!
       end
 

--- a/lib/modules/uscore_v3.1.0/resprate_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/resprate_sequence.rb
@@ -605,6 +605,12 @@ module Inferno
             * Observation.category:VSCat
             * Observation.value[x]:valueQuantity
             * subject
+
+
+            For elements of type 'reference' with one or more target profiles from US Core, this test will ensure that at least one of each resource type
+            associated with each US Core target profile is provided as a reference.  This test will not validate those references against their associated
+            US Core profile to reduce test complexity.
+
           )
           versions :r4
         end
@@ -644,7 +650,7 @@ module Inferno
         skip_if missing_must_support_elements.present?,
                 "Could not find #{missing_must_support_elements.join(', ')} in the #{@observation_ary&.values&.flatten&.length} provided Observation resource(s)"
         skip_if missing_must_support_references.present?,
-                "Could not find the following resource type references: #{missing_must_support_references.map { |k, v| k + ':' + v.join(',') }.join(';')}"
+                "Could not find the following resource type references:#{missing_must_support_references.map { |path, resource_types| path + ':' + resource_types.join(',') }.join(';')}"
 
         @instance.save!
       end

--- a/lib/modules/uscore_v3.1.0/resprate_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/resprate_sequence.rb
@@ -589,27 +589,27 @@ module Inferno
             US Core Responders SHALL be capable of populating all data elements as part of the query results as specified by the US Core Server Capability Statement.
             This will look through the Observation resources found previously for the following must support elements:
 
-            * status
-            * category
-            * category.coding
-            * category.coding.system
-            * category.coding.code
-            * code
-            * effective[x]
-            * value[x]
-            * value[x].value
-            * value[x].unit
-            * value[x].system
-            * value[x].code
-            * dataAbsentReason
             * Observation.category:VSCat
             * Observation.value[x]:valueQuantity
+            * category
+            * category.coding
+            * category.coding.code
+            * category.coding.system
+            * code
+            * dataAbsentReason
+            * effective[x]
+            * status
             * subject
+            * value[x]
+            * value[x].code
+            * value[x].system
+            * value[x].unit
+            * value[x].value
 
 
-            For elements of type 'reference' with one or more target profiles from US Core, this test will ensure that at least one of each resource type
-            associated with each US Core target profile is provided as a reference.  This test will not validate those references against their associated
-            US Core profile to reduce test complexity.
+          For elements of type 'reference' with one or more target profiles from US Core, this test will ensure that at least one of each resource type
+          associated with each US Core target profile is provided as a reference.  This test will not validate those references against their associated
+          US Core profile to reduce test complexity.
 
           )
           versions :r4

--- a/lib/modules/uscore_v3.1.0/us_core_allergyintolerance_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_allergyintolerance_sequence.rb
@@ -406,14 +406,14 @@ module Inferno
             This will look through the AllergyIntolerance resources found previously for the following must support elements:
 
             * clinicalStatus
-            * verificationStatus
             * code
             * patient
+            * verificationStatus
 
 
-            For elements of type 'reference' with one or more target profiles from US Core, this test will ensure that at least one of each resource type
-            associated with each US Core target profile is provided as a reference.  This test will not validate those references against their associated
-            US Core profile to reduce test complexity.
+          For elements of type 'reference' with one or more target profiles from US Core, this test will ensure that at least one of each resource type
+          associated with each US Core target profile is provided as a reference.  This test will not validate those references against their associated
+          US Core profile to reduce test complexity.
 
           )
           versions :r4

--- a/lib/modules/uscore_v3.1.0/us_core_allergyintolerance_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_allergyintolerance_sequence.rb
@@ -409,6 +409,12 @@ module Inferno
             * verificationStatus
             * code
             * patient
+
+
+            For elements of type 'reference' with one or more target profiles from US Core, this test will ensure that at least one of each resource type
+            associated with each US Core target profile is provided as a reference.  This test will not validate those references against their associated
+            US Core profile to reduce test complexity.
+
           )
           versions :r4
         end
@@ -439,7 +445,7 @@ module Inferno
         skip_if missing_must_support_elements.present?,
                 "Could not find #{missing_must_support_elements.join(', ')} in the #{@allergy_intolerance_ary&.values&.flatten&.length} provided AllergyIntolerance resource(s)"
         skip_if missing_must_support_references.present?,
-                "Could not find the following resource type references: #{missing_must_support_references.map { |k, v| k + ':' + v.join(',') }.join(';')}"
+                "Could not find the following resource type references:#{missing_must_support_references.map { |path, resource_types| path + ':' + resource_types.join(',') }.join(';')}"
 
         @instance.save!
       end

--- a/lib/modules/uscore_v3.1.0/us_core_allergyintolerance_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_allergyintolerance_sequence.rb
@@ -416,6 +416,18 @@ module Inferno
         skip_if_not_found(resource_type: 'AllergyIntolerance', delayed: false)
         must_supports = USCore310AllergyintoleranceSequenceDefinitions::MUST_SUPPORTS
 
+        missing_must_support_references = must_supports[:references].each_with_object({}) do |reference, missing_types_by_path|
+          missing_resource_types = reference[:resource_types].reject do |resource_type|
+            @allergy_intolerance_ary&.values&.flatten&.any? do |resource|
+              value_found = resolve_element_from_path(resource, reference[:path]) do |value|
+                value.is_a?(FHIR::Reference) && value.reference.include?("#{resource_type}/")
+              end
+              value_found.present?
+            end
+          end
+          missing_types_by_path[reference[:path]] = missing_resource_types if missing_resource_types.present?
+        end
+
         missing_must_support_elements = must_supports[:elements].reject do |element|
           @allergy_intolerance_ary&.values&.flatten&.any? do |resource|
             value_found = resolve_element_from_path(resource, element[:path]) { |value| element[:fixed_value].blank? || value == element[:fixed_value] }
@@ -426,6 +438,9 @@ module Inferno
 
         skip_if missing_must_support_elements.present?,
                 "Could not find #{missing_must_support_elements.join(', ')} in the #{@allergy_intolerance_ary&.values&.flatten&.length} provided AllergyIntolerance resource(s)"
+        skip_if missing_must_support_references.present?,
+                "Could not find the following resource type references: #{missing_must_support_references.map { |k, v| k + ':' + v.join(',') }.join(';')}"
+
         @instance.save!
       end
 

--- a/lib/modules/uscore_v3.1.0/us_core_careplan_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_careplan_sequence.rb
@@ -424,6 +424,12 @@ module Inferno
             * category
             * CarePlan.category:AssessPlan
             * subject
+
+
+            For elements of type 'reference' with one or more target profiles from US Core, this test will ensure that at least one of each resource type
+            associated with each US Core target profile is provided as a reference.  This test will not validate those references against their associated
+            US Core profile to reduce test complexity.
+
           )
           versions :r4
         end
@@ -463,7 +469,7 @@ module Inferno
         skip_if missing_must_support_elements.present?,
                 "Could not find #{missing_must_support_elements.join(', ')} in the #{@care_plan_ary&.values&.flatten&.length} provided CarePlan resource(s)"
         skip_if missing_must_support_references.present?,
-                "Could not find the following resource type references: #{missing_must_support_references.map { |k, v| k + ':' + v.join(',') }.join(';')}"
+                "Could not find the following resource type references:#{missing_must_support_references.map { |path, resource_types| path + ':' + resource_types.join(',') }.join(';')}"
 
         @instance.save!
       end

--- a/lib/modules/uscore_v3.1.0/us_core_careplan_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_careplan_sequence.rb
@@ -422,8 +422,8 @@ module Inferno
             * status
             * intent
             * category
-            * subject
             * CarePlan.category:AssessPlan
+            * subject
           )
           versions :r4
         end
@@ -438,6 +438,18 @@ module Inferno
           end
         end
 
+        missing_must_support_references = must_supports[:references].each_with_object({}) do |reference, missing_types_by_path|
+          missing_resource_types = reference[:resource_types].reject do |resource_type|
+            @care_plan_ary&.values&.flatten&.any? do |resource|
+              value_found = resolve_element_from_path(resource, reference[:path]) do |value|
+                value.is_a?(FHIR::Reference) && value.reference.include?("#{resource_type}/")
+              end
+              value_found.present?
+            end
+          end
+          missing_types_by_path[reference[:path]] = missing_resource_types if missing_resource_types.present?
+        end
+
         missing_must_support_elements = must_supports[:elements].reject do |element|
           @care_plan_ary&.values&.flatten&.any? do |resource|
             value_found = resolve_element_from_path(resource, element[:path]) { |value| element[:fixed_value].blank? || value == element[:fixed_value] }
@@ -450,6 +462,9 @@ module Inferno
 
         skip_if missing_must_support_elements.present?,
                 "Could not find #{missing_must_support_elements.join(', ')} in the #{@care_plan_ary&.values&.flatten&.length} provided CarePlan resource(s)"
+        skip_if missing_must_support_references.present?,
+                "Could not find the following resource type references: #{missing_must_support_references.map { |k, v| k + ':' + v.join(',') }.join(';')}"
+
         @instance.save!
       end
 

--- a/lib/modules/uscore_v3.1.0/us_core_careplan_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_careplan_sequence.rb
@@ -417,18 +417,18 @@ module Inferno
             US Core Responders SHALL be capable of populating all data elements as part of the query results as specified by the US Core Server Capability Statement.
             This will look through the CarePlan resources found previously for the following must support elements:
 
+            * CarePlan.category:AssessPlan
+            * category
+            * intent
+            * status
+            * subject
             * text
             * text.status
-            * status
-            * intent
-            * category
-            * CarePlan.category:AssessPlan
-            * subject
 
 
-            For elements of type 'reference' with one or more target profiles from US Core, this test will ensure that at least one of each resource type
-            associated with each US Core target profile is provided as a reference.  This test will not validate those references against their associated
-            US Core profile to reduce test complexity.
+          For elements of type 'reference' with one or more target profiles from US Core, this test will ensure that at least one of each resource type
+          associated with each US Core target profile is provided as a reference.  This test will not validate those references against their associated
+          US Core profile to reduce test complexity.
 
           )
           versions :r4

--- a/lib/modules/uscore_v3.1.0/us_core_careteam_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_careteam_sequence.rb
@@ -345,16 +345,16 @@ module Inferno
             US Core Responders SHALL be capable of populating all data elements as part of the query results as specified by the US Core Server Capability Statement.
             This will look through the CareTeam resources found previously for the following must support elements:
 
-            * status
             * participant
-            * participant.role
-            * subject
             * participant.member
+            * participant.role
+            * status
+            * subject
 
 
-            For elements of type 'reference' with one or more target profiles from US Core, this test will ensure that at least one of each resource type
-            associated with each US Core target profile is provided as a reference.  This test will not validate those references against their associated
-            US Core profile to reduce test complexity.
+          For elements of type 'reference' with one or more target profiles from US Core, this test will ensure that at least one of each resource type
+          associated with each US Core target profile is provided as a reference.  This test will not validate those references against their associated
+          US Core profile to reduce test complexity.
 
           )
           versions :r4

--- a/lib/modules/uscore_v3.1.0/us_core_careteam_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_careteam_sequence.rb
@@ -350,6 +350,12 @@ module Inferno
             * participant.role
             * subject
             * participant.member
+
+
+            For elements of type 'reference' with one or more target profiles from US Core, this test will ensure that at least one of each resource type
+            associated with each US Core target profile is provided as a reference.  This test will not validate those references against their associated
+            US Core profile to reduce test complexity.
+
           )
           versions :r4
         end
@@ -380,7 +386,7 @@ module Inferno
         skip_if missing_must_support_elements.present?,
                 "Could not find #{missing_must_support_elements.join(', ')} in the #{@care_team_ary&.values&.flatten&.length} provided CareTeam resource(s)"
         skip_if missing_must_support_references.present?,
-                "Could not find the following resource type references: #{missing_must_support_references.map { |k, v| k + ':' + v.join(',') }.join(';')}"
+                "Could not find the following resource type references:#{missing_must_support_references.map { |path, resource_types| path + ':' + resource_types.join(',') }.join(';')}"
 
         @instance.save!
       end

--- a/lib/modules/uscore_v3.1.0/us_core_careteam_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_careteam_sequence.rb
@@ -346,9 +346,9 @@ module Inferno
             This will look through the CareTeam resources found previously for the following must support elements:
 
             * status
-            * subject
             * participant
             * participant.role
+            * subject
             * participant.member
           )
           versions :r4
@@ -356,6 +356,18 @@ module Inferno
 
         skip_if_not_found(resource_type: 'CareTeam', delayed: false)
         must_supports = USCore310CareteamSequenceDefinitions::MUST_SUPPORTS
+
+        missing_must_support_references = must_supports[:references].each_with_object({}) do |reference, missing_types_by_path|
+          missing_resource_types = reference[:resource_types].reject do |resource_type|
+            @care_team_ary&.values&.flatten&.any? do |resource|
+              value_found = resolve_element_from_path(resource, reference[:path]) do |value|
+                value.is_a?(FHIR::Reference) && value.reference.include?("#{resource_type}/")
+              end
+              value_found.present?
+            end
+          end
+          missing_types_by_path[reference[:path]] = missing_resource_types if missing_resource_types.present?
+        end
 
         missing_must_support_elements = must_supports[:elements].reject do |element|
           @care_team_ary&.values&.flatten&.any? do |resource|
@@ -367,6 +379,9 @@ module Inferno
 
         skip_if missing_must_support_elements.present?,
                 "Could not find #{missing_must_support_elements.join(', ')} in the #{@care_team_ary&.values&.flatten&.length} provided CareTeam resource(s)"
+        skip_if missing_must_support_references.present?,
+                "Could not find the following resource type references: #{missing_must_support_references.map { |k, v| k + ':' + v.join(',') }.join(';')}"
+
         @instance.save!
       end
 

--- a/lib/modules/uscore_v3.1.0/us_core_condition_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_condition_sequence.rb
@@ -538,6 +538,18 @@ module Inferno
         skip_if_not_found(resource_type: 'Condition', delayed: false)
         must_supports = USCore310ConditionSequenceDefinitions::MUST_SUPPORTS
 
+        missing_must_support_references = must_supports[:references].each_with_object({}) do |reference, missing_types_by_path|
+          missing_resource_types = reference[:resource_types].reject do |resource_type|
+            @condition_ary&.values&.flatten&.any? do |resource|
+              value_found = resolve_element_from_path(resource, reference[:path]) do |value|
+                value.is_a?(FHIR::Reference) && value.reference.include?("#{resource_type}/")
+              end
+              value_found.present?
+            end
+          end
+          missing_types_by_path[reference[:path]] = missing_resource_types if missing_resource_types.present?
+        end
+
         missing_must_support_elements = must_supports[:elements].reject do |element|
           @condition_ary&.values&.flatten&.any? do |resource|
             value_found = resolve_element_from_path(resource, element[:path]) { |value| element[:fixed_value].blank? || value == element[:fixed_value] }
@@ -548,6 +560,9 @@ module Inferno
 
         skip_if missing_must_support_elements.present?,
                 "Could not find #{missing_must_support_elements.join(', ')} in the #{@condition_ary&.values&.flatten&.length} provided Condition resource(s)"
+        skip_if missing_must_support_references.present?,
+                "Could not find the following resource type references: #{missing_must_support_references.map { |k, v| k + ':' + v.join(',') }.join(';')}"
+
         @instance.save!
       end
 

--- a/lib/modules/uscore_v3.1.0/us_core_condition_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_condition_sequence.rb
@@ -531,6 +531,12 @@ module Inferno
             * category
             * code
             * subject
+
+
+            For elements of type 'reference' with one or more target profiles from US Core, this test will ensure that at least one of each resource type
+            associated with each US Core target profile is provided as a reference.  This test will not validate those references against their associated
+            US Core profile to reduce test complexity.
+
           )
           versions :r4
         end
@@ -561,7 +567,7 @@ module Inferno
         skip_if missing_must_support_elements.present?,
                 "Could not find #{missing_must_support_elements.join(', ')} in the #{@condition_ary&.values&.flatten&.length} provided Condition resource(s)"
         skip_if missing_must_support_references.present?,
-                "Could not find the following resource type references: #{missing_must_support_references.map { |k, v| k + ':' + v.join(',') }.join(';')}"
+                "Could not find the following resource type references:#{missing_must_support_references.map { |path, resource_types| path + ':' + resource_types.join(',') }.join(';')}"
 
         @instance.save!
       end

--- a/lib/modules/uscore_v3.1.0/us_core_condition_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_condition_sequence.rb
@@ -526,16 +526,16 @@ module Inferno
             US Core Responders SHALL be capable of populating all data elements as part of the query results as specified by the US Core Server Capability Statement.
             This will look through the Condition resources found previously for the following must support elements:
 
-            * clinicalStatus
-            * verificationStatus
             * category
+            * clinicalStatus
             * code
             * subject
+            * verificationStatus
 
 
-            For elements of type 'reference' with one or more target profiles from US Core, this test will ensure that at least one of each resource type
-            associated with each US Core target profile is provided as a reference.  This test will not validate those references against their associated
-            US Core profile to reduce test complexity.
+          For elements of type 'reference' with one or more target profiles from US Core, this test will ensure that at least one of each resource type
+          associated with each US Core target profile is provided as a reference.  This test will not validate those references against their associated
+          US Core profile to reduce test complexity.
 
           )
           versions :r4

--- a/lib/modules/uscore_v3.1.0/us_core_diagnosticreport_lab_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_diagnosticreport_lab_sequence.rb
@@ -616,20 +616,20 @@ module Inferno
             US Core Responders SHALL be capable of populating all data elements as part of the query results as specified by the US Core Server Capability Statement.
             This will look through the DiagnosticReport resources found previously for the following must support elements:
 
-            * status
+            * DiagnosticReport.category:LaboratorySlice
             * category
             * code
             * effective[x]
             * issued
-            * DiagnosticReport.category:LaboratorySlice
-            * subject
             * performer
             * result
+            * status
+            * subject
 
 
-            For elements of type 'reference' with one or more target profiles from US Core, this test will ensure that at least one of each resource type
-            associated with each US Core target profile is provided as a reference.  This test will not validate those references against their associated
-            US Core profile to reduce test complexity.
+          For elements of type 'reference' with one or more target profiles from US Core, this test will ensure that at least one of each resource type
+          associated with each US Core target profile is provided as a reference.  This test will not validate those references against their associated
+          US Core profile to reduce test complexity.
 
           )
           versions :r4

--- a/lib/modules/uscore_v3.1.0/us_core_diagnosticreport_lab_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_diagnosticreport_lab_sequence.rb
@@ -619,12 +619,12 @@ module Inferno
             * status
             * category
             * code
-            * subject
             * effective[x]
             * issued
+            * DiagnosticReport.category:LaboratorySlice
+            * subject
             * performer
             * result
-            * DiagnosticReport.category:LaboratorySlice
           )
           versions :r4
         end
@@ -639,6 +639,18 @@ module Inferno
           end
         end
 
+        missing_must_support_references = must_supports[:references].each_with_object({}) do |reference, missing_types_by_path|
+          missing_resource_types = reference[:resource_types].reject do |resource_type|
+            @diagnostic_report_ary&.values&.flatten&.any? do |resource|
+              value_found = resolve_element_from_path(resource, reference[:path]) do |value|
+                value.is_a?(FHIR::Reference) && value.reference.include?("#{resource_type}/")
+              end
+              value_found.present?
+            end
+          end
+          missing_types_by_path[reference[:path]] = missing_resource_types if missing_resource_types.present?
+        end
+
         missing_must_support_elements = must_supports[:elements].reject do |element|
           @diagnostic_report_ary&.values&.flatten&.any? do |resource|
             value_found = resolve_element_from_path(resource, element[:path]) { |value| element[:fixed_value].blank? || value == element[:fixed_value] }
@@ -651,6 +663,9 @@ module Inferno
 
         skip_if missing_must_support_elements.present?,
                 "Could not find #{missing_must_support_elements.join(', ')} in the #{@diagnostic_report_ary&.values&.flatten&.length} provided DiagnosticReport resource(s)"
+        skip_if missing_must_support_references.present?,
+                "Could not find the following resource type references: #{missing_must_support_references.map { |k, v| k + ':' + v.join(',') }.join(';')}"
+
         @instance.save!
       end
 

--- a/lib/modules/uscore_v3.1.0/us_core_diagnosticreport_lab_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_diagnosticreport_lab_sequence.rb
@@ -625,6 +625,12 @@ module Inferno
             * subject
             * performer
             * result
+
+
+            For elements of type 'reference' with one or more target profiles from US Core, this test will ensure that at least one of each resource type
+            associated with each US Core target profile is provided as a reference.  This test will not validate those references against their associated
+            US Core profile to reduce test complexity.
+
           )
           versions :r4
         end
@@ -664,7 +670,7 @@ module Inferno
         skip_if missing_must_support_elements.present?,
                 "Could not find #{missing_must_support_elements.join(', ')} in the #{@diagnostic_report_ary&.values&.flatten&.length} provided DiagnosticReport resource(s)"
         skip_if missing_must_support_references.present?,
-                "Could not find the following resource type references: #{missing_must_support_references.map { |k, v| k + ':' + v.join(',') }.join(';')}"
+                "Could not find the following resource type references:#{missing_must_support_references.map { |path, resource_types| path + ':' + resource_types.join(',') }.join(';')}"
 
         @instance.save!
       end

--- a/lib/modules/uscore_v3.1.0/us_core_diagnosticreport_note_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_diagnosticreport_note_sequence.rb
@@ -619,18 +619,30 @@ module Inferno
             * status
             * category
             * code
-            * subject
-            * encounter
             * effective[x]
             * issued
-            * performer
             * presentedForm
+            * subject
+            * encounter
+            * performer
           )
           versions :r4
         end
 
         skip_if_not_found(resource_type: 'DiagnosticReport', delayed: false)
         must_supports = USCore310DiagnosticreportNoteSequenceDefinitions::MUST_SUPPORTS
+
+        missing_must_support_references = must_supports[:references].each_with_object({}) do |reference, missing_types_by_path|
+          missing_resource_types = reference[:resource_types].reject do |resource_type|
+            @diagnostic_report_ary&.values&.flatten&.any? do |resource|
+              value_found = resolve_element_from_path(resource, reference[:path]) do |value|
+                value.is_a?(FHIR::Reference) && value.reference.include?("#{resource_type}/")
+              end
+              value_found.present?
+            end
+          end
+          missing_types_by_path[reference[:path]] = missing_resource_types if missing_resource_types.present?
+        end
 
         missing_must_support_elements = must_supports[:elements].reject do |element|
           @diagnostic_report_ary&.values&.flatten&.any? do |resource|
@@ -642,6 +654,9 @@ module Inferno
 
         skip_if missing_must_support_elements.present?,
                 "Could not find #{missing_must_support_elements.join(', ')} in the #{@diagnostic_report_ary&.values&.flatten&.length} provided DiagnosticReport resource(s)"
+        skip_if missing_must_support_references.present?,
+                "Could not find the following resource type references: #{missing_must_support_references.map { |k, v| k + ':' + v.join(',') }.join(';')}"
+
         @instance.save!
       end
 

--- a/lib/modules/uscore_v3.1.0/us_core_diagnosticreport_note_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_diagnosticreport_note_sequence.rb
@@ -616,20 +616,20 @@ module Inferno
             US Core Responders SHALL be capable of populating all data elements as part of the query results as specified by the US Core Server Capability Statement.
             This will look through the DiagnosticReport resources found previously for the following must support elements:
 
-            * status
             * category
             * code
             * effective[x]
-            * issued
-            * presentedForm
-            * subject
             * encounter
+            * issued
             * performer
+            * presentedForm
+            * status
+            * subject
 
 
-            For elements of type 'reference' with one or more target profiles from US Core, this test will ensure that at least one of each resource type
-            associated with each US Core target profile is provided as a reference.  This test will not validate those references against their associated
-            US Core profile to reduce test complexity.
+          For elements of type 'reference' with one or more target profiles from US Core, this test will ensure that at least one of each resource type
+          associated with each US Core target profile is provided as a reference.  This test will not validate those references against their associated
+          US Core profile to reduce test complexity.
 
           )
           versions :r4

--- a/lib/modules/uscore_v3.1.0/us_core_diagnosticreport_note_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_diagnosticreport_note_sequence.rb
@@ -625,6 +625,12 @@ module Inferno
             * subject
             * encounter
             * performer
+
+
+            For elements of type 'reference' with one or more target profiles from US Core, this test will ensure that at least one of each resource type
+            associated with each US Core target profile is provided as a reference.  This test will not validate those references against their associated
+            US Core profile to reduce test complexity.
+
           )
           versions :r4
         end
@@ -655,7 +661,7 @@ module Inferno
         skip_if missing_must_support_elements.present?,
                 "Could not find #{missing_must_support_elements.join(', ')} in the #{@diagnostic_report_ary&.values&.flatten&.length} provided DiagnosticReport resource(s)"
         skip_if missing_must_support_references.present?,
-                "Could not find the following resource type references: #{missing_must_support_references.map { |k, v| k + ':' + v.join(',') }.join(';')}"
+                "Could not find the following resource type references:#{missing_must_support_references.map { |path, resource_types| path + ':' + resource_types.join(',') }.join(';')}"
 
         @instance.save!
       end

--- a/lib/modules/uscore_v3.1.0/us_core_documentreference_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_documentreference_sequence.rb
@@ -672,11 +672,8 @@ module Inferno
             US Core Responders SHALL be capable of populating all data elements as part of the query results as specified by the US Core Server Capability Statement.
             This will look through the DocumentReference resources found previously for the following must support elements:
 
-            * identifier
-            * status
-            * type
+            * author
             * category
-            * date
             * content
             * content.attachment
             * content.attachment.contentType
@@ -684,16 +681,19 @@ module Inferno
             * content.attachment.url
             * content.format
             * context
-            * context.period
-            * subject
-            * author
-            * custodian
             * context.encounter
+            * context.period
+            * custodian
+            * date
+            * identifier
+            * status
+            * subject
+            * type
 
 
-            For elements of type 'reference' with one or more target profiles from US Core, this test will ensure that at least one of each resource type
-            associated with each US Core target profile is provided as a reference.  This test will not validate those references against their associated
-            US Core profile to reduce test complexity.
+          For elements of type 'reference' with one or more target profiles from US Core, this test will ensure that at least one of each resource type
+          associated with each US Core target profile is provided as a reference.  This test will not validate those references against their associated
+          US Core profile to reduce test complexity.
 
           )
           versions :r4

--- a/lib/modules/uscore_v3.1.0/us_core_documentreference_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_documentreference_sequence.rb
@@ -689,6 +689,12 @@ module Inferno
             * author
             * custodian
             * context.encounter
+
+
+            For elements of type 'reference' with one or more target profiles from US Core, this test will ensure that at least one of each resource type
+            associated with each US Core target profile is provided as a reference.  This test will not validate those references against their associated
+            US Core profile to reduce test complexity.
+
           )
           versions :r4
         end
@@ -719,7 +725,7 @@ module Inferno
         skip_if missing_must_support_elements.present?,
                 "Could not find #{missing_must_support_elements.join(', ')} in the #{@document_reference_ary&.values&.flatten&.length} provided DocumentReference resource(s)"
         skip_if missing_must_support_references.present?,
-                "Could not find the following resource type references: #{missing_must_support_references.map { |k, v| k + ':' + v.join(',') }.join(';')}"
+                "Could not find the following resource type references:#{missing_must_support_references.map { |path, resource_types| path + ':' + resource_types.join(',') }.join(';')}"
 
         @instance.save!
       end

--- a/lib/modules/uscore_v3.1.0/us_core_encounter_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_encounter_sequence.rb
@@ -261,6 +261,12 @@ module Inferno
             * subject
             * participant.individual
             * location.location
+
+
+            For elements of type 'reference' with one or more target profiles from US Core, this test will ensure that at least one of each resource type
+            associated with each US Core target profile is provided as a reference.  This test will not validate those references against their associated
+            US Core profile to reduce test complexity.
+
           )
           versions :r4
         end
@@ -291,7 +297,7 @@ module Inferno
         skip_if missing_must_support_elements.present?,
                 "Could not find #{missing_must_support_elements.join(', ')} in the #{@encounter_ary&.length} provided Encounter resource(s)"
         skip_if missing_must_support_references.present?,
-                "Could not find the following resource type references: #{missing_must_support_references.map { |k, v| k + ':' + v.join(',') }.join(';')}"
+                "Could not find the following resource type references:#{missing_must_support_references.map { |path, resource_types| path + ':' + resource_types.join(',') }.join(';')}"
 
         @instance.save!
       end

--- a/lib/modules/uscore_v3.1.0/us_core_encounter_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_encounter_sequence.rb
@@ -244,28 +244,28 @@ module Inferno
             US Core Responders SHALL be capable of populating all data elements as part of the query results as specified by the US Core Server Capability Statement.
             This will look through the Encounter resources found previously for the following must support elements:
 
+            * class
+            * hospitalization
+            * hospitalization.dischargeDisposition
             * identifier
             * identifier.system
             * identifier.value
-            * status
-            * class
-            * type
+            * location
+            * location.location
             * participant
-            * participant.type
+            * participant.individual
             * participant.period
+            * participant.type
             * period
             * reasonCode
-            * hospitalization
-            * hospitalization.dischargeDisposition
-            * location
+            * status
             * subject
-            * participant.individual
-            * location.location
+            * type
 
 
-            For elements of type 'reference' with one or more target profiles from US Core, this test will ensure that at least one of each resource type
-            associated with each US Core target profile is provided as a reference.  This test will not validate those references against their associated
-            US Core profile to reduce test complexity.
+          For elements of type 'reference' with one or more target profiles from US Core, this test will ensure that at least one of each resource type
+          associated with each US Core target profile is provided as a reference.  This test will not validate those references against their associated
+          US Core profile to reduce test complexity.
 
           )
           versions :r4

--- a/lib/modules/uscore_v3.1.0/us_core_goal_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_goal_sequence.rb
@@ -438,6 +438,12 @@ module Inferno
             * target
             * Goal.target.due[x]:dueDate
             * subject
+
+
+            For elements of type 'reference' with one or more target profiles from US Core, this test will ensure that at least one of each resource type
+            associated with each US Core target profile is provided as a reference.  This test will not validate those references against their associated
+            US Core profile to reduce test complexity.
+
           )
           versions :r4
         end
@@ -477,7 +483,7 @@ module Inferno
         skip_if missing_must_support_elements.present?,
                 "Could not find #{missing_must_support_elements.join(', ')} in the #{@goal_ary&.values&.flatten&.length} provided Goal resource(s)"
         skip_if missing_must_support_references.present?,
-                "Could not find the following resource type references: #{missing_must_support_references.map { |k, v| k + ':' + v.join(',') }.join(';')}"
+                "Could not find the following resource type references:#{missing_must_support_references.map { |path, resource_types| path + ':' + resource_types.join(',') }.join(';')}"
 
         @instance.save!
       end

--- a/lib/modules/uscore_v3.1.0/us_core_goal_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_goal_sequence.rb
@@ -435,9 +435,9 @@ module Inferno
 
             * lifecycleStatus
             * description
-            * subject
             * target
             * Goal.target.due[x]:dueDate
+            * subject
           )
           versions :r4
         end
@@ -452,6 +452,18 @@ module Inferno
           end
         end
 
+        missing_must_support_references = must_supports[:references].each_with_object({}) do |reference, missing_types_by_path|
+          missing_resource_types = reference[:resource_types].reject do |resource_type|
+            @goal_ary&.values&.flatten&.any? do |resource|
+              value_found = resolve_element_from_path(resource, reference[:path]) do |value|
+                value.is_a?(FHIR::Reference) && value.reference.include?("#{resource_type}/")
+              end
+              value_found.present?
+            end
+          end
+          missing_types_by_path[reference[:path]] = missing_resource_types if missing_resource_types.present?
+        end
+
         missing_must_support_elements = must_supports[:elements].reject do |element|
           @goal_ary&.values&.flatten&.any? do |resource|
             value_found = resolve_element_from_path(resource, element[:path]) { |value| element[:fixed_value].blank? || value == element[:fixed_value] }
@@ -464,6 +476,9 @@ module Inferno
 
         skip_if missing_must_support_elements.present?,
                 "Could not find #{missing_must_support_elements.join(', ')} in the #{@goal_ary&.values&.flatten&.length} provided Goal resource(s)"
+        skip_if missing_must_support_references.present?,
+                "Could not find the following resource type references: #{missing_must_support_references.map { |k, v| k + ':' + v.join(',') }.join(';')}"
+
         @instance.save!
       end
 

--- a/lib/modules/uscore_v3.1.0/us_core_goal_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_goal_sequence.rb
@@ -433,16 +433,16 @@ module Inferno
             US Core Responders SHALL be capable of populating all data elements as part of the query results as specified by the US Core Server Capability Statement.
             This will look through the Goal resources found previously for the following must support elements:
 
-            * lifecycleStatus
-            * description
-            * target
             * Goal.target.due[x]:dueDate
+            * description
+            * lifecycleStatus
             * subject
+            * target
 
 
-            For elements of type 'reference' with one or more target profiles from US Core, this test will ensure that at least one of each resource type
-            associated with each US Core target profile is provided as a reference.  This test will not validate those references against their associated
-            US Core profile to reduce test complexity.
+          For elements of type 'reference' with one or more target profiles from US Core, this test will ensure that at least one of each resource type
+          associated with each US Core target profile is provided as a reference.  This test will not validate those references against their associated
+          US Core profile to reduce test complexity.
 
           )
           versions :r4

--- a/lib/modules/uscore_v3.1.0/us_core_immunization_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_immunization_sequence.rb
@@ -439,6 +439,12 @@ module Inferno
             * occurrence[x]
             * primarySource
             * patient
+
+
+            For elements of type 'reference' with one or more target profiles from US Core, this test will ensure that at least one of each resource type
+            associated with each US Core target profile is provided as a reference.  This test will not validate those references against their associated
+            US Core profile to reduce test complexity.
+
           )
           versions :r4
         end
@@ -469,7 +475,7 @@ module Inferno
         skip_if missing_must_support_elements.present?,
                 "Could not find #{missing_must_support_elements.join(', ')} in the #{@immunization_ary&.values&.flatten&.length} provided Immunization resource(s)"
         skip_if missing_must_support_references.present?,
-                "Could not find the following resource type references: #{missing_must_support_references.map { |k, v| k + ':' + v.join(',') }.join(';')}"
+                "Could not find the following resource type references:#{missing_must_support_references.map { |path, resource_types| path + ':' + resource_types.join(',') }.join(';')}"
 
         @instance.save!
       end

--- a/lib/modules/uscore_v3.1.0/us_core_immunization_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_immunization_sequence.rb
@@ -433,17 +433,17 @@ module Inferno
             US Core Responders SHALL be capable of populating all data elements as part of the query results as specified by the US Core Server Capability Statement.
             This will look through the Immunization resources found previously for the following must support elements:
 
+            * occurrence[x]
+            * patient
+            * primarySource
             * status
             * statusReason
             * vaccineCode
-            * occurrence[x]
-            * primarySource
-            * patient
 
 
-            For elements of type 'reference' with one or more target profiles from US Core, this test will ensure that at least one of each resource type
-            associated with each US Core target profile is provided as a reference.  This test will not validate those references against their associated
-            US Core profile to reduce test complexity.
+          For elements of type 'reference' with one or more target profiles from US Core, this test will ensure that at least one of each resource type
+          associated with each US Core target profile is provided as a reference.  This test will not validate those references against their associated
+          US Core profile to reduce test complexity.
 
           )
           versions :r4

--- a/lib/modules/uscore_v3.1.0/us_core_implantable_device_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_implantable_device_sequence.rb
@@ -377,6 +377,12 @@ module Inferno
             * serialNumber
             * type
             * patient
+
+
+            For elements of type 'reference' with one or more target profiles from US Core, this test will ensure that at least one of each resource type
+            associated with each US Core target profile is provided as a reference.  This test will not validate those references against their associated
+            US Core profile to reduce test complexity.
+
           )
           versions :r4
         end
@@ -407,7 +413,7 @@ module Inferno
         skip_if missing_must_support_elements.present?,
                 "Could not find #{missing_must_support_elements.join(', ')} in the #{@device_ary&.values&.flatten&.length} provided Device resource(s)"
         skip_if missing_must_support_references.present?,
-                "Could not find the following resource type references: #{missing_must_support_references.map { |k, v| k + ':' + v.join(',') }.join(';')}"
+                "Could not find the following resource type references:#{missing_must_support_references.map { |path, resource_types| path + ':' + resource_types.join(',') }.join(';')}"
 
         @instance.save!
       end

--- a/lib/modules/uscore_v3.1.0/us_core_implantable_device_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_implantable_device_sequence.rb
@@ -366,22 +366,22 @@ module Inferno
             US Core Responders SHALL be capable of populating all data elements as part of the query results as specified by the US Core Server Capability Statement.
             This will look through the Device resources found previously for the following must support elements:
 
-            * udiCarrier
-            * udiCarrier.deviceIdentifier
-            * udiCarrier.carrierAIDC
-            * udiCarrier.carrierHRF
             * distinctIdentifier
-            * manufactureDate
             * expirationDate
             * lotNumber
+            * manufactureDate
+            * patient
             * serialNumber
             * type
-            * patient
+            * udiCarrier
+            * udiCarrier.carrierAIDC
+            * udiCarrier.carrierHRF
+            * udiCarrier.deviceIdentifier
 
 
-            For elements of type 'reference' with one or more target profiles from US Core, this test will ensure that at least one of each resource type
-            associated with each US Core target profile is provided as a reference.  This test will not validate those references against their associated
-            US Core profile to reduce test complexity.
+          For elements of type 'reference' with one or more target profiles from US Core, this test will ensure that at least one of each resource type
+          associated with each US Core target profile is provided as a reference.  This test will not validate those references against their associated
+          US Core profile to reduce test complexity.
 
           )
           versions :r4

--- a/lib/modules/uscore_v3.1.0/us_core_implantable_device_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_implantable_device_sequence.rb
@@ -384,6 +384,18 @@ module Inferno
         skip_if_not_found(resource_type: 'Device', delayed: false)
         must_supports = USCore310ImplantableDeviceSequenceDefinitions::MUST_SUPPORTS
 
+        missing_must_support_references = must_supports[:references].each_with_object({}) do |reference, missing_types_by_path|
+          missing_resource_types = reference[:resource_types].reject do |resource_type|
+            @device_ary&.values&.flatten&.any? do |resource|
+              value_found = resolve_element_from_path(resource, reference[:path]) do |value|
+                value.is_a?(FHIR::Reference) && value.reference.include?("#{resource_type}/")
+              end
+              value_found.present?
+            end
+          end
+          missing_types_by_path[reference[:path]] = missing_resource_types if missing_resource_types.present?
+        end
+
         missing_must_support_elements = must_supports[:elements].reject do |element|
           @device_ary&.values&.flatten&.any? do |resource|
             value_found = resolve_element_from_path(resource, element[:path]) { |value| element[:fixed_value].blank? || value == element[:fixed_value] }
@@ -394,6 +406,9 @@ module Inferno
 
         skip_if missing_must_support_elements.present?,
                 "Could not find #{missing_must_support_elements.join(', ')} in the #{@device_ary&.values&.flatten&.length} provided Device resource(s)"
+        skip_if missing_must_support_references.present?,
+                "Could not find the following resource type references: #{missing_must_support_references.map { |k, v| k + ':' + v.join(',') }.join(';')}"
+
         @instance.save!
       end
 

--- a/lib/modules/uscore_v3.1.0/us_core_location_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_location_sequence.rb
@@ -211,6 +211,18 @@ module Inferno
         skip_if_not_found(resource_type: 'Location', delayed: true)
         must_supports = USCore310LocationSequenceDefinitions::MUST_SUPPORTS
 
+        missing_must_support_references = must_supports[:references].each_with_object({}) do |reference, missing_types_by_path|
+          missing_resource_types = reference[:resource_types].reject do |resource_type|
+            @location_ary&.any? do |resource|
+              value_found = resolve_element_from_path(resource, reference[:path]) do |value|
+                value.is_a?(FHIR::Reference) && value.reference.include?("#{resource_type}/")
+              end
+              value_found.present?
+            end
+          end
+          missing_types_by_path[reference[:path]] = missing_resource_types if missing_resource_types.present?
+        end
+
         missing_must_support_elements = must_supports[:elements].reject do |element|
           @location_ary&.any? do |resource|
             value_found = resolve_element_from_path(resource, element[:path]) { |value| element[:fixed_value].blank? || value == element[:fixed_value] }
@@ -221,6 +233,9 @@ module Inferno
 
         skip_if missing_must_support_elements.present?,
                 "Could not find #{missing_must_support_elements.join(', ')} in the #{@location_ary&.length} provided Location resource(s)"
+        skip_if missing_must_support_references.present?,
+                "Could not find the following resource type references: #{missing_must_support_references.map { |k, v| k + ':' + v.join(',') }.join(';')}"
+
         @instance.save!
       end
 

--- a/lib/modules/uscore_v3.1.0/us_core_location_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_location_sequence.rb
@@ -204,6 +204,12 @@ module Inferno
             * address.state
             * address.postalCode
             * managingOrganization
+
+
+            For elements of type 'reference' with one or more target profiles from US Core, this test will ensure that at least one of each resource type
+            associated with each US Core target profile is provided as a reference.  This test will not validate those references against their associated
+            US Core profile to reduce test complexity.
+
           )
           versions :r4
         end
@@ -234,7 +240,7 @@ module Inferno
         skip_if missing_must_support_elements.present?,
                 "Could not find #{missing_must_support_elements.join(', ')} in the #{@location_ary&.length} provided Location resource(s)"
         skip_if missing_must_support_references.present?,
-                "Could not find the following resource type references: #{missing_must_support_references.map { |k, v| k + ':' + v.join(',') }.join(';')}"
+                "Could not find the following resource type references:#{missing_must_support_references.map { |path, resource_types| path + ':' + resource_types.join(',') }.join(';')}"
 
         @instance.save!
       end

--- a/lib/modules/uscore_v3.1.0/us_core_location_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_location_sequence.rb
@@ -195,20 +195,20 @@ module Inferno
             US Core Responders SHALL be capable of populating all data elements as part of the query results as specified by the US Core Server Capability Statement.
             This will look through the Location resources found previously for the following must support elements:
 
-            * status
-            * name
-            * telecom
             * address
-            * address.line
             * address.city
-            * address.state
+            * address.line
             * address.postalCode
+            * address.state
             * managingOrganization
+            * name
+            * status
+            * telecom
 
 
-            For elements of type 'reference' with one or more target profiles from US Core, this test will ensure that at least one of each resource type
-            associated with each US Core target profile is provided as a reference.  This test will not validate those references against their associated
-            US Core profile to reduce test complexity.
+          For elements of type 'reference' with one or more target profiles from US Core, this test will ensure that at least one of each resource type
+          associated with each US Core target profile is provided as a reference.  This test will not validate those references against their associated
+          US Core profile to reduce test complexity.
 
           )
           versions :r4

--- a/lib/modules/uscore_v3.1.0/us_core_medicationrequest_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_medicationrequest_sequence.rb
@@ -602,21 +602,21 @@ module Inferno
             US Core Responders SHALL be capable of populating all data elements as part of the query results as specified by the US Core Server Capability Statement.
             This will look through the MedicationRequest resources found previously for the following must support elements:
 
-            * status
-            * intent
             * authoredOn
             * dosageInstruction
             * dosageInstruction.text
-            * reported[x]
-            * medication[x]
-            * subject
             * encounter
+            * intent
+            * medication[x]
+            * reported[x]
             * requester
+            * status
+            * subject
 
 
-            For elements of type 'reference' with one or more target profiles from US Core, this test will ensure that at least one of each resource type
-            associated with each US Core target profile is provided as a reference.  This test will not validate those references against their associated
-            US Core profile to reduce test complexity.
+          For elements of type 'reference' with one or more target profiles from US Core, this test will ensure that at least one of each resource type
+          associated with each US Core target profile is provided as a reference.  This test will not validate those references against their associated
+          US Core profile to reduce test complexity.
 
           )
           versions :r4

--- a/lib/modules/uscore_v3.1.0/us_core_medicationrequest_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_medicationrequest_sequence.rb
@@ -604,20 +604,32 @@ module Inferno
 
             * status
             * intent
+            * authoredOn
+            * dosageInstruction
+            * dosageInstruction.text
             * reported[x]
             * medication[x]
             * subject
             * encounter
-            * authoredOn
             * requester
-            * dosageInstruction
-            * dosageInstruction.text
           )
           versions :r4
         end
 
         skip_if_not_found(resource_type: 'MedicationRequest', delayed: false)
         must_supports = USCore310MedicationrequestSequenceDefinitions::MUST_SUPPORTS
+
+        missing_must_support_references = must_supports[:references].each_with_object({}) do |reference, missing_types_by_path|
+          missing_resource_types = reference[:resource_types].reject do |resource_type|
+            @medication_request_ary&.values&.flatten&.any? do |resource|
+              value_found = resolve_element_from_path(resource, reference[:path]) do |value|
+                value.is_a?(FHIR::Reference) && value.reference.include?("#{resource_type}/")
+              end
+              value_found.present?
+            end
+          end
+          missing_types_by_path[reference[:path]] = missing_resource_types if missing_resource_types.present?
+        end
 
         missing_must_support_elements = must_supports[:elements].reject do |element|
           @medication_request_ary&.values&.flatten&.any? do |resource|
@@ -629,6 +641,9 @@ module Inferno
 
         skip_if missing_must_support_elements.present?,
                 "Could not find #{missing_must_support_elements.join(', ')} in the #{@medication_request_ary&.values&.flatten&.length} provided MedicationRequest resource(s)"
+        skip_if missing_must_support_references.present?,
+                "Could not find the following resource type references: #{missing_must_support_references.map { |k, v| k + ':' + v.join(',') }.join(';')}"
+
         @instance.save!
       end
 

--- a/lib/modules/uscore_v3.1.0/us_core_medicationrequest_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_medicationrequest_sequence.rb
@@ -612,6 +612,12 @@ module Inferno
             * subject
             * encounter
             * requester
+
+
+            For elements of type 'reference' with one or more target profiles from US Core, this test will ensure that at least one of each resource type
+            associated with each US Core target profile is provided as a reference.  This test will not validate those references against their associated
+            US Core profile to reduce test complexity.
+
           )
           versions :r4
         end
@@ -642,7 +648,7 @@ module Inferno
         skip_if missing_must_support_elements.present?,
                 "Could not find #{missing_must_support_elements.join(', ')} in the #{@medication_request_ary&.values&.flatten&.length} provided MedicationRequest resource(s)"
         skip_if missing_must_support_references.present?,
-                "Could not find the following resource type references: #{missing_must_support_references.map { |k, v| k + ':' + v.join(',') }.join(';')}"
+                "Could not find the following resource type references:#{missing_must_support_references.map { |path, resource_types| path + ':' + resource_types.join(',') }.join(';')}"
 
         @instance.save!
       end

--- a/lib/modules/uscore_v3.1.0/us_core_observation_lab_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_observation_lab_sequence.rb
@@ -592,11 +592,11 @@ module Inferno
             * status
             * category
             * code
-            * subject
             * effective[x]
             * value[x]
             * dataAbsentReason
             * Observation.category:Laboratory
+            * subject
           )
           versions :r4
         end
@@ -611,6 +611,18 @@ module Inferno
           end
         end
 
+        missing_must_support_references = must_supports[:references].each_with_object({}) do |reference, missing_types_by_path|
+          missing_resource_types = reference[:resource_types].reject do |resource_type|
+            @observation_ary&.values&.flatten&.any? do |resource|
+              value_found = resolve_element_from_path(resource, reference[:path]) do |value|
+                value.is_a?(FHIR::Reference) && value.reference.include?("#{resource_type}/")
+              end
+              value_found.present?
+            end
+          end
+          missing_types_by_path[reference[:path]] = missing_resource_types if missing_resource_types.present?
+        end
+
         missing_must_support_elements = must_supports[:elements].reject do |element|
           @observation_ary&.values&.flatten&.any? do |resource|
             value_found = resolve_element_from_path(resource, element[:path]) { |value| element[:fixed_value].blank? || value == element[:fixed_value] }
@@ -623,6 +635,9 @@ module Inferno
 
         skip_if missing_must_support_elements.present?,
                 "Could not find #{missing_must_support_elements.join(', ')} in the #{@observation_ary&.values&.flatten&.length} provided Observation resource(s)"
+        skip_if missing_must_support_references.present?,
+                "Could not find the following resource type references: #{missing_must_support_references.map { |k, v| k + ':' + v.join(',') }.join(';')}"
+
         @instance.save!
       end
 

--- a/lib/modules/uscore_v3.1.0/us_core_observation_lab_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_observation_lab_sequence.rb
@@ -597,6 +597,12 @@ module Inferno
             * dataAbsentReason
             * Observation.category:Laboratory
             * subject
+
+
+            For elements of type 'reference' with one or more target profiles from US Core, this test will ensure that at least one of each resource type
+            associated with each US Core target profile is provided as a reference.  This test will not validate those references against their associated
+            US Core profile to reduce test complexity.
+
           )
           versions :r4
         end
@@ -636,7 +642,7 @@ module Inferno
         skip_if missing_must_support_elements.present?,
                 "Could not find #{missing_must_support_elements.join(', ')} in the #{@observation_ary&.values&.flatten&.length} provided Observation resource(s)"
         skip_if missing_must_support_references.present?,
-                "Could not find the following resource type references: #{missing_must_support_references.map { |k, v| k + ':' + v.join(',') }.join(';')}"
+                "Could not find the following resource type references:#{missing_must_support_references.map { |path, resource_types| path + ':' + resource_types.join(',') }.join(';')}"
 
         @instance.save!
       end

--- a/lib/modules/uscore_v3.1.0/us_core_observation_lab_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_observation_lab_sequence.rb
@@ -589,19 +589,19 @@ module Inferno
             US Core Responders SHALL be capable of populating all data elements as part of the query results as specified by the US Core Server Capability Statement.
             This will look through the Observation resources found previously for the following must support elements:
 
-            * status
+            * Observation.category:Laboratory
             * category
             * code
-            * effective[x]
-            * value[x]
             * dataAbsentReason
-            * Observation.category:Laboratory
+            * effective[x]
+            * status
             * subject
+            * value[x]
 
 
-            For elements of type 'reference' with one or more target profiles from US Core, this test will ensure that at least one of each resource type
-            associated with each US Core target profile is provided as a reference.  This test will not validate those references against their associated
-            US Core profile to reduce test complexity.
+          For elements of type 'reference' with one or more target profiles from US Core, this test will ensure that at least one of each resource type
+          associated with each US Core target profile is provided as a reference.  This test will not validate those references against their associated
+          US Core profile to reduce test complexity.
 
           )
           versions :r4

--- a/lib/modules/uscore_v3.1.0/us_core_organization_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_organization_sequence.rb
@@ -191,6 +191,12 @@ module Inferno
             * address.country
             * Organization.identifier:NPI
             * Organization.identifier:CLIA
+
+
+            For elements of type 'reference' with one or more target profiles from US Core, this test will ensure that at least one of each resource type
+            associated with each US Core target profile is provided as a reference.  This test will not validate those references against their associated
+            US Core profile to reduce test complexity.
+
           )
           versions :r4
         end

--- a/lib/modules/uscore_v3.1.0/us_core_organization_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_organization_sequence.rb
@@ -177,25 +177,22 @@ module Inferno
             US Core Responders SHALL be capable of populating all data elements as part of the query results as specified by the US Core Server Capability Statement.
             This will look through the Organization resources found previously for the following must support elements:
 
+            * Organization.identifier:CLIA
+            * Organization.identifier:NPI
+            * active
+            * address
+            * address.city
+            * address.country
+            * address.line
+            * address.postalCode
+            * address.state
             * identifier
             * identifier.system
             * identifier.value
-            * active
             * name
             * telecom
-            * address
-            * address.line
-            * address.city
-            * address.state
-            * address.postalCode
-            * address.country
-            * Organization.identifier:NPI
-            * Organization.identifier:CLIA
 
 
-            For elements of type 'reference' with one or more target profiles from US Core, this test will ensure that at least one of each resource type
-            associated with each US Core target profile is provided as a reference.  This test will not validate those references against their associated
-            US Core profile to reduce test complexity.
 
           )
           versions :r4

--- a/lib/modules/uscore_v3.1.0/us_core_patient_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_patient_sequence.rb
@@ -587,6 +587,12 @@ module Inferno
             * Patient.extension:race
             * Patient.extension:ethnicity
             * Patient.extension:birthsex
+
+
+            For elements of type 'reference' with one or more target profiles from US Core, this test will ensure that at least one of each resource type
+            associated with each US Core target profile is provided as a reference.  This test will not validate those references against their associated
+            US Core profile to reduce test complexity.
+
           )
           versions :r4
         end

--- a/lib/modules/uscore_v3.1.0/us_core_patient_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_patient_sequence.rb
@@ -564,6 +564,19 @@ module Inferno
             US Core Responders SHALL be capable of populating all data elements as part of the query results as specified by the US Core Server Capability Statement.
             This will look through the Patient resources found previously for the following must support elements:
 
+            * Patient.extension:birthsex
+            * Patient.extension:ethnicity
+            * Patient.extension:race
+            * address
+            * address.city
+            * address.line
+            * address.period
+            * address.postalCode
+            * address.state
+            * birthDate
+            * communication
+            * communication.language
+            * gender
             * identifier
             * identifier.system
             * identifier.value
@@ -572,26 +585,10 @@ module Inferno
             * name.given
             * telecom
             * telecom.system
-            * telecom.value
             * telecom.use
-            * gender
-            * birthDate
-            * address
-            * address.line
-            * address.city
-            * address.state
-            * address.postalCode
-            * address.period
-            * communication
-            * communication.language
-            * Patient.extension:race
-            * Patient.extension:ethnicity
-            * Patient.extension:birthsex
+            * telecom.value
 
 
-            For elements of type 'reference' with one or more target profiles from US Core, this test will ensure that at least one of each resource type
-            associated with each US Core target profile is provided as a reference.  This test will not validate those references against their associated
-            US Core profile to reduce test complexity.
 
           )
           versions :r4

--- a/lib/modules/uscore_v3.1.0/us_core_practitioner_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_practitioner_sequence.rb
@@ -187,6 +187,12 @@ module Inferno
             * name
             * name.family
             * Practitioner.identifier:NPI
+
+
+            For elements of type 'reference' with one or more target profiles from US Core, this test will ensure that at least one of each resource type
+            associated with each US Core target profile is provided as a reference.  This test will not validate those references against their associated
+            US Core profile to reduce test complexity.
+
           )
           versions :r4
         end

--- a/lib/modules/uscore_v3.1.0/us_core_practitioner_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_practitioner_sequence.rb
@@ -181,17 +181,14 @@ module Inferno
             US Core Responders SHALL be capable of populating all data elements as part of the query results as specified by the US Core Server Capability Statement.
             This will look through the Practitioner resources found previously for the following must support elements:
 
+            * Practitioner.identifier:NPI
             * identifier
             * identifier.system
             * identifier.value
             * name
             * name.family
-            * Practitioner.identifier:NPI
 
 
-            For elements of type 'reference' with one or more target profiles from US Core, this test will ensure that at least one of each resource type
-            associated with each US Core target profile is provided as a reference.  This test will not validate those references against their associated
-            US Core profile to reduce test complexity.
 
           )
           versions :r4

--- a/lib/modules/uscore_v3.1.0/us_core_practitionerrole_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_practitionerrole_sequence.rb
@@ -179,14 +179,14 @@ module Inferno
             US Core Responders SHALL be capable of populating all data elements as part of the query results as specified by the US Core Server Capability Statement.
             This will look through the PractitionerRole resources found previously for the following must support elements:
 
-            * practitioner
-            * organization
             * code
             * specialty
-            * location
             * telecom
             * telecom.system
             * telecom.value
+            * practitioner
+            * organization
+            * location
             * endpoint
           )
           versions :r4
@@ -194,6 +194,18 @@ module Inferno
 
         skip_if_not_found(resource_type: 'PractitionerRole', delayed: true)
         must_supports = USCore310PractitionerroleSequenceDefinitions::MUST_SUPPORTS
+
+        missing_must_support_references = must_supports[:references].each_with_object({}) do |reference, missing_types_by_path|
+          missing_resource_types = reference[:resource_types].reject do |resource_type|
+            @practitioner_role_ary&.any? do |resource|
+              value_found = resolve_element_from_path(resource, reference[:path]) do |value|
+                value.is_a?(FHIR::Reference) && value.reference.include?("#{resource_type}/")
+              end
+              value_found.present?
+            end
+          end
+          missing_types_by_path[reference[:path]] = missing_resource_types if missing_resource_types.present?
+        end
 
         missing_must_support_elements = must_supports[:elements].reject do |element|
           @practitioner_role_ary&.any? do |resource|
@@ -205,6 +217,9 @@ module Inferno
 
         skip_if missing_must_support_elements.present?,
                 "Could not find #{missing_must_support_elements.join(', ')} in the #{@practitioner_role_ary&.length} provided PractitionerRole resource(s)"
+        skip_if missing_must_support_references.present?,
+                "Could not find the following resource type references: #{missing_must_support_references.map { |k, v| k + ':' + v.join(',') }.join(';')}"
+
         @instance.save!
       end
 

--- a/lib/modules/uscore_v3.1.0/us_core_practitionerrole_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_practitionerrole_sequence.rb
@@ -188,6 +188,12 @@ module Inferno
             * organization
             * location
             * endpoint
+
+
+            For elements of type 'reference' with one or more target profiles from US Core, this test will ensure that at least one of each resource type
+            associated with each US Core target profile is provided as a reference.  This test will not validate those references against their associated
+            US Core profile to reduce test complexity.
+
           )
           versions :r4
         end
@@ -218,7 +224,7 @@ module Inferno
         skip_if missing_must_support_elements.present?,
                 "Could not find #{missing_must_support_elements.join(', ')} in the #{@practitioner_role_ary&.length} provided PractitionerRole resource(s)"
         skip_if missing_must_support_references.present?,
-                "Could not find the following resource type references: #{missing_must_support_references.map { |k, v| k + ':' + v.join(',') }.join(';')}"
+                "Could not find the following resource type references:#{missing_must_support_references.map { |path, resource_types| path + ':' + resource_types.join(',') }.join(';')}"
 
         @instance.save!
       end

--- a/lib/modules/uscore_v3.1.0/us_core_practitionerrole_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_practitionerrole_sequence.rb
@@ -180,19 +180,19 @@ module Inferno
             This will look through the PractitionerRole resources found previously for the following must support elements:
 
             * code
+            * endpoint
+            * location
+            * organization
+            * practitioner
             * specialty
             * telecom
             * telecom.system
             * telecom.value
-            * practitioner
-            * organization
-            * location
-            * endpoint
 
 
-            For elements of type 'reference' with one or more target profiles from US Core, this test will ensure that at least one of each resource type
-            associated with each US Core target profile is provided as a reference.  This test will not validate those references against their associated
-            US Core profile to reduce test complexity.
+          For elements of type 'reference' with one or more target profiles from US Core, this test will ensure that at least one of each resource type
+          associated with each US Core target profile is provided as a reference.  This test will not validate those references against their associated
+          US Core profile to reduce test complexity.
 
           )
           versions :r4

--- a/lib/modules/uscore_v3.1.0/us_core_procedure_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_procedure_sequence.rb
@@ -507,6 +507,12 @@ module Inferno
             * code
             * performed[x]
             * subject
+
+
+            For elements of type 'reference' with one or more target profiles from US Core, this test will ensure that at least one of each resource type
+            associated with each US Core target profile is provided as a reference.  This test will not validate those references against their associated
+            US Core profile to reduce test complexity.
+
           )
           versions :r4
         end
@@ -537,7 +543,7 @@ module Inferno
         skip_if missing_must_support_elements.present?,
                 "Could not find #{missing_must_support_elements.join(', ')} in the #{@procedure_ary&.values&.flatten&.length} provided Procedure resource(s)"
         skip_if missing_must_support_references.present?,
-                "Could not find the following resource type references: #{missing_must_support_references.map { |k, v| k + ':' + v.join(',') }.join(';')}"
+                "Could not find the following resource type references:#{missing_must_support_references.map { |path, resource_types| path + ':' + resource_types.join(',') }.join(';')}"
 
         @instance.save!
       end

--- a/lib/modules/uscore_v3.1.0/us_core_procedure_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_procedure_sequence.rb
@@ -503,15 +503,15 @@ module Inferno
             US Core Responders SHALL be capable of populating all data elements as part of the query results as specified by the US Core Server Capability Statement.
             This will look through the Procedure resources found previously for the following must support elements:
 
-            * status
             * code
             * performed[x]
+            * status
             * subject
 
 
-            For elements of type 'reference' with one or more target profiles from US Core, this test will ensure that at least one of each resource type
-            associated with each US Core target profile is provided as a reference.  This test will not validate those references against their associated
-            US Core profile to reduce test complexity.
+          For elements of type 'reference' with one or more target profiles from US Core, this test will ensure that at least one of each resource type
+          associated with each US Core target profile is provided as a reference.  This test will not validate those references against their associated
+          US Core profile to reduce test complexity.
 
           )
           versions :r4

--- a/lib/modules/uscore_v3.1.0/us_core_procedure_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_procedure_sequence.rb
@@ -505,14 +505,26 @@ module Inferno
 
             * status
             * code
-            * subject
             * performed[x]
+            * subject
           )
           versions :r4
         end
 
         skip_if_not_found(resource_type: 'Procedure', delayed: false)
         must_supports = USCore310ProcedureSequenceDefinitions::MUST_SUPPORTS
+
+        missing_must_support_references = must_supports[:references].each_with_object({}) do |reference, missing_types_by_path|
+          missing_resource_types = reference[:resource_types].reject do |resource_type|
+            @procedure_ary&.values&.flatten&.any? do |resource|
+              value_found = resolve_element_from_path(resource, reference[:path]) do |value|
+                value.is_a?(FHIR::Reference) && value.reference.include?("#{resource_type}/")
+              end
+              value_found.present?
+            end
+          end
+          missing_types_by_path[reference[:path]] = missing_resource_types if missing_resource_types.present?
+        end
 
         missing_must_support_elements = must_supports[:elements].reject do |element|
           @procedure_ary&.values&.flatten&.any? do |resource|
@@ -524,6 +536,9 @@ module Inferno
 
         skip_if missing_must_support_elements.present?,
                 "Could not find #{missing_must_support_elements.join(', ')} in the #{@procedure_ary&.values&.flatten&.length} provided Procedure resource(s)"
+        skip_if missing_must_support_references.present?,
+                "Could not find the following resource type references: #{missing_must_support_references.map { |k, v| k + ':' + v.join(',') }.join(';')}"
+
         @instance.save!
       end
 

--- a/lib/modules/uscore_v3.1.0/us_core_provenance_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_provenance_sequence.rb
@@ -163,6 +163,12 @@ module Inferno
             * target
             * agent.who
             * agent.onBehalfOf
+
+
+            For elements of type 'reference' with one or more target profiles from US Core, this test will ensure that at least one of each resource type
+            associated with each US Core target profile is provided as a reference.  This test will not validate those references against their associated
+            US Core profile to reduce test complexity.
+
           )
           versions :r4
         end
@@ -202,7 +208,7 @@ module Inferno
         skip_if missing_must_support_elements.present?,
                 "Could not find #{missing_must_support_elements.join(', ')} in the #{@provenance_ary&.length} provided Provenance resource(s)"
         skip_if missing_must_support_references.present?,
-                "Could not find the following resource type references: #{missing_must_support_references.map { |k, v| k + ':' + v.join(',') }.join(';')}"
+                "Could not find the following resource type references:#{missing_must_support_references.map { |path, resource_types| path + ':' + resource_types.join(',') }.join(';')}"
 
         @instance.save!
       end

--- a/lib/modules/uscore_v3.1.0/us_core_provenance_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_provenance_sequence.rb
@@ -153,21 +153,21 @@ module Inferno
             US Core Responders SHALL be capable of populating all data elements as part of the query results as specified by the US Core Server Capability Statement.
             This will look through the Provenance resources found previously for the following must support elements:
 
-            * recorded
+            * Provenance.agent:ProvenanceAuthor
+            * Provenance.agent:ProvenanceTransmitter
             * agent
+            * agent.onBehalfOf
             * agent.type
             * agent.type.coding.code
             * agent.type.coding.code
-            * Provenance.agent:ProvenanceAuthor
-            * Provenance.agent:ProvenanceTransmitter
-            * target
             * agent.who
-            * agent.onBehalfOf
+            * recorded
+            * target
 
 
-            For elements of type 'reference' with one or more target profiles from US Core, this test will ensure that at least one of each resource type
-            associated with each US Core target profile is provided as a reference.  This test will not validate those references against their associated
-            US Core profile to reduce test complexity.
+          For elements of type 'reference' with one or more target profiles from US Core, this test will ensure that at least one of each resource type
+          associated with each US Core target profile is provided as a reference.  This test will not validate those references against their associated
+          US Core profile to reduce test complexity.
 
           )
           versions :r4

--- a/lib/modules/uscore_v3.1.0/us_core_pulse_oximetry_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_pulse_oximetry_sequence.rb
@@ -589,45 +589,45 @@ module Inferno
             US Core Responders SHALL be capable of populating all data elements as part of the query results as specified by the US Core Server Capability Statement.
             This will look through the Observation resources found previously for the following must support elements:
 
-            * status
+            * Observation.category:VSCat
+            * Observation.code.coding:PulseOx
+            * Observation.component:Concentration
+            * Observation.component:FlowRate
+            * Observation.value[x]:valueQuantity
             * category
             * category.coding
-            * category.coding.system
             * category.coding.code
+            * category.coding.system
             * code
             * code.coding
-            * code.coding.system
             * code.coding.code
-            * effective[x]
-            * value[x]
-            * value[x].value
-            * value[x].unit
-            * value[x].system
-            * value[x].code
-            * dataAbsentReason
+            * code.coding.system
             * component
             * component.code
             * component.code.coding.code
-            * component.value[x].system
-            * component.value[x].code
             * component.code.coding.code
-            * component.value[x]
-            * component.value[x].value
-            * component.value[x].unit
-            * component.value[x].system
-            * component.value[x].code
             * component.dataAbsentReason
-            * Observation.category:VSCat
-            * Observation.code.coding:PulseOx
-            * Observation.value[x]:valueQuantity
-            * Observation.component:FlowRate
-            * Observation.component:Concentration
+            * component.value[x]
+            * component.value[x].code
+            * component.value[x].code
+            * component.value[x].system
+            * component.value[x].system
+            * component.value[x].unit
+            * component.value[x].value
+            * dataAbsentReason
+            * effective[x]
+            * status
             * subject
+            * value[x]
+            * value[x].code
+            * value[x].system
+            * value[x].unit
+            * value[x].value
 
 
-            For elements of type 'reference' with one or more target profiles from US Core, this test will ensure that at least one of each resource type
-            associated with each US Core target profile is provided as a reference.  This test will not validate those references against their associated
-            US Core profile to reduce test complexity.
+          For elements of type 'reference' with one or more target profiles from US Core, this test will ensure that at least one of each resource type
+          associated with each US Core target profile is provided as a reference.  This test will not validate those references against their associated
+          US Core profile to reduce test complexity.
 
           )
           versions :r4

--- a/lib/modules/uscore_v3.1.0/us_core_pulse_oximetry_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_pulse_oximetry_sequence.rb
@@ -623,6 +623,12 @@ module Inferno
             * Observation.component:FlowRate
             * Observation.component:Concentration
             * subject
+
+
+            For elements of type 'reference' with one or more target profiles from US Core, this test will ensure that at least one of each resource type
+            associated with each US Core target profile is provided as a reference.  This test will not validate those references against their associated
+            US Core profile to reduce test complexity.
+
           )
           versions :r4
         end
@@ -662,7 +668,7 @@ module Inferno
         skip_if missing_must_support_elements.present?,
                 "Could not find #{missing_must_support_elements.join(', ')} in the #{@observation_ary&.values&.flatten&.length} provided Observation resource(s)"
         skip_if missing_must_support_references.present?,
-                "Could not find the following resource type references: #{missing_must_support_references.map { |k, v| k + ':' + v.join(',') }.join(';')}"
+                "Could not find the following resource type references:#{missing_must_support_references.map { |path, resource_types| path + ':' + resource_types.join(',') }.join(';')}"
 
         @instance.save!
       end

--- a/lib/modules/uscore_v3.1.0/us_core_pulse_oximetry_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_pulse_oximetry_sequence.rb
@@ -598,7 +598,6 @@ module Inferno
             * code.coding
             * code.coding.system
             * code.coding.code
-            * subject
             * effective[x]
             * value[x]
             * value[x].value
@@ -623,6 +622,7 @@ module Inferno
             * Observation.value[x]:valueQuantity
             * Observation.component:FlowRate
             * Observation.component:Concentration
+            * subject
           )
           versions :r4
         end
@@ -637,6 +637,18 @@ module Inferno
           end
         end
 
+        missing_must_support_references = must_supports[:references].each_with_object({}) do |reference, missing_types_by_path|
+          missing_resource_types = reference[:resource_types].reject do |resource_type|
+            @observation_ary&.values&.flatten&.any? do |resource|
+              value_found = resolve_element_from_path(resource, reference[:path]) do |value|
+                value.is_a?(FHIR::Reference) && value.reference.include?("#{resource_type}/")
+              end
+              value_found.present?
+            end
+          end
+          missing_types_by_path[reference[:path]] = missing_resource_types if missing_resource_types.present?
+        end
+
         missing_must_support_elements = must_supports[:elements].reject do |element|
           @observation_ary&.values&.flatten&.any? do |resource|
             value_found = resolve_element_from_path(resource, element[:path]) { |value| element[:fixed_value].blank? || value == element[:fixed_value] }
@@ -649,6 +661,9 @@ module Inferno
 
         skip_if missing_must_support_elements.present?,
                 "Could not find #{missing_must_support_elements.join(', ')} in the #{@observation_ary&.values&.flatten&.length} provided Observation resource(s)"
+        skip_if missing_must_support_references.present?,
+                "Could not find the following resource type references: #{missing_must_support_references.map { |k, v| k + ':' + v.join(',') }.join(';')}"
+
         @instance.save!
       end
 

--- a/lib/modules/uscore_v3.1.0/us_core_smokingstatus_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_smokingstatus_sequence.rb
@@ -392,16 +392,16 @@ module Inferno
             US Core Responders SHALL be capable of populating all data elements as part of the query results as specified by the US Core Server Capability Statement.
             This will look through the Observation resources found previously for the following must support elements:
 
-            * status
+            * Observation.value[x]:valueCodeableConcept
             * code
             * issued
-            * Observation.value[x]:valueCodeableConcept
+            * status
             * subject
 
 
-            For elements of type 'reference' with one or more target profiles from US Core, this test will ensure that at least one of each resource type
-            associated with each US Core target profile is provided as a reference.  This test will not validate those references against their associated
-            US Core profile to reduce test complexity.
+          For elements of type 'reference' with one or more target profiles from US Core, this test will ensure that at least one of each resource type
+          associated with each US Core target profile is provided as a reference.  This test will not validate those references against their associated
+          US Core profile to reduce test complexity.
 
           )
           versions :r4

--- a/lib/modules/uscore_v3.1.0/us_core_smokingstatus_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_smokingstatus_sequence.rb
@@ -397,6 +397,12 @@ module Inferno
             * issued
             * Observation.value[x]:valueCodeableConcept
             * subject
+
+
+            For elements of type 'reference' with one or more target profiles from US Core, this test will ensure that at least one of each resource type
+            associated with each US Core target profile is provided as a reference.  This test will not validate those references against their associated
+            US Core profile to reduce test complexity.
+
           )
           versions :r4
         end
@@ -436,7 +442,7 @@ module Inferno
         skip_if missing_must_support_elements.present?,
                 "Could not find #{missing_must_support_elements.join(', ')} in the #{@observation_ary&.values&.flatten&.length} provided Observation resource(s)"
         skip_if missing_must_support_references.present?,
-                "Could not find the following resource type references: #{missing_must_support_references.map { |k, v| k + ':' + v.join(',') }.join(';')}"
+                "Could not find the following resource type references:#{missing_must_support_references.map { |path, resource_types| path + ':' + resource_types.join(',') }.join(';')}"
 
         @instance.save!
       end

--- a/lib/modules/uscore_v3.1.0/us_core_smokingstatus_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_smokingstatus_sequence.rb
@@ -394,9 +394,9 @@ module Inferno
 
             * status
             * code
-            * subject
             * issued
             * Observation.value[x]:valueCodeableConcept
+            * subject
           )
           versions :r4
         end
@@ -411,6 +411,18 @@ module Inferno
           end
         end
 
+        missing_must_support_references = must_supports[:references].each_with_object({}) do |reference, missing_types_by_path|
+          missing_resource_types = reference[:resource_types].reject do |resource_type|
+            @observation_ary&.values&.flatten&.any? do |resource|
+              value_found = resolve_element_from_path(resource, reference[:path]) do |value|
+                value.is_a?(FHIR::Reference) && value.reference.include?("#{resource_type}/")
+              end
+              value_found.present?
+            end
+          end
+          missing_types_by_path[reference[:path]] = missing_resource_types if missing_resource_types.present?
+        end
+
         missing_must_support_elements = must_supports[:elements].reject do |element|
           @observation_ary&.values&.flatten&.any? do |resource|
             value_found = resolve_element_from_path(resource, element[:path]) { |value| element[:fixed_value].blank? || value == element[:fixed_value] }
@@ -423,6 +435,9 @@ module Inferno
 
         skip_if missing_must_support_elements.present?,
                 "Could not find #{missing_must_support_elements.join(', ')} in the #{@observation_ary&.values&.flatten&.length} provided Observation resource(s)"
+        skip_if missing_must_support_references.present?,
+                "Could not find the following resource type references: #{missing_must_support_references.map { |k, v| k + ':' + v.join(',') }.join(';')}"
+
         @instance.save!
       end
 


### PR DESCRIPTION
This PR makes it so that we now check to see all us core reference types in reference elements that are "must support".  This means that if reference element can be either reference to a us core patient or us core practitioner, then we expect to see both reference types from the resources returned in the search. 

To note, medicationrequest.reported can either be a boolean or a reference. Before, we were only checking if either one was present. Now, it is expecting to see a reportedReference in there. 

**Submitter:**
- [X] This pull request describes why these changes were made
- [X] Internal ticket for this PR: https://oncprojectracking.healthit.gov/support/browse/FI-971
- [X] Internal ticket links to this PR
- [X] Internal ticket is properly labeled (Community/Program)
- [X] Internal ticket has a justification for its Community/Program label
- [X] Code diff has been reviewed for extraneous/missing code
- [X] Tests are included and test edge cases
- [X] Tests/code quality metrics have been run locally and pass


**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
