### PR TITLE
Move values_found to inside the patients loop, so we get at least one patient with 2 status values

### DIFF
--- a/generator/uscore/uscore_generator.rb
+++ b/generator/uscore/uscore_generator.rb
@@ -1099,9 +1099,9 @@ module Inferno
           #{skip_if_search_not_supported_code(sequence, search_parameters)}
           @#{sequence[:resource].underscore}_ary = {}
           @resources_found = false
-          #{'values_found = 0' if find_two_values}
           #{values_variable_name} = [#{search_param[:values].map { |val| "'#{val}'" }.join(', ')}]
           patient_ids.each do |patient|
+            #{'values_found = 0' if find_two_values}
             @#{sequence[:resource].underscore}_ary[patient] = []
             #{values_variable_name}.each do |val|
               search_params = { 'patient': patient, '#{search_param[:name]}': val }

--- a/lib/modules/uscore_v3.1.0/bodyheight_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/bodyheight_sequence.rb
@@ -173,7 +173,6 @@ module Inferno
         skip_if_known_search_not_supported('Observation', ['patient', 'code'])
         @observation_ary = {}
         @resources_found = false
-
         code_val = ['8302-2']
         patient_ids.each do |patient|
           @observation_ary[patient] = []

--- a/lib/modules/uscore_v3.1.0/bodytemp_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/bodytemp_sequence.rb
@@ -173,7 +173,6 @@ module Inferno
         skip_if_known_search_not_supported('Observation', ['patient', 'code'])
         @observation_ary = {}
         @resources_found = false
-
         code_val = ['8310-5']
         patient_ids.each do |patient|
           @observation_ary[patient] = []

--- a/lib/modules/uscore_v3.1.0/bodyweight_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/bodyweight_sequence.rb
@@ -173,7 +173,6 @@ module Inferno
         skip_if_known_search_not_supported('Observation', ['patient', 'code'])
         @observation_ary = {}
         @resources_found = false
-
         code_val = ['29463-7']
         patient_ids.each do |patient|
           @observation_ary[patient] = []

--- a/lib/modules/uscore_v3.1.0/bp_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/bp_sequence.rb
@@ -173,7 +173,6 @@ module Inferno
         skip_if_known_search_not_supported('Observation', ['patient', 'code'])
         @observation_ary = {}
         @resources_found = false
-
         code_val = ['85354-9']
         patient_ids.each do |patient|
           @observation_ary[patient] = []

--- a/lib/modules/uscore_v3.1.0/headcircum_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/headcircum_sequence.rb
@@ -173,7 +173,6 @@ module Inferno
         skip_if_known_search_not_supported('Observation', ['patient', 'code'])
         @observation_ary = {}
         @resources_found = false
-
         code_val = ['9843-4']
         patient_ids.each do |patient|
           @observation_ary[patient] = []

--- a/lib/modules/uscore_v3.1.0/heartrate_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/heartrate_sequence.rb
@@ -173,7 +173,6 @@ module Inferno
         skip_if_known_search_not_supported('Observation', ['patient', 'code'])
         @observation_ary = {}
         @resources_found = false
-
         code_val = ['8867-4']
         patient_ids.each do |patient|
           @observation_ary[patient] = []

--- a/lib/modules/uscore_v3.1.0/pediatric_bmi_for_age_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/pediatric_bmi_for_age_sequence.rb
@@ -173,7 +173,6 @@ module Inferno
         skip_if_known_search_not_supported('Observation', ['patient', 'code'])
         @observation_ary = {}
         @resources_found = false
-
         code_val = ['59576-9']
         patient_ids.each do |patient|
           @observation_ary[patient] = []

--- a/lib/modules/uscore_v3.1.0/pediatric_weight_for_height_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/pediatric_weight_for_height_sequence.rb
@@ -173,7 +173,6 @@ module Inferno
         skip_if_known_search_not_supported('Observation', ['patient', 'code'])
         @observation_ary = {}
         @resources_found = false
-
         code_val = ['77606-2']
         patient_ids.each do |patient|
           @observation_ary[patient] = []

--- a/lib/modules/uscore_v3.1.0/resprate_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/resprate_sequence.rb
@@ -173,7 +173,6 @@ module Inferno
         skip_if_known_search_not_supported('Observation', ['patient', 'code'])
         @observation_ary = {}
         @resources_found = false
-
         code_val = ['9279-1']
         patient_ids.each do |patient|
           @observation_ary[patient] = []

