### PR TITLE
FI-996: Check resolved reference types

### DIFF
--- a/lib/app/sequence_base.rb
+++ b/lib/app/sequence_base.rb
@@ -30,6 +30,8 @@ module Inferno
       include SearchValidationUtil
       include Inferno::WebDriver
 
+      class InvalidReferenceResource < StandardError; end
+
       @@test_index = 0
 
       @@group = {}
@@ -708,10 +710,17 @@ module Inferno
                 next
               end
             end
-            value.read
+            reference = value.reference
+            reference_type = value.resource_type
+            resource = value.read
+
+            raise InvalidReferenceResource if resource.resourceType != reference_type
+
             resolved_references.add(value.reference)
           rescue ClientException => e
             problems << "#{path} did not resolve: #{e}"
+          rescue InvalidReferenceResource
+            problems << "Expected #{reference} to refer to a #{reference_type} resource, but found a #{resource.resourceType} resource."
           end
         end
 

--- a/lib/modules/argonaut/test/argonaut_careteam_sequence_test.rb
+++ b/lib/modules/argonaut/test/argonaut_careteam_sequence_test.rb
@@ -23,6 +23,7 @@ class CareTeamSequenceTest < MiniTest::Test
     @patient_id = @patient_id.split('/')[-1] if @patient_id.include?('/')
 
     @patient_resource = FHIR::DSTU2::Patient.new(id: @patient_id)
+    @practitioner_resource = FHIR::DSTU2::Practitioner.new(id: 432)
 
     # Assume we already have a patient
     @instance.resource_references << Inferno::Models::ResourceReference.new(
@@ -93,7 +94,7 @@ class CareTeamSequenceTest < MiniTest::Test
     stub_request(:get, %r{example.com/Practitioner/1})
       .with(headers: @extended_request_headers)
       .to_return(status: 200,
-                 body: @patient_resource.to_json,
+                 body: @practitioner_resource.to_json,
                  headers: { content_type: 'application/json+fhir; charset=UTF-8' })
   end
 

--- a/lib/modules/argonaut/test/argonaut_diagnostic_report_sequence_test.rb
+++ b/lib/modules/argonaut/test/argonaut_diagnostic_report_sequence_test.rb
@@ -104,7 +104,7 @@ class DiagnosticReportTest < MiniTest::Test
               'Authorization' => "Bearer #{@instance.token}"
             })
       .to_return(status: 200,
-                 body: @patient_resource.to_json,
+                 body: @practitioner_resource.to_json,
                  headers: { content_type: 'application/json+fhir; charset=UTF-8' })
     stub_request(:get, %r{example.com/Encounter/})
       .with(headers: {


### PR DESCRIPTION
This branch checks that the correct resource type is returned when resolving a reference.

**Submitter:**
- [x] This pull request describes why these changes were made
- [x] Internal ticket links to this PR
- [x] Internal ticket is properly labeled (Community/Program)
- [x] Internal ticket has a justification for its Community/Program label
- [x] Code diff has been reviewed for extraneous/missing code
- [ ] Tests are included and test edge cases
- [x] Tests/code quality metrics have been run locally and pass


**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
