### PR TITLE
FI-984: Move fhir-validation to use the fhir-validator-service v0.1.0 tag

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
         source: "./resources/terminology/validators"
         target: "/var/www/inferno/resources/terminology/validators"
   validator_service:
-    image: infernocommunity/fhir-validator-wrapper
+    image: infernocommunity/fhir-validator-service:v0.1.0
     environment:
       DISABLE_TX: 'true'
   nginx_server:


### PR DESCRIPTION
This PR pins inferno-program's validator to a specific version of fhir-validator-service, so we can begin the deprecation process for fhir-validator-wrapper. This version is the same as what is currently in fhir-validator-wrapper, so this should result in no change in functionality.

Pull requests into Inferno require the following items to be completed. Submitter and reviewer 
should check the relevant check boxes when the associated item is done. For items that are not 
applicable, note it's not applicable ("N/A") and check the box. For example, external Pull 
Requests do not require ticket links.

**Submitter:**
- [x] This pull request describes why these changes were made
- [x] Internal ticket for this PR: FI-984
- [x] Internal ticket links to this PR
- [x] Internal ticket is properly labeled (Community/Program)
- [x] Internal ticket has a justification for its Community/Program label
- [x] Code diff has been reviewed for extraneous/missing code
- [x] Tests are included and test edge cases
- [x] Tests/code quality metrics have been run locally and pass


**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
