### PR TITLE
added preset values for bulk data fields

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -108,3 +108,8 @@ presets:
     onc_sl_client_secret: SAMPLE_CONFIDENTIAL_CLIENT_SECRET
     onc_public_client_id: SAMPLE_PUBLIC_CLIENT_ID
     patient_ids: "76,185"
+    bulk_url:  http://inferno.healthit.gov/bulk-data-server/eyJlcnIiOiIiLCJwYWdlIjoxMDAwMCwiZHVyIjoxMCwidGx0IjoxNSwibSI6MSwic3R1Ijo0fQ/fhir
+    bulk_token_endpoint: http://inferno.healthit.gov/bulk-data-server/auth/token  
+    bulk_client_id: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6InJlZ2lzdHJhdGlvbi10b2tlbiJ9.eyJqd2tzX3VybCI6Imh0dHBzOi8vaW5mZXJuby5oZWFsdGhpdC5nb3YvaW5mZXJuby8ud2VsbC1rbm93bi9qd2tzLmpzb24iLCJhY2Nlc3NUb2tlbnNFeHBpcmVJbiI6MTUsImlhdCI6MTU5OTE1NzgyMX0.-wulnE05BlY_Zcm5iP77Meqxr6iNiYxBsOADB5CGE8I
+    bulk_scope: system/*.read
+    group_id: 3d7d2344-ca49-40ac-9e1f-88b40fff3bd9


### PR DESCRIPTION
Added preset values so that if the inferno reference server preset option is used, fields in the  Multi-Patient Api are automatically populated

Pull requests into Inferno require the following items to be completed. Submitter and reviewer 
should check the relevant check boxes when the associated item is done. For items that are not 
applicable, note it's not applicable ("N/A") and check the box. For example, external Pull 
Requests do not require ticket links.

**Submitter:**
- [ ] This pull request describes why these changes were made
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Internal ticket is properly labeled (Community/Program)
- [ ] Internal ticket has a justification for its Community/Program label
- [ ] Code diff has been reviewed for extraneous/missing code
- [ ] Tests are included and test edge cases
- [ ] Tests/code quality metrics have been run locally and pass


**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
