### PR TITLE
Add a note to the readme about .env variables and quotes

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ bundle exec rackup -p 3000
 -->
 
 ### Terminology Support
+
 In order to validate terminologies, Inferno must be loaded with files generated
 from the Unified Medical Language System (UMLS).  The UMLS is distributed by the
 National Library of Medicine (NLM) and requires an account to access.
@@ -102,6 +103,7 @@ a Dockerfile and docker-compose file that will create the validators in a
 self-contained environment.
 
 Prerequisites:
+
 * A UMLS account
 * A working Docker toolchain, which has been assigned at least 10GB of RAM (The Metathesaurus step requires 8GB of RAM for the Java process)
   * Note: the Docker terminology process will not run unless Docker has access to at least 10GB of RAM.
@@ -110,52 +112,66 @@ Prerequisites:
 * A copy of the Inferno repository, which contains the required Docker and Ruby files
 
 You can prebuild the terminology docker container by running the following command:
+
 ```sh
 docker-compose -f terminology_compose.yml build
 ```
-Once the container is built, you will have to add your UMLS username and passwords to a file named `.env` at the root of the inferno project. The file should look like this:
+
+Once the container is built, you will have to add your UMLS username and passwords to a file named `.env` at the root of the inferno project. The file should look like this (replacing `your_username` and `your_password` with your UMLS username/password, respectively):
+
 ```sh
-UMLS_USERNAME=<your UMLS username>
-UMLS_PASSWORD=<your UMLS password>
+UMLS_USERNAME=your_username
+UMLS_PASSWORD=your_password
 ```
+
+Note that _anything_ after the equals sign in `.env` will be considered part of the variable, so don't wrap your username/password in quotation marks (unless they're actually part of your username).
+
 Once that file exists, you can run the terminology creation task by using the following commands, in order:
+
 ```sh
 docker-compose -f terminology_compose.yml up
 ```
+
 This will run the terminology creation steps in order, using the UMLS credentials supplied in `.env`. These tasks may take several hours. If the creation task is cancelled in progress and restarted, it will restart after the last _completed_ step. Intermediate files are saved to `tmp/terminology` in the Inferno repository that the Docker Compose job is run from, and the validators are saved to `resources/terminology/validators/bloom`, where Inferno can use them for validation.
 
 #### Cleanup
+
 Once the terminology building is done, the `.env` file should be deleted to remove the UMLS username and password from the system.
 
 Optionally, the files and folders in `tmp/terminology/` can be deleted after terminology building to free up space, as they are several GB in size. If you intend to re-run the terminology builder, these files can be left to speed up building in the future, since the builder will be able to skip the initial download/preprocessing steps.
 
 #### Spot Checking the Terminology Files
+
 You can use the following `rake` command to spot check the validators to make sure they are installed correctly:
 
 ```ruby
 bundle exec rake "terminology:check_code[91935009,http://snomed.info/sct, http://hl7.org/fhir/us/core/ValueSet/us-core-allergy-substance]"
 ```
+
 Should return:
 
 ```shell
 X http://snomed.info/sct|91935009  is not in http://hl7.org/fhir/us/core/ValueSet/us-core-allergy-substance
 ```
+
 And
+
 ```ruby
-be rake "terminology:check_code[91935009,http://snomed.info/sct]"
+bundle exec rake "terminology:check_code[91935009,http://snomed.info/sct]"
 ```
+
 Should return:
 
 ```shell
 ✓ http://snomed.info/sct|91935009  is in http://snomed.info/sct
 ```
 
-
 #### Manual build instructions
 
 If this Docker-based method does not work based on your architecture, manual setup and creation of the terminology validators is documented [on this wiki page](https://github.com/onc-healthit/inferno/wiki/Installing-Terminology-Validators#building-the-validators-without-docker)
 
 #### UMLS Data Sources
+
 Some material in the UMLS Metathesaurus is from copyrighted sources of the respective copyright holders.
 Users of the UMLS Metathesaurus are solely responsible for compliance with any copyright, patent or trademark
 restrictions and are referred to the copyright, patent or trademark notices appearing in the original sources,


### PR DESCRIPTION
A recent Github issue brought to our attention that variables used in `.env` behave differently than expected with respect to quotation marks. According to https://docs.docker.com/compose/env-file/ (last bullet under `Syntax Rules`), quotation marks surrounding a variable in `.env` will be considered part of the variable, which will mess up terminology building. This PR adds a note to the README letting people know, and also does some Markdown Lint/other cleanups in the Terminology section.

Pull requests into Inferno require the following items to be completed. Submitter and reviewer 
should check the relevant check boxes when the associated item is done. For items that are not 
applicable, note it's not applicable ("N/A") and check the box. For example, external Pull 
Requests do not require ticket links.

**Submitter:**
- [x] This pull request describes why these changes were made
- [x] Internal ticket for this PR: N/A
- [x] Internal ticket links to this PR N/A
- [x] Internal ticket is properly labeled (Community/Program) N/A
- [x] Internal ticket has a justification for its Community/Program label N/A
- [x] Code diff has been reviewed for extraneous/missing code
- [x] Tests are included and test edge cases N/A
- [x] Tests/code quality metrics have been run locally and pass N/A


**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
