### PR TITLE
Fix http(s) on bulk data server preset.

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -108,8 +108,8 @@ presets:
     onc_sl_client_secret: SAMPLE_CONFIDENTIAL_CLIENT_SECRET
     onc_public_client_id: SAMPLE_PUBLIC_CLIENT_ID
     patient_ids: "76,185"
-    bulk_url:  http://inferno.healthit.gov/bulk-data-server/eyJlcnIiOiIiLCJwYWdlIjoxMDAwMCwiZHVyIjoxMCwidGx0IjoxNSwibSI6MSwic3R1Ijo0fQ/fhir
-    bulk_token_endpoint: http://inferno.healthit.gov/bulk-data-server/auth/token  
+    bulk_url:  https://inferno.healthit.gov/bulk-data-server/eyJlcnIiOiIiLCJwYWdlIjoxMDAwMCwiZHVyIjoxMCwidGx0IjoxNSwibSI6MSwic3R1Ijo0fQ/fhir
+    bulk_token_endpoint: https://inferno.healthit.gov/bulk-data-server/auth/token
     bulk_client_id: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6InJlZ2lzdHJhdGlvbi10b2tlbiJ9.eyJqd2tzX3VybCI6Imh0dHBzOi8vaW5mZXJuby5oZWFsdGhpdC5nb3YvaW5mZXJuby8ud2VsbC1rbm93bi9qd2tzLmpzb24iLCJhY2Nlc3NUb2tlbnNFeHBpcmVJbiI6MTUsImlhdCI6MTU5OTE1NzgyMX0.-wulnE05BlY_Zcm5iP77Meqxr6iNiYxBsOADB5CGE8I
     bulk_scope: system/*.read
     group_id: 3d7d2344-ca49-40ac-9e1f-88b40fff3bd9


### PR DESCRIPTION
Minor fix on preset to point to the http(s) version of inferno.healthit.gov for the bulk data server.