### PR TITLE
FI - 1041 don't check for other component.value[x] must supports in pulse oximetry

### DIFF
--- a/generator/uscore/metadata_extractor.rb
+++ b/generator/uscore/metadata_extractor.rb
@@ -557,6 +557,12 @@ module Inferno
             set_first_search(sequence, ['patient', 'category'])
           end
 
+        pulse_ox_sequence = metadata[:sequences].find { |sequence| sequence[:profile] == 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-pulse-oximetry' }
+        pulse_ox_sequence[:must_supports][:elements].delete_if do |element|
+          path = element[:path]
+          (path.start_with? 'component.value') && (!path.include? '[x]') && (path != 'component.valueQuantity')
+        end
+
         metadata
       end
 

--- a/generator/uscore/metadata_extractor.rb
+++ b/generator/uscore/metadata_extractor.rb
@@ -366,6 +366,7 @@ module Inferno
             sequence[:must_supports][:elements] << must_support_element
           end
         end
+        sequence[:must_supports][:elements].uniq!
       end
 
       def add_mandatory_elements(profile_definition, sequence)

--- a/lib/modules/uscore_v3.1.0/profile_definitions/us_core_pulse_oximetry_definitions.rb
+++ b/lib/modules/uscore_v3.1.0/profile_definitions/us_core_pulse_oximetry_definitions.rb
@@ -156,12 +156,6 @@ module Inferno
             fixed_value: '3151-8'
           },
           {
-            path: 'component.valueQuantity'
-          },
-          {
-            path: 'component.value'
-          },
-          {
             path: 'component.value.system',
             fixed_value: 'http://unitsofmeasure.org'
           },
@@ -174,20 +168,10 @@ module Inferno
             fixed_value: '3150-0'
           },
           {
-            path: 'component.valueQuantity'
-          },
-          {
-            path: 'component.value'
-          },
-          {
             path: 'component.value.value'
           },
           {
             path: 'component.value.unit'
-          },
-          {
-            path: 'component.value.system',
-            fixed_value: 'http://unitsofmeasure.org'
           },
           {
             path: 'component.value.code',

--- a/lib/modules/uscore_v3.1.0/profile_definitions/us_core_pulse_oximetry_definitions.rb
+++ b/lib/modules/uscore_v3.1.0/profile_definitions/us_core_pulse_oximetry_definitions.rb
@@ -149,36 +149,6 @@ module Inferno
             path: 'component.valueQuantity'
           },
           {
-            path: 'component.valueCodeableConcept'
-          },
-          {
-            path: 'component.valueString'
-          },
-          {
-            path: 'component.valueBoolean'
-          },
-          {
-            path: 'component.valueInteger'
-          },
-          {
-            path: 'component.valueRange'
-          },
-          {
-            path: 'component.valueRatio'
-          },
-          {
-            path: 'component.valueSampledData'
-          },
-          {
-            path: 'component.valueTime'
-          },
-          {
-            path: 'component.valueDateTime'
-          },
-          {
-            path: 'component.valuePeriod'
-          },
-          {
             path: 'component.value'
           },
           {

--- a/lib/modules/uscore_v3.1.0/us_core_pulse_oximetry_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_pulse_oximetry_sequence.rb
@@ -608,14 +608,9 @@ module Inferno
             * component.code.coding.code
             * component.dataAbsentReason
             * component.valueQuantity
-            * component.valueQuantity
-            * component.valueQuantity
-            * component.value[x]
-            * component.value[x]
             * component.value[x]
             * component.value[x].code
             * component.value[x].code
-            * component.value[x].system
             * component.value[x].system
             * component.value[x].unit
             * component.value[x].value

--- a/lib/modules/uscore_v3.1.0/us_core_pulse_oximetry_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_pulse_oximetry_sequence.rb
@@ -607,19 +607,9 @@ module Inferno
             * component.code.coding.code
             * component.code.coding.code
             * component.dataAbsentReason
-            * component.valueBoolean
-            * component.valueCodeableConcept
-            * component.valueDateTime
-            * component.valueInteger
-            * component.valuePeriod
             * component.valueQuantity
             * component.valueQuantity
             * component.valueQuantity
-            * component.valueRange
-            * component.valueRatio
-            * component.valueSampledData
-            * component.valueString
-            * component.valueTime
             * component.value[x]
             * component.value[x]
             * component.value[x]


### PR DESCRIPTION
This just removes the other Component.value[x] must supports besides valueQuantity. To note, there needs to be work done on must support sub-elements of slices. But this requires a pretty major change and will require restructuring of how we're currently handling must supports.

**Submitter:**
- [X] This pull request describes why these changes were made
- [X] Internal ticket for this PR: https://oncprojectracking.healthit.gov/support/browse/FI-1041
- [X] Internal ticket links to this PR
- [X] Internal ticket is properly labeled (Community/Program)
- [X] Internal ticket has a justification for its Community/Program label
- [X] Code diff has been reviewed for extraneous/missing code
- [X] Tests are included and test edge cases
- [X] Tests/code quality metrics have been run locally and pass


**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