--- a/lib/modules/uscore_v3.1.0/us_core_careplan_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_careplan_sequence.rb
@@ -158,7 +158,6 @@ module Inferno
         skip_if_known_search_not_supported('CarePlan', ['patient', 'category'])
         @care_plan_ary = {}
         @resources_found = false
-
         category_val = ['assess-plan']
         patient_ids.each do |patient|
           @care_plan_ary[patient] = []

--- a/lib/modules/uscore_v3.1.0/us_core_careteam_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_careteam_sequence.rb
@@ -140,9 +140,9 @@ module Inferno
         skip_if_known_search_not_supported('CareTeam', ['patient', 'status'])
         @care_team_ary = {}
         @resources_found = false
-        values_found = 0
         status_val = ['proposed', 'active', 'suspended', 'inactive', 'entered-in-error']
         patient_ids.each do |patient|
+          values_found = 0
           @care_team_ary[patient] = []
           status_val.each do |val|
             search_params = { 'patient': patient, 'status': val }

--- a/lib/modules/uscore_v3.1.0/us_core_diagnosticreport_lab_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_diagnosticreport_lab_sequence.rb
@@ -176,7 +176,6 @@ module Inferno
         skip_if_known_search_not_supported('DiagnosticReport', ['patient', 'category'])
         @diagnostic_report_ary = {}
         @resources_found = false
-
         category_val = ['LAB']
         patient_ids.each do |patient|
           @diagnostic_report_ary[patient] = []

--- a/lib/modules/uscore_v3.1.0/us_core_diagnosticreport_note_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_diagnosticreport_note_sequence.rb
@@ -176,7 +176,6 @@ module Inferno
         skip_if_known_search_not_supported('DiagnosticReport', ['patient', 'category'])
         @diagnostic_report_ary = {}
         @resources_found = false
-
         category_val = ['LP29684-5', 'LP29708-2', 'LP7839-6']
         patient_ids.each do |patient|
           @diagnostic_report_ary[patient] = []

--- a/lib/modules/uscore_v3.1.0/us_core_medicationrequest_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_medicationrequest_sequence.rb
@@ -193,7 +193,6 @@ module Inferno
         skip_if_known_search_not_supported('MedicationRequest', ['patient', 'intent'])
         @medication_request_ary = {}
         @resources_found = false
-
         intent_val = ['proposal', 'plan', 'order', 'original-order', 'reflex-order', 'filler-order', 'instance-order', 'option']
         patient_ids.each do |patient|
           @medication_request_ary[patient] = []

--- a/lib/modules/uscore_v3.1.0/us_core_observation_lab_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_observation_lab_sequence.rb
@@ -173,7 +173,6 @@ module Inferno
         skip_if_known_search_not_supported('Observation', ['patient', 'category'])
         @observation_ary = {}
         @resources_found = false
-
         category_val = ['laboratory']
         patient_ids.each do |patient|
           @observation_ary[patient] = []

--- a/lib/modules/uscore_v3.1.0/us_core_pulse_oximetry_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_pulse_oximetry_sequence.rb
@@ -173,7 +173,6 @@ module Inferno
         skip_if_known_search_not_supported('Observation', ['patient', 'code'])
         @observation_ary = {}
         @resources_found = false
-
         code_val = ['2708-6', '59408-5']
         patient_ids.each do |patient|
           @observation_ary[patient] = []

--- a/lib/modules/uscore_v3.1.0/us_core_smokingstatus_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_smokingstatus_sequence.rb
@@ -177,7 +177,6 @@ module Inferno
         skip_if_known_search_not_supported('Observation', ['patient', 'code'])
         @observation_ary = {}
         @resources_found = false
-
         code_val = ['72166-2']
         patient_ids.each do |patient|
           @observation_ary[patient] = []


### PR DESCRIPTION
This PR moves the `values_found` counter in the US Core search tests into the patient loop, so we look for at least two statuses for each resource type for each patient. This is needed to allow for the multipleOr tests that occur later on in the test suites.

Pull requests into Inferno require the following items to be completed. Submitter and reviewer 
should check the relevant check boxes when the associated item is done. For items that are not 
applicable, note it's not applicable ("N/A") and check the box. For example, external Pull 
Requests do not require ticket links.

**Submitter:**
- [ ] This pull request describes why these changes were made
- [ ] Internal ticket for this PR:
- [ ] Internal ticket links to this PR
- [ ] Internal ticket is properly labeled (Community/Program)
- [ ] Internal ticket has a justification for its Community/Program label
- [ ] Code diff has been reviewed for extraneous/missing code
- [ ] Tests are included and test edge cases
- [ ] Tests/code quality metrics have been run locally and pass


**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
