### PR TITLE
revert must support choice type changes

### DIFF
--- a/generator/uscore/metadata_extractor.rb
+++ b/generator/uscore/metadata_extractor.rb
@@ -341,13 +341,6 @@ module Inferno
               resource_types: resource_types
             }
             sequence[:must_supports][:references] << must_support_element
-          elsif element['path'].end_with? '[x]'
-            element['type'].each do |type|
-              path = element['path'].gsub(sequence[:resource] + '.', '').gsub('[x]', '') + type['code'].upcase_first
-              must_support_element = { path: path }
-              sequence[:must_supports][:elements] << must_support_element
-            end
-            sequence[:must_supports][:elements] << { path: element['path'].gsub(sequence[:resource] + '.', '') }
           else
             path = element['path'].gsub(sequence[:resource] + '.', '')
             must_support_element = { path: path }
@@ -522,7 +515,7 @@ module Inferno
               end
 
               any_mandatory_elements = sequence[:mandatory_elements].any? do |element|
-                element == path || element == "#{path}[x]"
+                element == path
               end
 
               any_must_support_elements || any_must_support_slices || any_mandatory_elements

--- a/generator/uscore/metadata_extractor.rb
+++ b/generator/uscore/metadata_extractor.rb
@@ -86,7 +86,6 @@ module Inferno
           must_supports: {
             extensions: [],
             slices: [],
-            references: [],
             elements: []
           },
           mandatory_elements: [],
@@ -330,17 +329,6 @@ module Inferno
               end
             end
             sequence[:must_supports][:slices] << must_support_element
-          elsif element['type'].any? { |type| type['code'] == 'Reference' }
-            reference_type = element['type'].find { |type| type['code'] == 'Reference' }
-            profiles = reference_type['targetProfile']
-            resource_types = profiles
-              .select { |profile| resources_by_type['StructureDefinition'].find { |stdef| stdef['url'] == profile } }
-              .map { |profile| resources_by_type['StructureDefinition'].find { |stdef| stdef['url'] == profile }['type'] }
-            must_support_element = {
-              path: element['path'].gsub(sequence[:resource] + '.', ''),
-              resource_types: resource_types
-            }
-            sequence[:must_supports][:references] << must_support_element
           else
             path = element['path'].gsub(sequence[:resource] + '.', '')
             must_support_element = { path: path }
@@ -497,7 +485,7 @@ module Inferno
           sequence[:searches].each do |search|
             search[:names_not_must_support_or_mandatory] = search[:names].reject do |name|
               path = sequence[:search_param_descriptions][name.to_sym][:path]
-              any_must_support_elements = (sequence[:must_supports][:elements] + sequence[:must_supports][:references]).any? do |element|
+              any_must_support_elements = (sequence[:must_supports][:elements]).any? do |element|
                 full_must_support_path = "#{sequence[:resource]}.#{element[:path]}"
 
                 # allow for non-choice, choice types, and _id

--- a/generator/uscore/uscore_generator.rb
+++ b/generator/uscore/uscore_generator.rb
@@ -578,13 +578,7 @@ module Inferno
       def create_must_support_test(sequence)
         must_support_list = sequence[:must_supports][:elements].map { |element| "* #{element[:path]}" } +
                             sequence[:must_supports][:extensions].map { |extension| "* #{extension[:id]}" } +
-                            sequence[:must_supports][:slices].map { |slice| "* #{slice[:name]}" } +
-                            sequence[:must_supports][:references].map { |reference| "* #{reference[:path]}" }
-
-        must_suport_reference_description = %(
-          For elements of type 'reference' with one or more target profiles from US Core, this test will ensure that at least one of each resource type
-          associated with each US Core target profile is provided as a reference.  This test will not validate those references against their associated
-          US Core profile to reduce test complexity.)
+                            sequence[:must_supports][:slices].map { |slice| "* #{slice[:name]}" }
 
         test = {
           tests_that: "All must support elements are provided in the #{sequence[:resource]} resources returned.",
@@ -596,17 +590,13 @@ module Inferno
             This will look through the #{sequence[:resource]} resources found previously for the following must support elements:
 
             #{must_support_list.sort.join("\n            ")}
-
-            #{must_suport_reference_description if sequence[:must_supports][:references].present?}
           )
         }
         must_support_extensions = sequence[:must_supports][:extensions]
-        must_support_references = sequence[:must_supports][:references]
         must_support_slices = sequence[:must_supports][:slices]
         must_support_elements = sequence[:must_supports][:elements]
 
         must_support_elements.each { |must_support| must_support[:path]&.gsub!('[x]', '')&.gsub!(/(?<!\w)class(?!\w)/, 'local_class') }
-        must_support_references.each { |must_support| must_support[:path]&.gsub!('[x]', '')&.gsub!(/(?<!\w)class(?!\w)/, 'local_class') }
         must_support_slices.each { |must_support| must_support[:path]&.gsub!('[x]', '')&.gsub!(/(?<!\w)class(?!\w)/, 'local_class') }
 
         test[:test_code] += %(
@@ -632,22 +622,6 @@ module Inferno
                 slice_found = find_slice(resource, slice[:path], slice[:discriminator])
                 slice_found.present?
               end
-            end
-          )
-        end
-
-        if must_support_references.present?
-          test[:test_code] += %(
-            missing_must_support_references = must_supports[:references].each_with_object({}) do |reference, missing_types_by_path|
-              missing_resource_types = reference[:resource_types].reject do |resource_type|
-                #{resource_array}&.any? do |resource|
-                  value_found = resolve_element_from_path(resource, reference[:path]) do |value|
-                    value.is_a?(FHIR::Reference) && value.reference.include?("\#{resource_type}/")
-                  end
-                  value_found.present?
-                end
-              end
-              missing_types_by_path[reference[:path]] = missing_resource_types if missing_resource_types.present?
             end
           )
         end
@@ -681,13 +655,6 @@ module Inferno
           test[:test_code] += %(
             skip_if missing_must_support_elements.present?,
               "Could not find \#{missing_must_support_elements.join(', ')} in the \#{#{resource_array}&.length} provided #{sequence[:resource]} resource(s)")
-
-          if must_support_references.present?
-            test[:test_code] += %(
-              skip_if missing_must_support_references.present?,
-              "Could not find the following resource type references:\#{missing_must_support_references.map{|path,resource_types| path+':'+resource_types.join(',')}.join(';')}"
-            )
-          end
         end
 
         test[:test_code] += %(

--- a/lib/modules/onc_program/bulk_data_group_validation_sequence.rb
+++ b/lib/modules/onc_program/bulk_data_group_validation_sequence.rb
@@ -237,16 +237,6 @@ module Inferno
         must_support_info[:slices].reject! do |ms_slice|
           find_slice(resource, ms_slice[:path], ms_slice[:discriminator])
         end
-
-        must_support_info[:references].each do |ms_reference|
-          ms_reference[:resource_types].reject! do |resource_type|
-            value_found = resolve_element_from_path(resource, ms_reference[:path]) do |value|
-              value.is_a?(FHIR::Reference) && value.reference.include?("#{resource_type}/")
-            end
-            value_found.present?
-          end
-        end
-        must_support_info[:references].delete_if { |ms_reference| ms_reference[:resource_types].empty? }
       end
 
       def validate_bindings(bindings, resources)
@@ -328,9 +318,6 @@ module Inferno
 
           missing_extensions_list = missing_must_supports[:extensions].map { |extension| extension[:id] }
           skip_if missing_extensions_list.present?, format(error_string, 'extensions', missing_extensions_list.join(', '))
-
-          missing_references_list = missing_must_supports[:references].map { |reference| "#{reference[:path]}: #{reference[:resource_types].join(',')}" }
-          skip_if missing_references_list.present?, format(error_string, 'reference elements', missing_references_list.join(';'))
         end
       end
 

--- a/lib/modules/onc_program/test/bulk_group_validation_sequence_test.rb
+++ b/lib/modules/onc_program/test/bulk_group_validation_sequence_test.rb
@@ -349,7 +349,6 @@ describe Inferno::Sequence::BulkDataGroupExportValidationSequence do
           must_support_info: {
             extensions: [],
             slices: [],
-            references: [],
             elements: [
               {
                 path: 'name'
@@ -377,7 +376,6 @@ describe Inferno::Sequence::BulkDataGroupExportValidationSequence do
           must_support_info: {
             extensions: [],
             slices: [],
-            references: [],
             elements: [
               {
                 path: 'name'

--- a/lib/modules/uscore_v3.1.0/bodyheight_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/bodyheight_sequence.rb
@@ -608,11 +608,6 @@ module Inferno
             * value[x].unit
             * value[x].value
 
-
-          For elements of type 'reference' with one or more target profiles from US Core, this test will ensure that at least one of each resource type
-          associated with each US Core target profile is provided as a reference.  This test will not validate those references against their associated
-          US Core profile to reduce test complexity.
-
           )
           versions :r4
         end
@@ -625,18 +620,6 @@ module Inferno
             slice_found = find_slice(resource, slice[:path], slice[:discriminator])
             slice_found.present?
           end
-        end
-
-        missing_must_support_references = must_supports[:references].each_with_object({}) do |reference, missing_types_by_path|
-          missing_resource_types = reference[:resource_types].reject do |resource_type|
-            @observation_ary&.values&.flatten&.any? do |resource|
-              value_found = resolve_element_from_path(resource, reference[:path]) do |value|
-                value.is_a?(FHIR::Reference) && value.reference.include?("#{resource_type}/")
-              end
-              value_found.present?
-            end
-          end
-          missing_types_by_path[reference[:path]] = missing_resource_types if missing_resource_types.present?
         end
 
         missing_must_support_elements = must_supports[:elements].reject do |element|
@@ -655,9 +638,6 @@ module Inferno
 
         skip_if missing_must_support_elements.present?,
                 "Could not find #{missing_must_support_elements.join(', ')} in the #{@observation_ary&.values&.flatten&.length} provided Observation resource(s)"
-        skip_if missing_must_support_references.present?,
-                "Could not find the following resource type references:#{missing_must_support_references.map { |path, resource_types| path + ':' + resource_types.join(',') }.join(';')}"
-
         @instance.save!
       end
 

--- a/lib/modules/uscore_v3.1.0/bodyheight_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/bodyheight_sequence.rb
@@ -599,12 +599,9 @@ module Inferno
             * category.coding.system
             * code
             * dataAbsentReason
-            * effectiveDateTime
-            * effectivePeriod
             * effective[x]
             * status
             * subject
-            * valueQuantity
             * value[x]
             * value[x].code
             * value[x].system

--- a/lib/modules/uscore_v3.1.0/bodytemp_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/bodytemp_sequence.rb
@@ -608,11 +608,6 @@ module Inferno
             * value[x].unit
             * value[x].value
 
-
-          For elements of type 'reference' with one or more target profiles from US Core, this test will ensure that at least one of each resource type
-          associated with each US Core target profile is provided as a reference.  This test will not validate those references against their associated
-          US Core profile to reduce test complexity.
-
           )
           versions :r4
         end
@@ -625,18 +620,6 @@ module Inferno
             slice_found = find_slice(resource, slice[:path], slice[:discriminator])
             slice_found.present?
           end
-        end
-
-        missing_must_support_references = must_supports[:references].each_with_object({}) do |reference, missing_types_by_path|
-          missing_resource_types = reference[:resource_types].reject do |resource_type|
-            @observation_ary&.values&.flatten&.any? do |resource|
-              value_found = resolve_element_from_path(resource, reference[:path]) do |value|
-                value.is_a?(FHIR::Reference) && value.reference.include?("#{resource_type}/")
-              end
-              value_found.present?
-            end
-          end
-          missing_types_by_path[reference[:path]] = missing_resource_types if missing_resource_types.present?
         end
 
         missing_must_support_elements = must_supports[:elements].reject do |element|
@@ -655,9 +638,6 @@ module Inferno
 
         skip_if missing_must_support_elements.present?,
                 "Could not find #{missing_must_support_elements.join(', ')} in the #{@observation_ary&.values&.flatten&.length} provided Observation resource(s)"
-        skip_if missing_must_support_references.present?,
-                "Could not find the following resource type references:#{missing_must_support_references.map { |path, resource_types| path + ':' + resource_types.join(',') }.join(';')}"
-
         @instance.save!
       end
 

--- a/lib/modules/uscore_v3.1.0/bodytemp_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/bodytemp_sequence.rb
@@ -599,12 +599,9 @@ module Inferno
             * category.coding.system
             * code
             * dataAbsentReason
-            * effectiveDateTime
-            * effectivePeriod
             * effective[x]
             * status
             * subject
-            * valueQuantity
             * value[x]
             * value[x].code
             * value[x].system

--- a/lib/modules/uscore_v3.1.0/bodyweight_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/bodyweight_sequence.rb
@@ -608,11 +608,6 @@ module Inferno
             * value[x].unit
             * value[x].value
 
-
-          For elements of type 'reference' with one or more target profiles from US Core, this test will ensure that at least one of each resource type
-          associated with each US Core target profile is provided as a reference.  This test will not validate those references against their associated
-          US Core profile to reduce test complexity.
-
           )
           versions :r4
         end
@@ -625,18 +620,6 @@ module Inferno
             slice_found = find_slice(resource, slice[:path], slice[:discriminator])
             slice_found.present?
           end
-        end
-
-        missing_must_support_references = must_supports[:references].each_with_object({}) do |reference, missing_types_by_path|
-          missing_resource_types = reference[:resource_types].reject do |resource_type|
-            @observation_ary&.values&.flatten&.any? do |resource|
-              value_found = resolve_element_from_path(resource, reference[:path]) do |value|
-                value.is_a?(FHIR::Reference) && value.reference.include?("#{resource_type}/")
-              end
-              value_found.present?
-            end
-          end
-          missing_types_by_path[reference[:path]] = missing_resource_types if missing_resource_types.present?
         end
 
         missing_must_support_elements = must_supports[:elements].reject do |element|
@@ -655,9 +638,6 @@ module Inferno
 
         skip_if missing_must_support_elements.present?,
                 "Could not find #{missing_must_support_elements.join(', ')} in the #{@observation_ary&.values&.flatten&.length} provided Observation resource(s)"
-        skip_if missing_must_support_references.present?,
-                "Could not find the following resource type references:#{missing_must_support_references.map { |path, resource_types| path + ':' + resource_types.join(',') }.join(';')}"
-
         @instance.save!
       end
 

--- a/lib/modules/uscore_v3.1.0/bodyweight_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/bodyweight_sequence.rb
@@ -599,12 +599,9 @@ module Inferno
             * category.coding.system
             * code
             * dataAbsentReason
-            * effectiveDateTime
-            * effectivePeriod
             * effective[x]
             * status
             * subject
-            * valueQuantity
             * value[x]
             * value[x].code
             * value[x].system

--- a/lib/modules/uscore_v3.1.0/bp_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/bp_sequence.rb
@@ -598,8 +598,6 @@ module Inferno
             * category.coding.system
             * code
             * dataAbsentReason
-            * effectiveDateTime
-            * effectivePeriod
             * effective[x]
             * status
             * subject

--- a/lib/modules/uscore_v3.1.0/bp_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/bp_sequence.rb
@@ -602,11 +602,6 @@ module Inferno
             * status
             * subject
 
-
-          For elements of type 'reference' with one or more target profiles from US Core, this test will ensure that at least one of each resource type
-          associated with each US Core target profile is provided as a reference.  This test will not validate those references against their associated
-          US Core profile to reduce test complexity.
-
           )
           versions :r4
         end
@@ -619,18 +614,6 @@ module Inferno
             slice_found = find_slice(resource, slice[:path], slice[:discriminator])
             slice_found.present?
           end
-        end
-
-        missing_must_support_references = must_supports[:references].each_with_object({}) do |reference, missing_types_by_path|
-          missing_resource_types = reference[:resource_types].reject do |resource_type|
-            @observation_ary&.values&.flatten&.any? do |resource|
-              value_found = resolve_element_from_path(resource, reference[:path]) do |value|
-                value.is_a?(FHIR::Reference) && value.reference.include?("#{resource_type}/")
-              end
-              value_found.present?
-            end
-          end
-          missing_types_by_path[reference[:path]] = missing_resource_types if missing_resource_types.present?
         end
 
         missing_must_support_elements = must_supports[:elements].reject do |element|
@@ -649,9 +632,6 @@ module Inferno
 
         skip_if missing_must_support_elements.present?,
                 "Could not find #{missing_must_support_elements.join(', ')} in the #{@observation_ary&.values&.flatten&.length} provided Observation resource(s)"
-        skip_if missing_must_support_references.present?,
-                "Could not find the following resource type references:#{missing_must_support_references.map { |path, resource_types| path + ':' + resource_types.join(',') }.join(';')}"
-
         @instance.save!
       end
 

--- a/lib/modules/uscore_v3.1.0/headcircum_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/headcircum_sequence.rb
@@ -608,11 +608,6 @@ module Inferno
             * value[x].unit
             * value[x].value
 
-
-          For elements of type 'reference' with one or more target profiles from US Core, this test will ensure that at least one of each resource type
-          associated with each US Core target profile is provided as a reference.  This test will not validate those references against their associated
-          US Core profile to reduce test complexity.
-
           )
           versions :r4
         end
@@ -625,18 +620,6 @@ module Inferno
             slice_found = find_slice(resource, slice[:path], slice[:discriminator])
             slice_found.present?
           end
-        end
-
-        missing_must_support_references = must_supports[:references].each_with_object({}) do |reference, missing_types_by_path|
-          missing_resource_types = reference[:resource_types].reject do |resource_type|
-            @observation_ary&.values&.flatten&.any? do |resource|
-              value_found = resolve_element_from_path(resource, reference[:path]) do |value|
-                value.is_a?(FHIR::Reference) && value.reference.include?("#{resource_type}/")
-              end
-              value_found.present?
-            end
-          end
-          missing_types_by_path[reference[:path]] = missing_resource_types if missing_resource_types.present?
         end
 
         missing_must_support_elements = must_supports[:elements].reject do |element|
@@ -655,9 +638,6 @@ module Inferno
 
         skip_if missing_must_support_elements.present?,
                 "Could not find #{missing_must_support_elements.join(', ')} in the #{@observation_ary&.values&.flatten&.length} provided Observation resource(s)"
-        skip_if missing_must_support_references.present?,
-                "Could not find the following resource type references:#{missing_must_support_references.map { |path, resource_types| path + ':' + resource_types.join(',') }.join(';')}"
-
         @instance.save!
       end
 

--- a/lib/modules/uscore_v3.1.0/headcircum_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/headcircum_sequence.rb
@@ -599,12 +599,9 @@ module Inferno
             * category.coding.system
             * code
             * dataAbsentReason
-            * effectiveDateTime
-            * effectivePeriod
             * effective[x]
             * status
             * subject
-            * valueQuantity
             * value[x]
             * value[x].code
             * value[x].system

--- a/lib/modules/uscore_v3.1.0/heartrate_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/heartrate_sequence.rb
@@ -608,11 +608,6 @@ module Inferno
             * value[x].unit
             * value[x].value
 
-
-          For elements of type 'reference' with one or more target profiles from US Core, this test will ensure that at least one of each resource type
-          associated with each US Core target profile is provided as a reference.  This test will not validate those references against their associated
-          US Core profile to reduce test complexity.
-
           )
           versions :r4
         end
@@ -625,18 +620,6 @@ module Inferno
             slice_found = find_slice(resource, slice[:path], slice[:discriminator])
             slice_found.present?
           end
-        end
-
-        missing_must_support_references = must_supports[:references].each_with_object({}) do |reference, missing_types_by_path|
-          missing_resource_types = reference[:resource_types].reject do |resource_type|
-            @observation_ary&.values&.flatten&.any? do |resource|
-              value_found = resolve_element_from_path(resource, reference[:path]) do |value|
-                value.is_a?(FHIR::Reference) && value.reference.include?("#{resource_type}/")
-              end
-              value_found.present?
-            end
-          end
-          missing_types_by_path[reference[:path]] = missing_resource_types if missing_resource_types.present?
         end
 
         missing_must_support_elements = must_supports[:elements].reject do |element|
@@ -655,9 +638,6 @@ module Inferno
 
         skip_if missing_must_support_elements.present?,
                 "Could not find #{missing_must_support_elements.join(', ')} in the #{@observation_ary&.values&.flatten&.length} provided Observation resource(s)"
-        skip_if missing_must_support_references.present?,
-                "Could not find the following resource type references:#{missing_must_support_references.map { |path, resource_types| path + ':' + resource_types.join(',') }.join(';')}"
-
         @instance.save!
       end
 

--- a/lib/modules/uscore_v3.1.0/heartrate_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/heartrate_sequence.rb
@@ -599,12 +599,9 @@ module Inferno
             * category.coding.system
             * code
             * dataAbsentReason
-            * effectiveDateTime
-            * effectivePeriod
             * effective[x]
             * status
             * subject
-            * valueQuantity
             * value[x]
             * value[x].code
             * value[x].system

--- a/lib/modules/uscore_v3.1.0/pediatric_bmi_for_age_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/pediatric_bmi_for_age_sequence.rb
@@ -596,12 +596,9 @@ module Inferno
             * category.coding
             * category.coding.code
             * category.coding.system
-            * effectiveDateTime
-            * effectivePeriod
             * effective[x]
             * status
             * subject
-            * valueQuantity
             * value[x]
             * value[x].code
             * value[x].system

--- a/lib/modules/uscore_v3.1.0/pediatric_bmi_for_age_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/pediatric_bmi_for_age_sequence.rb
@@ -605,11 +605,6 @@ module Inferno
             * value[x].unit
             * value[x].value
 
-
-          For elements of type 'reference' with one or more target profiles from US Core, this test will ensure that at least one of each resource type
-          associated with each US Core target profile is provided as a reference.  This test will not validate those references against their associated
-          US Core profile to reduce test complexity.
-
           )
           versions :r4
         end
@@ -622,18 +617,6 @@ module Inferno
             slice_found = find_slice(resource, slice[:path], slice[:discriminator])
             slice_found.present?
           end
-        end
-
-        missing_must_support_references = must_supports[:references].each_with_object({}) do |reference, missing_types_by_path|
-          missing_resource_types = reference[:resource_types].reject do |resource_type|
-            @observation_ary&.values&.flatten&.any? do |resource|
-              value_found = resolve_element_from_path(resource, reference[:path]) do |value|
-                value.is_a?(FHIR::Reference) && value.reference.include?("#{resource_type}/")
-              end
-              value_found.present?
-            end
-          end
-          missing_types_by_path[reference[:path]] = missing_resource_types if missing_resource_types.present?
         end
 
         missing_must_support_elements = must_supports[:elements].reject do |element|
@@ -652,9 +635,6 @@ module Inferno
 
         skip_if missing_must_support_elements.present?,
                 "Could not find #{missing_must_support_elements.join(', ')} in the #{@observation_ary&.values&.flatten&.length} provided Observation resource(s)"
-        skip_if missing_must_support_references.present?,
-                "Could not find the following resource type references:#{missing_must_support_references.map { |path, resource_types| path + ':' + resource_types.join(',') }.join(';')}"
-
         @instance.save!
       end
 

--- a/lib/modules/uscore_v3.1.0/pediatric_weight_for_height_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/pediatric_weight_for_height_sequence.rb
@@ -596,12 +596,9 @@ module Inferno
             * category.coding
             * category.coding.code
             * category.coding.system
-            * effectiveDateTime
-            * effectivePeriod
             * effective[x]
             * status
             * subject
-            * valueQuantity
             * value[x]
             * value[x].code
             * value[x].system

--- a/lib/modules/uscore_v3.1.0/pediatric_weight_for_height_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/pediatric_weight_for_height_sequence.rb
@@ -605,11 +605,6 @@ module Inferno
             * value[x].unit
             * value[x].value
 
-
-          For elements of type 'reference' with one or more target profiles from US Core, this test will ensure that at least one of each resource type
-          associated with each US Core target profile is provided as a reference.  This test will not validate those references against their associated
-          US Core profile to reduce test complexity.
-
           )
           versions :r4
         end
@@ -622,18 +617,6 @@ module Inferno
             slice_found = find_slice(resource, slice[:path], slice[:discriminator])
             slice_found.present?
           end
-        end
-
-        missing_must_support_references = must_supports[:references].each_with_object({}) do |reference, missing_types_by_path|
-          missing_resource_types = reference[:resource_types].reject do |resource_type|
-            @observation_ary&.values&.flatten&.any? do |resource|
-              value_found = resolve_element_from_path(resource, reference[:path]) do |value|
-                value.is_a?(FHIR::Reference) && value.reference.include?("#{resource_type}/")
-              end
-              value_found.present?
-            end
-          end
-          missing_types_by_path[reference[:path]] = missing_resource_types if missing_resource_types.present?
         end
 
         missing_must_support_elements = must_supports[:elements].reject do |element|
@@ -652,9 +635,6 @@ module Inferno
 
         skip_if missing_must_support_elements.present?,
                 "Could not find #{missing_must_support_elements.join(', ')} in the #{@observation_ary&.values&.flatten&.length} provided Observation resource(s)"
-        skip_if missing_must_support_references.present?,
-                "Could not find the following resource type references:#{missing_must_support_references.map { |path, resource_types| path + ':' + resource_types.join(',') }.join(';')}"
-
         @instance.save!
       end
 

--- a/lib/modules/uscore_v3.1.0/profile_definitions/bodyheight_definitions.rb
+++ b/lib/modules/uscore_v3.1.0/profile_definitions/bodyheight_definitions.rb
@@ -32,12 +32,6 @@ module Inferno
             }
           }
         ],
-        references: [
-          {
-            path: 'subject',
-            resource_types: []
-          }
-        ],
         elements: [
           {
             path: 'status'
@@ -58,6 +52,9 @@ module Inferno
           },
           {
             path: 'code'
+          },
+          {
+            path: 'subject'
           },
           {
             path: 'effective'

--- a/lib/modules/uscore_v3.1.0/profile_definitions/bodyheight_definitions.rb
+++ b/lib/modules/uscore_v3.1.0/profile_definitions/bodyheight_definitions.rb
@@ -60,16 +60,7 @@ module Inferno
             path: 'code'
           },
           {
-            path: 'effectiveDateTime'
-          },
-          {
-            path: 'effectivePeriod'
-          },
-          {
             path: 'effective'
-          },
-          {
-            path: 'valueQuantity'
           },
           {
             path: 'value'

--- a/lib/modules/uscore_v3.1.0/profile_definitions/bodytemp_definitions.rb
+++ b/lib/modules/uscore_v3.1.0/profile_definitions/bodytemp_definitions.rb
@@ -32,12 +32,6 @@ module Inferno
             }
           }
         ],
-        references: [
-          {
-            path: 'subject',
-            resource_types: []
-          }
-        ],
         elements: [
           {
             path: 'status'
@@ -58,6 +52,9 @@ module Inferno
           },
           {
             path: 'code'
+          },
+          {
+            path: 'subject'
           },
           {
             path: 'effective'

--- a/lib/modules/uscore_v3.1.0/profile_definitions/bodytemp_definitions.rb
+++ b/lib/modules/uscore_v3.1.0/profile_definitions/bodytemp_definitions.rb
@@ -60,16 +60,7 @@ module Inferno
             path: 'code'
           },
           {
-            path: 'effectiveDateTime'
-          },
-          {
-            path: 'effectivePeriod'
-          },
-          {
             path: 'effective'
-          },
-          {
-            path: 'valueQuantity'
           },
           {
             path: 'value'

--- a/lib/modules/uscore_v3.1.0/profile_definitions/bodyweight_definitions.rb
+++ b/lib/modules/uscore_v3.1.0/profile_definitions/bodyweight_definitions.rb
@@ -32,12 +32,6 @@ module Inferno
             }
           }
         ],
-        references: [
-          {
-            path: 'subject',
-            resource_types: []
-          }
-        ],
         elements: [
           {
             path: 'status'
@@ -58,6 +52,9 @@ module Inferno
           },
           {
             path: 'code'
+          },
+          {
+            path: 'subject'
           },
           {
             path: 'effective'

--- a/lib/modules/uscore_v3.1.0/profile_definitions/bodyweight_definitions.rb
+++ b/lib/modules/uscore_v3.1.0/profile_definitions/bodyweight_definitions.rb
@@ -60,16 +60,7 @@ module Inferno
             path: 'code'
           },
           {
-            path: 'effectiveDateTime'
-          },
-          {
-            path: 'effectivePeriod'
-          },
-          {
             path: 'effective'
-          },
-          {
-            path: 'valueQuantity'
           },
           {
             path: 'value'

--- a/lib/modules/uscore_v3.1.0/profile_definitions/bp_definitions.rb
+++ b/lib/modules/uscore_v3.1.0/profile_definitions/bp_definitions.rb
@@ -52,12 +52,6 @@ module Inferno
             path: 'code'
           },
           {
-            path: 'effectiveDateTime'
-          },
-          {
-            path: 'effectivePeriod'
-          },
-          {
             path: 'effective'
           },
           {

--- a/lib/modules/uscore_v3.1.0/profile_definitions/bp_definitions.rb
+++ b/lib/modules/uscore_v3.1.0/profile_definitions/bp_definitions.rb
@@ -24,12 +24,6 @@ module Inferno
             }
           }
         ],
-        references: [
-          {
-            path: 'subject',
-            resource_types: []
-          }
-        ],
         elements: [
           {
             path: 'status'
@@ -50,6 +44,9 @@ module Inferno
           },
           {
             path: 'code'
+          },
+          {
+            path: 'subject'
           },
           {
             path: 'effective'

--- a/lib/modules/uscore_v3.1.0/profile_definitions/headcircum_definitions.rb
+++ b/lib/modules/uscore_v3.1.0/profile_definitions/headcircum_definitions.rb
@@ -32,12 +32,6 @@ module Inferno
             }
           }
         ],
-        references: [
-          {
-            path: 'subject',
-            resource_types: []
-          }
-        ],
         elements: [
           {
             path: 'status'
@@ -58,6 +52,9 @@ module Inferno
           },
           {
             path: 'code'
+          },
+          {
+            path: 'subject'
           },
           {
             path: 'effective'

--- a/lib/modules/uscore_v3.1.0/profile_definitions/headcircum_definitions.rb
+++ b/lib/modules/uscore_v3.1.0/profile_definitions/headcircum_definitions.rb
@@ -60,16 +60,7 @@ module Inferno
             path: 'code'
           },
           {
-            path: 'effectiveDateTime'
-          },
-          {
-            path: 'effectivePeriod'
-          },
-          {
             path: 'effective'
-          },
-          {
-            path: 'valueQuantity'
           },
           {
             path: 'value'

--- a/lib/modules/uscore_v3.1.0/profile_definitions/heartrate_definitions.rb
+++ b/lib/modules/uscore_v3.1.0/profile_definitions/heartrate_definitions.rb
@@ -32,12 +32,6 @@ module Inferno
             }
           }
         ],
-        references: [
-          {
-            path: 'subject',
-            resource_types: []
-          }
-        ],
         elements: [
           {
             path: 'status'
@@ -58,6 +52,9 @@ module Inferno
           },
           {
             path: 'code'
+          },
+          {
+            path: 'subject'
           },
           {
             path: 'effective'

--- a/lib/modules/uscore_v3.1.0/profile_definitions/heartrate_definitions.rb
+++ b/lib/modules/uscore_v3.1.0/profile_definitions/heartrate_definitions.rb
@@ -60,16 +60,7 @@ module Inferno
             path: 'code'
           },
           {
-            path: 'effectiveDateTime'
-          },
-          {
-            path: 'effectivePeriod'
-          },
-          {
             path: 'effective'
-          },
-          {
-            path: 'valueQuantity'
           },
           {
             path: 'value'

--- a/lib/modules/uscore_v3.1.0/profile_definitions/pediatric_bmi_for_age_definitions.rb
+++ b/lib/modules/uscore_v3.1.0/profile_definitions/pediatric_bmi_for_age_definitions.rb
@@ -24,12 +24,6 @@ module Inferno
             }
           }
         ],
-        references: [
-          {
-            path: 'subject',
-            resource_types: []
-          }
-        ],
         elements: [
           {
             path: 'status'
@@ -47,6 +41,9 @@ module Inferno
           {
             path: 'category.coding.code',
             fixed_value: 'vital-signs'
+          },
+          {
+            path: 'subject'
           },
           {
             path: 'effective'

--- a/lib/modules/uscore_v3.1.0/profile_definitions/pediatric_bmi_for_age_definitions.rb
+++ b/lib/modules/uscore_v3.1.0/profile_definitions/pediatric_bmi_for_age_definitions.rb
@@ -49,16 +49,7 @@ module Inferno
             fixed_value: 'vital-signs'
           },
           {
-            path: 'effectiveDateTime'
-          },
-          {
-            path: 'effectivePeriod'
-          },
-          {
             path: 'effective'
-          },
-          {
-            path: 'valueQuantity'
           },
           {
             path: 'value'

--- a/lib/modules/uscore_v3.1.0/profile_definitions/pediatric_weight_for_height_definitions.rb
+++ b/lib/modules/uscore_v3.1.0/profile_definitions/pediatric_weight_for_height_definitions.rb
@@ -24,12 +24,6 @@ module Inferno
             }
           }
         ],
-        references: [
-          {
-            path: 'subject',
-            resource_types: []
-          }
-        ],
         elements: [
           {
             path: 'status'
@@ -47,6 +41,9 @@ module Inferno
           {
             path: 'category.coding.code',
             fixed_value: 'vital-signs'
+          },
+          {
+            path: 'subject'
           },
           {
             path: 'effective'

--- a/lib/modules/uscore_v3.1.0/profile_definitions/pediatric_weight_for_height_definitions.rb
+++ b/lib/modules/uscore_v3.1.0/profile_definitions/pediatric_weight_for_height_definitions.rb
@@ -49,16 +49,7 @@ module Inferno
             fixed_value: 'vital-signs'
           },
           {
-            path: 'effectiveDateTime'
-          },
-          {
-            path: 'effectivePeriod'
-          },
-          {
             path: 'effective'
-          },
-          {
-            path: 'valueQuantity'
           },
           {
             path: 'value'

--- a/lib/modules/uscore_v3.1.0/profile_definitions/resprate_definitions.rb
+++ b/lib/modules/uscore_v3.1.0/profile_definitions/resprate_definitions.rb
@@ -32,12 +32,6 @@ module Inferno
             }
           }
         ],
-        references: [
-          {
-            path: 'subject',
-            resource_types: []
-          }
-        ],
         elements: [
           {
             path: 'status'
@@ -58,6 +52,9 @@ module Inferno
           },
           {
             path: 'code'
+          },
+          {
+            path: 'subject'
           },
           {
             path: 'effective'

--- a/lib/modules/uscore_v3.1.0/profile_definitions/resprate_definitions.rb
+++ b/lib/modules/uscore_v3.1.0/profile_definitions/resprate_definitions.rb
@@ -60,16 +60,7 @@ module Inferno
             path: 'code'
           },
           {
-            path: 'effectiveDateTime'
-          },
-          {
-            path: 'effectivePeriod'
-          },
-          {
             path: 'effective'
-          },
-          {
-            path: 'valueQuantity'
           },
           {
             path: 'value'

--- a/lib/modules/uscore_v3.1.0/profile_definitions/us_core_allergyintolerance_definitions.rb
+++ b/lib/modules/uscore_v3.1.0/profile_definitions/us_core_allergyintolerance_definitions.rb
@@ -6,14 +6,6 @@ module Inferno
       MUST_SUPPORTS = {
         extensions: [],
         slices: [],
-        references: [
-          {
-            path: 'patient',
-            resource_types: [
-              'Patient'
-            ]
-          }
-        ],
         elements: [
           {
             path: 'clinicalStatus'
@@ -23,6 +15,9 @@ module Inferno
           },
           {
             path: 'code'
+          },
+          {
+            path: 'patient'
           }
         ]
       }.freeze

--- a/lib/modules/uscore_v3.1.0/profile_definitions/us_core_careplan_definitions.rb
+++ b/lib/modules/uscore_v3.1.0/profile_definitions/us_core_careplan_definitions.rb
@@ -17,14 +17,6 @@ module Inferno
             }
           }
         ],
-        references: [
-          {
-            path: 'subject',
-            resource_types: [
-              'Patient'
-            ]
-          }
-        ],
         elements: [
           {
             path: 'text'
@@ -40,6 +32,9 @@ module Inferno
           },
           {
             path: 'category'
+          },
+          {
+            path: 'subject'
           }
         ]
       }.freeze

--- a/lib/modules/uscore_v3.1.0/profile_definitions/us_core_careteam_definitions.rb
+++ b/lib/modules/uscore_v3.1.0/profile_definitions/us_core_careteam_definitions.rb
@@ -6,31 +6,21 @@ module Inferno
       MUST_SUPPORTS = {
         extensions: [],
         slices: [],
-        references: [
-          {
-            path: 'subject',
-            resource_types: [
-              'Patient'
-            ]
-          },
-          {
-            path: 'participant.member',
-            resource_types: [
-              'Patient',
-              'Practitioner',
-              'Organization'
-            ]
-          }
-        ],
         elements: [
           {
             path: 'status'
+          },
+          {
+            path: 'subject'
           },
           {
             path: 'participant'
           },
           {
             path: 'participant.role'
+          },
+          {
+            path: 'participant.member'
           }
         ]
       }.freeze

--- a/lib/modules/uscore_v3.1.0/profile_definitions/us_core_condition_definitions.rb
+++ b/lib/modules/uscore_v3.1.0/profile_definitions/us_core_condition_definitions.rb
@@ -6,14 +6,6 @@ module Inferno
       MUST_SUPPORTS = {
         extensions: [],
         slices: [],
-        references: [
-          {
-            path: 'subject',
-            resource_types: [
-              'Patient'
-            ]
-          }
-        ],
         elements: [
           {
             path: 'clinicalStatus'
@@ -26,6 +18,9 @@ module Inferno
           },
           {
             path: 'code'
+          },
+          {
+            path: 'subject'
           }
         ]
       }.freeze

--- a/lib/modules/uscore_v3.1.0/profile_definitions/us_core_diagnosticreport_lab_definitions.rb
+++ b/lib/modules/uscore_v3.1.0/profile_definitions/us_core_diagnosticreport_lab_definitions.rb
@@ -49,12 +49,6 @@ module Inferno
             path: 'code'
           },
           {
-            path: 'effectiveDateTime'
-          },
-          {
-            path: 'effectivePeriod'
-          },
-          {
             path: 'effective'
           },
           {

--- a/lib/modules/uscore_v3.1.0/profile_definitions/us_core_diagnosticreport_lab_definitions.rb
+++ b/lib/modules/uscore_v3.1.0/profile_definitions/us_core_diagnosticreport_lab_definitions.rb
@@ -17,27 +17,6 @@ module Inferno
             }
           }
         ],
-        references: [
-          {
-            path: 'subject',
-            resource_types: [
-              'Patient'
-            ]
-          },
-          {
-            path: 'performer',
-            resource_types: [
-              'Practitioner',
-              'Organization'
-            ]
-          },
-          {
-            path: 'result',
-            resource_types: [
-              'Observation'
-            ]
-          }
-        ],
         elements: [
           {
             path: 'status'
@@ -49,10 +28,19 @@ module Inferno
             path: 'code'
           },
           {
+            path: 'subject'
+          },
+          {
             path: 'effective'
           },
           {
             path: 'issued'
+          },
+          {
+            path: 'performer'
+          },
+          {
+            path: 'result'
           }
         ]
       }.freeze

--- a/lib/modules/uscore_v3.1.0/profile_definitions/us_core_diagnosticreport_note_definitions.rb
+++ b/lib/modules/uscore_v3.1.0/profile_definitions/us_core_diagnosticreport_note_definitions.rb
@@ -38,12 +38,6 @@ module Inferno
             path: 'code'
           },
           {
-            path: 'effectiveDateTime'
-          },
-          {
-            path: 'effectivePeriod'
-          },
-          {
             path: 'effective'
           },
           {

--- a/lib/modules/uscore_v3.1.0/profile_definitions/us_core_diagnosticreport_note_definitions.rb
+++ b/lib/modules/uscore_v3.1.0/profile_definitions/us_core_diagnosticreport_note_definitions.rb
@@ -6,27 +6,6 @@ module Inferno
       MUST_SUPPORTS = {
         extensions: [],
         slices: [],
-        references: [
-          {
-            path: 'subject',
-            resource_types: [
-              'Patient'
-            ]
-          },
-          {
-            path: 'encounter',
-            resource_types: [
-              'Encounter'
-            ]
-          },
-          {
-            path: 'performer',
-            resource_types: [
-              'Practitioner',
-              'Organization'
-            ]
-          }
-        ],
         elements: [
           {
             path: 'status'
@@ -38,10 +17,19 @@ module Inferno
             path: 'code'
           },
           {
+            path: 'subject'
+          },
+          {
+            path: 'encounter'
+          },
+          {
             path: 'effective'
           },
           {
             path: 'issued'
+          },
+          {
+            path: 'performer'
           },
           {
             path: 'presentedForm'

--- a/lib/modules/uscore_v3.1.0/profile_definitions/us_core_documentreference_definitions.rb
+++ b/lib/modules/uscore_v3.1.0/profile_definitions/us_core_documentreference_definitions.rb
@@ -6,34 +6,6 @@ module Inferno
       MUST_SUPPORTS = {
         extensions: [],
         slices: [],
-        references: [
-          {
-            path: 'subject',
-            resource_types: [
-              'Patient'
-            ]
-          },
-          {
-            path: 'author',
-            resource_types: [
-              'Practitioner',
-              'Organization',
-              'Patient'
-            ]
-          },
-          {
-            path: 'custodian',
-            resource_types: [
-              'Organization'
-            ]
-          },
-          {
-            path: 'context.encounter',
-            resource_types: [
-              'Encounter'
-            ]
-          }
-        ],
         elements: [
           {
             path: 'identifier'
@@ -48,7 +20,16 @@ module Inferno
             path: 'category'
           },
           {
+            path: 'subject'
+          },
+          {
             path: 'date'
+          },
+          {
+            path: 'author'
+          },
+          {
+            path: 'custodian'
           },
           {
             path: 'content'
@@ -70,6 +51,9 @@ module Inferno
           },
           {
             path: 'context'
+          },
+          {
+            path: 'context.encounter'
           },
           {
             path: 'context.period'

--- a/lib/modules/uscore_v3.1.0/profile_definitions/us_core_encounter_definitions.rb
+++ b/lib/modules/uscore_v3.1.0/profile_definitions/us_core_encounter_definitions.rb
@@ -6,24 +6,6 @@ module Inferno
       MUST_SUPPORTS = {
         extensions: [],
         slices: [],
-        references: [
-          {
-            path: 'subject',
-            resource_types: [
-              'Patient'
-            ]
-          },
-          {
-            path: 'participant.individual',
-            resource_types: [
-              'Practitioner'
-            ]
-          },
-          {
-            path: 'location.location',
-            resource_types: []
-          }
-        ],
         elements: [
           {
             path: 'identifier'
@@ -44,6 +26,9 @@ module Inferno
             path: 'type'
           },
           {
+            path: 'subject'
+          },
+          {
             path: 'participant'
           },
           {
@@ -51,6 +36,9 @@ module Inferno
           },
           {
             path: 'participant.period'
+          },
+          {
+            path: 'participant.individual'
           },
           {
             path: 'period'
@@ -66,6 +54,9 @@ module Inferno
           },
           {
             path: 'location'
+          },
+          {
+            path: 'location.location'
           }
         ]
       }.freeze

--- a/lib/modules/uscore_v3.1.0/profile_definitions/us_core_goal_definitions.rb
+++ b/lib/modules/uscore_v3.1.0/profile_definitions/us_core_goal_definitions.rb
@@ -15,20 +15,15 @@ module Inferno
             }
           }
         ],
-        references: [
-          {
-            path: 'subject',
-            resource_types: [
-              'Patient'
-            ]
-          }
-        ],
         elements: [
           {
             path: 'lifecycleStatus'
           },
           {
             path: 'description'
+          },
+          {
+            path: 'subject'
           },
           {
             path: 'target'

--- a/lib/modules/uscore_v3.1.0/profile_definitions/us_core_immunization_definitions.rb
+++ b/lib/modules/uscore_v3.1.0/profile_definitions/us_core_immunization_definitions.rb
@@ -6,14 +6,6 @@ module Inferno
       MUST_SUPPORTS = {
         extensions: [],
         slices: [],
-        references: [
-          {
-            path: 'patient',
-            resource_types: [
-              'Patient'
-            ]
-          }
-        ],
         elements: [
           {
             path: 'status'
@@ -23,6 +15,9 @@ module Inferno
           },
           {
             path: 'vaccineCode'
+          },
+          {
+            path: 'patient'
           },
           {
             path: 'occurrence'

--- a/lib/modules/uscore_v3.1.0/profile_definitions/us_core_immunization_definitions.rb
+++ b/lib/modules/uscore_v3.1.0/profile_definitions/us_core_immunization_definitions.rb
@@ -25,12 +25,6 @@ module Inferno
             path: 'vaccineCode'
           },
           {
-            path: 'occurrenceDateTime'
-          },
-          {
-            path: 'occurrenceString'
-          },
-          {
             path: 'occurrence'
           },
           {

--- a/lib/modules/uscore_v3.1.0/profile_definitions/us_core_implantable_device_definitions.rb
+++ b/lib/modules/uscore_v3.1.0/profile_definitions/us_core_implantable_device_definitions.rb
@@ -6,14 +6,6 @@ module Inferno
       MUST_SUPPORTS = {
         extensions: [],
         slices: [],
-        references: [
-          {
-            path: 'patient',
-            resource_types: [
-              'Patient'
-            ]
-          }
-        ],
         elements: [
           {
             path: 'udiCarrier'
@@ -44,6 +36,9 @@ module Inferno
           },
           {
             path: 'type'
+          },
+          {
+            path: 'patient'
           }
         ]
       }.freeze

--- a/lib/modules/uscore_v3.1.0/profile_definitions/us_core_location_definitions.rb
+++ b/lib/modules/uscore_v3.1.0/profile_definitions/us_core_location_definitions.rb
@@ -6,14 +6,6 @@ module Inferno
       MUST_SUPPORTS = {
         extensions: [],
         slices: [],
-        references: [
-          {
-            path: 'managingOrganization',
-            resource_types: [
-              'Organization'
-            ]
-          }
-        ],
         elements: [
           {
             path: 'status'
@@ -38,6 +30,9 @@ module Inferno
           },
           {
             path: 'address.postalCode'
+          },
+          {
+            path: 'managingOrganization'
           }
         ]
       }.freeze

--- a/lib/modules/uscore_v3.1.0/profile_definitions/us_core_medicationrequest_definitions.rb
+++ b/lib/modules/uscore_v3.1.0/profile_definitions/us_core_medicationrequest_definitions.rb
@@ -6,41 +6,6 @@ module Inferno
       MUST_SUPPORTS = {
         extensions: [],
         slices: [],
-        references: [
-          {
-            path: 'reported',
-            resource_types: [
-              'Patient',
-              'Practitioner',
-              'Organization'
-            ]
-          },
-          {
-            path: 'medication',
-            resource_types: [
-              'Medication'
-            ]
-          },
-          {
-            path: 'subject',
-            resource_types: [
-              'Patient'
-            ]
-          },
-          {
-            path: 'encounter',
-            resource_types: []
-          },
-          {
-            path: 'requester',
-            resource_types: [
-              'Practitioner',
-              'Organization',
-              'Patient',
-              'Device'
-            ]
-          }
-        ],
         elements: [
           {
             path: 'status'
@@ -49,7 +14,22 @@ module Inferno
             path: 'intent'
           },
           {
+            path: 'reported'
+          },
+          {
+            path: 'medication'
+          },
+          {
+            path: 'subject'
+          },
+          {
+            path: 'encounter'
+          },
+          {
             path: 'authoredOn'
+          },
+          {
+            path: 'requester'
           },
           {
             path: 'dosageInstruction'

--- a/lib/modules/uscore_v3.1.0/profile_definitions/us_core_observation_lab_definitions.rb
+++ b/lib/modules/uscore_v3.1.0/profile_definitions/us_core_observation_lab_definitions.rb
@@ -36,46 +36,7 @@ module Inferno
             path: 'code'
           },
           {
-            path: 'effectiveDateTime'
-          },
-          {
-            path: 'effectivePeriod'
-          },
-          {
             path: 'effective'
-          },
-          {
-            path: 'valueQuantity'
-          },
-          {
-            path: 'valueCodeableConcept'
-          },
-          {
-            path: 'valueString'
-          },
-          {
-            path: 'valueBoolean'
-          },
-          {
-            path: 'valueInteger'
-          },
-          {
-            path: 'valueRange'
-          },
-          {
-            path: 'valueRatio'
-          },
-          {
-            path: 'valueSampledData'
-          },
-          {
-            path: 'valueTime'
-          },
-          {
-            path: 'valueDateTime'
-          },
-          {
-            path: 'valuePeriod'
           },
           {
             path: 'value'

--- a/lib/modules/uscore_v3.1.0/profile_definitions/us_core_observation_lab_definitions.rb
+++ b/lib/modules/uscore_v3.1.0/profile_definitions/us_core_observation_lab_definitions.rb
@@ -17,14 +17,6 @@ module Inferno
             }
           }
         ],
-        references: [
-          {
-            path: 'subject',
-            resource_types: [
-              'Patient'
-            ]
-          }
-        ],
         elements: [
           {
             path: 'status'
@@ -34,6 +26,9 @@ module Inferno
           },
           {
             path: 'code'
+          },
+          {
+            path: 'subject'
           },
           {
             path: 'effective'

--- a/lib/modules/uscore_v3.1.0/profile_definitions/us_core_organization_definitions.rb
+++ b/lib/modules/uscore_v3.1.0/profile_definitions/us_core_organization_definitions.rb
@@ -25,7 +25,6 @@ module Inferno
             }
           }
         ],
-        references: [],
         elements: [
           {
             path: 'identifier'

--- a/lib/modules/uscore_v3.1.0/profile_definitions/us_core_patient_definitions.rb
+++ b/lib/modules/uscore_v3.1.0/profile_definitions/us_core_patient_definitions.rb
@@ -19,7 +19,6 @@ module Inferno
           }
         ],
         slices: [],
-        references: [],
         elements: [
           {
             path: 'identifier'

--- a/lib/modules/uscore_v3.1.0/profile_definitions/us_core_practitioner_definitions.rb
+++ b/lib/modules/uscore_v3.1.0/profile_definitions/us_core_practitioner_definitions.rb
@@ -16,7 +16,6 @@ module Inferno
             }
           }
         ],
-        references: [],
         elements: [
           {
             path: 'identifier'

--- a/lib/modules/uscore_v3.1.0/profile_definitions/us_core_practitionerrole_definitions.rb
+++ b/lib/modules/uscore_v3.1.0/profile_definitions/us_core_practitionerrole_definitions.rb
@@ -6,34 +6,21 @@ module Inferno
       MUST_SUPPORTS = {
         extensions: [],
         slices: [],
-        references: [
-          {
-            path: 'practitioner',
-            resource_types: [
-              'Practitioner'
-            ]
-          },
-          {
-            path: 'organization',
-            resource_types: [
-              'Organization'
-            ]
-          },
-          {
-            path: 'location',
-            resource_types: []
-          },
-          {
-            path: 'endpoint',
-            resource_types: []
-          }
-        ],
         elements: [
+          {
+            path: 'practitioner'
+          },
+          {
+            path: 'organization'
+          },
           {
             path: 'code'
           },
           {
             path: 'specialty'
+          },
+          {
+            path: 'location'
           },
           {
             path: 'telecom'
@@ -43,6 +30,9 @@ module Inferno
           },
           {
             path: 'telecom.value'
+          },
+          {
+            path: 'endpoint'
           }
         ]
       }.freeze

--- a/lib/modules/uscore_v3.1.0/profile_definitions/us_core_procedure_definitions.rb
+++ b/lib/modules/uscore_v3.1.0/profile_definitions/us_core_procedure_definitions.rb
@@ -6,20 +6,15 @@ module Inferno
       MUST_SUPPORTS = {
         extensions: [],
         slices: [],
-        references: [
-          {
-            path: 'subject',
-            resource_types: [
-              'Patient'
-            ]
-          }
-        ],
         elements: [
           {
             path: 'status'
           },
           {
             path: 'code'
+          },
+          {
+            path: 'subject'
           },
           {
             path: 'performed'

--- a/lib/modules/uscore_v3.1.0/profile_definitions/us_core_procedure_definitions.rb
+++ b/lib/modules/uscore_v3.1.0/profile_definitions/us_core_procedure_definitions.rb
@@ -22,12 +22,6 @@ module Inferno
             path: 'code'
           },
           {
-            path: 'performedDateTime'
-          },
-          {
-            path: 'performedPeriod'
-          },
-          {
             path: 'performed'
           }
         ]

--- a/lib/modules/uscore_v3.1.0/profile_definitions/us_core_provenance_definitions.rb
+++ b/lib/modules/uscore_v3.1.0/profile_definitions/us_core_provenance_definitions.rb
@@ -27,27 +27,10 @@ module Inferno
             }
           }
         ],
-        references: [
-          {
-            path: 'target',
-            resource_types: []
-          },
-          {
-            path: 'agent.who',
-            resource_types: [
-              'Practitioner',
-              'Patient',
-              'Organization'
-            ]
-          },
-          {
-            path: 'agent.onBehalfOf',
-            resource_types: [
-              'Organization'
-            ]
-          }
-        ],
         elements: [
+          {
+            path: 'target'
+          },
           {
             path: 'recorded'
           },
@@ -56,6 +39,12 @@ module Inferno
           },
           {
             path: 'agent.type'
+          },
+          {
+            path: 'agent.who'
+          },
+          {
+            path: 'agent.onBehalfOf'
           },
           {
             path: 'agent.type.coding.code',

--- a/lib/modules/uscore_v3.1.0/profile_definitions/us_core_pulse_oximetry_definitions.rb
+++ b/lib/modules/uscore_v3.1.0/profile_definitions/us_core_pulse_oximetry_definitions.rb
@@ -69,12 +69,6 @@ module Inferno
             }
           }
         ],
-        references: [
-          {
-            path: 'subject',
-            resource_types: []
-          }
-        ],
         elements: [
           {
             path: 'status'
@@ -106,6 +100,9 @@ module Inferno
           {
             path: 'code.coding.code',
             fixed_value: '59408-5'
+          },
+          {
+            path: 'subject'
           },
           {
             path: 'effective'

--- a/lib/modules/uscore_v3.1.0/profile_definitions/us_core_pulse_oximetry_definitions.rb
+++ b/lib/modules/uscore_v3.1.0/profile_definitions/us_core_pulse_oximetry_definitions.rb
@@ -108,16 +108,7 @@ module Inferno
             fixed_value: '59408-5'
           },
           {
-            path: 'effectiveDateTime'
-          },
-          {
-            path: 'effectivePeriod'
-          },
-          {
             path: 'effective'
-          },
-          {
-            path: 'valueQuantity'
           },
           {
             path: 'value'
@@ -146,12 +137,6 @@ module Inferno
             path: 'component.code'
           },
           {
-            path: 'component.valueQuantity'
-          },
-          {
-            path: 'component.value'
-          },
-          {
             path: 'component.code.coding.code',
             fixed_value: '3151-8'
           },
@@ -166,6 +151,9 @@ module Inferno
           {
             path: 'component.code.coding.code',
             fixed_value: '3150-0'
+          },
+          {
+            path: 'component.value'
           },
           {
             path: 'component.value.value'

--- a/lib/modules/uscore_v3.1.0/profile_definitions/us_core_smokingstatus_definitions.rb
+++ b/lib/modules/uscore_v3.1.0/profile_definitions/us_core_smokingstatus_definitions.rb
@@ -15,20 +15,15 @@ module Inferno
             }
           }
         ],
-        references: [
-          {
-            path: 'subject',
-            resource_types: [
-              'Patient'
-            ]
-          }
-        ],
         elements: [
           {
             path: 'status'
           },
           {
             path: 'code'
+          },
+          {
+            path: 'subject'
           },
           {
             path: 'issued'

--- a/lib/modules/uscore_v3.1.0/resprate_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/resprate_sequence.rb
@@ -608,11 +608,6 @@ module Inferno
             * value[x].unit
             * value[x].value
 
-
-          For elements of type 'reference' with one or more target profiles from US Core, this test will ensure that at least one of each resource type
-          associated with each US Core target profile is provided as a reference.  This test will not validate those references against their associated
-          US Core profile to reduce test complexity.
-
           )
           versions :r4
         end
@@ -625,18 +620,6 @@ module Inferno
             slice_found = find_slice(resource, slice[:path], slice[:discriminator])
             slice_found.present?
           end
-        end
-
-        missing_must_support_references = must_supports[:references].each_with_object({}) do |reference, missing_types_by_path|
-          missing_resource_types = reference[:resource_types].reject do |resource_type|
-            @observation_ary&.values&.flatten&.any? do |resource|
-              value_found = resolve_element_from_path(resource, reference[:path]) do |value|
-                value.is_a?(FHIR::Reference) && value.reference.include?("#{resource_type}/")
-              end
-              value_found.present?
-            end
-          end
-          missing_types_by_path[reference[:path]] = missing_resource_types if missing_resource_types.present?
         end
 
         missing_must_support_elements = must_supports[:elements].reject do |element|
@@ -655,9 +638,6 @@ module Inferno
 
         skip_if missing_must_support_elements.present?,
                 "Could not find #{missing_must_support_elements.join(', ')} in the #{@observation_ary&.values&.flatten&.length} provided Observation resource(s)"
-        skip_if missing_must_support_references.present?,
-                "Could not find the following resource type references:#{missing_must_support_references.map { |path, resource_types| path + ':' + resource_types.join(',') }.join(';')}"
-
         @instance.save!
       end
 

--- a/lib/modules/uscore_v3.1.0/resprate_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/resprate_sequence.rb
@@ -599,12 +599,9 @@ module Inferno
             * category.coding.system
             * code
             * dataAbsentReason
-            * effectiveDateTime
-            * effectivePeriod
             * effective[x]
             * status
             * subject
-            * valueQuantity
             * value[x]
             * value[x].code
             * value[x].system

--- a/lib/modules/uscore_v3.1.0/us_core_allergyintolerance_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_allergyintolerance_sequence.rb
@@ -410,29 +410,12 @@ module Inferno
             * patient
             * verificationStatus
 
-
-          For elements of type 'reference' with one or more target profiles from US Core, this test will ensure that at least one of each resource type
-          associated with each US Core target profile is provided as a reference.  This test will not validate those references against their associated
-          US Core profile to reduce test complexity.
-
           )
           versions :r4
         end
 
         skip_if_not_found(resource_type: 'AllergyIntolerance', delayed: false)
         must_supports = USCore310AllergyintoleranceSequenceDefinitions::MUST_SUPPORTS
-
-        missing_must_support_references = must_supports[:references].each_with_object({}) do |reference, missing_types_by_path|
-          missing_resource_types = reference[:resource_types].reject do |resource_type|
-            @allergy_intolerance_ary&.values&.flatten&.any? do |resource|
-              value_found = resolve_element_from_path(resource, reference[:path]) do |value|
-                value.is_a?(FHIR::Reference) && value.reference.include?("#{resource_type}/")
-              end
-              value_found.present?
-            end
-          end
-          missing_types_by_path[reference[:path]] = missing_resource_types if missing_resource_types.present?
-        end
 
         missing_must_support_elements = must_supports[:elements].reject do |element|
           @allergy_intolerance_ary&.values&.flatten&.any? do |resource|
@@ -448,9 +431,6 @@ module Inferno
 
         skip_if missing_must_support_elements.present?,
                 "Could not find #{missing_must_support_elements.join(', ')} in the #{@allergy_intolerance_ary&.values&.flatten&.length} provided AllergyIntolerance resource(s)"
-        skip_if missing_must_support_references.present?,
-                "Could not find the following resource type references:#{missing_must_support_references.map { |path, resource_types| path + ':' + resource_types.join(',') }.join(';')}"
-
         @instance.save!
       end
 

--- a/lib/modules/uscore_v3.1.0/us_core_careplan_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_careplan_sequence.rb
@@ -427,11 +427,6 @@ module Inferno
             * text
             * text.status
 
-
-          For elements of type 'reference' with one or more target profiles from US Core, this test will ensure that at least one of each resource type
-          associated with each US Core target profile is provided as a reference.  This test will not validate those references against their associated
-          US Core profile to reduce test complexity.
-
           )
           versions :r4
         end
@@ -444,18 +439,6 @@ module Inferno
             slice_found = find_slice(resource, slice[:path], slice[:discriminator])
             slice_found.present?
           end
-        end
-
-        missing_must_support_references = must_supports[:references].each_with_object({}) do |reference, missing_types_by_path|
-          missing_resource_types = reference[:resource_types].reject do |resource_type|
-            @care_plan_ary&.values&.flatten&.any? do |resource|
-              value_found = resolve_element_from_path(resource, reference[:path]) do |value|
-                value.is_a?(FHIR::Reference) && value.reference.include?("#{resource_type}/")
-              end
-              value_found.present?
-            end
-          end
-          missing_types_by_path[reference[:path]] = missing_resource_types if missing_resource_types.present?
         end
 
         missing_must_support_elements = must_supports[:elements].reject do |element|
@@ -474,9 +457,6 @@ module Inferno
 
         skip_if missing_must_support_elements.present?,
                 "Could not find #{missing_must_support_elements.join(', ')} in the #{@care_plan_ary&.values&.flatten&.length} provided CarePlan resource(s)"
-        skip_if missing_must_support_references.present?,
-                "Could not find the following resource type references:#{missing_must_support_references.map { |path, resource_types| path + ':' + resource_types.join(',') }.join(';')}"
-
         @instance.save!
       end
 

--- a/lib/modules/uscore_v3.1.0/us_core_careteam_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_careteam_sequence.rb
@@ -352,29 +352,12 @@ module Inferno
             * status
             * subject
 
-
-          For elements of type 'reference' with one or more target profiles from US Core, this test will ensure that at least one of each resource type
-          associated with each US Core target profile is provided as a reference.  This test will not validate those references against their associated
-          US Core profile to reduce test complexity.
-
           )
           versions :r4
         end
 
         skip_if_not_found(resource_type: 'CareTeam', delayed: false)
         must_supports = USCore310CareteamSequenceDefinitions::MUST_SUPPORTS
-
-        missing_must_support_references = must_supports[:references].each_with_object({}) do |reference, missing_types_by_path|
-          missing_resource_types = reference[:resource_types].reject do |resource_type|
-            @care_team_ary&.values&.flatten&.any? do |resource|
-              value_found = resolve_element_from_path(resource, reference[:path]) do |value|
-                value.is_a?(FHIR::Reference) && value.reference.include?("#{resource_type}/")
-              end
-              value_found.present?
-            end
-          end
-          missing_types_by_path[reference[:path]] = missing_resource_types if missing_resource_types.present?
-        end
 
         missing_must_support_elements = must_supports[:elements].reject do |element|
           @care_team_ary&.values&.flatten&.any? do |resource|
@@ -390,9 +373,6 @@ module Inferno
 
         skip_if missing_must_support_elements.present?,
                 "Could not find #{missing_must_support_elements.join(', ')} in the #{@care_team_ary&.values&.flatten&.length} provided CareTeam resource(s)"
-        skip_if missing_must_support_references.present?,
-                "Could not find the following resource type references:#{missing_must_support_references.map { |path, resource_types| path + ':' + resource_types.join(',') }.join(';')}"
-
         @instance.save!
       end
 

--- a/lib/modules/uscore_v3.1.0/us_core_condition_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_condition_sequence.rb
@@ -532,29 +532,12 @@ module Inferno
             * subject
             * verificationStatus
 
-
-          For elements of type 'reference' with one or more target profiles from US Core, this test will ensure that at least one of each resource type
-          associated with each US Core target profile is provided as a reference.  This test will not validate those references against their associated
-          US Core profile to reduce test complexity.
-
           )
           versions :r4
         end
 
         skip_if_not_found(resource_type: 'Condition', delayed: false)
         must_supports = USCore310ConditionSequenceDefinitions::MUST_SUPPORTS
-
-        missing_must_support_references = must_supports[:references].each_with_object({}) do |reference, missing_types_by_path|
-          missing_resource_types = reference[:resource_types].reject do |resource_type|
-            @condition_ary&.values&.flatten&.any? do |resource|
-              value_found = resolve_element_from_path(resource, reference[:path]) do |value|
-                value.is_a?(FHIR::Reference) && value.reference.include?("#{resource_type}/")
-              end
-              value_found.present?
-            end
-          end
-          missing_types_by_path[reference[:path]] = missing_resource_types if missing_resource_types.present?
-        end
 
         missing_must_support_elements = must_supports[:elements].reject do |element|
           @condition_ary&.values&.flatten&.any? do |resource|
@@ -570,9 +553,6 @@ module Inferno
 
         skip_if missing_must_support_elements.present?,
                 "Could not find #{missing_must_support_elements.join(', ')} in the #{@condition_ary&.values&.flatten&.length} provided Condition resource(s)"
-        skip_if missing_must_support_references.present?,
-                "Could not find the following resource type references:#{missing_must_support_references.map { |path, resource_types| path + ':' + resource_types.join(',') }.join(';')}"
-
         @instance.save!
       end
 

--- a/lib/modules/uscore_v3.1.0/us_core_diagnosticreport_lab_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_diagnosticreport_lab_sequence.rb
@@ -628,11 +628,6 @@ module Inferno
             * status
             * subject
 
-
-          For elements of type 'reference' with one or more target profiles from US Core, this test will ensure that at least one of each resource type
-          associated with each US Core target profile is provided as a reference.  This test will not validate those references against their associated
-          US Core profile to reduce test complexity.
-
           )
           versions :r4
         end
@@ -645,18 +640,6 @@ module Inferno
             slice_found = find_slice(resource, slice[:path], slice[:discriminator])
             slice_found.present?
           end
-        end
-
-        missing_must_support_references = must_supports[:references].each_with_object({}) do |reference, missing_types_by_path|
-          missing_resource_types = reference[:resource_types].reject do |resource_type|
-            @diagnostic_report_ary&.values&.flatten&.any? do |resource|
-              value_found = resolve_element_from_path(resource, reference[:path]) do |value|
-                value.is_a?(FHIR::Reference) && value.reference.include?("#{resource_type}/")
-              end
-              value_found.present?
-            end
-          end
-          missing_types_by_path[reference[:path]] = missing_resource_types if missing_resource_types.present?
         end
 
         missing_must_support_elements = must_supports[:elements].reject do |element|
@@ -675,9 +658,6 @@ module Inferno
 
         skip_if missing_must_support_elements.present?,
                 "Could not find #{missing_must_support_elements.join(', ')} in the #{@diagnostic_report_ary&.values&.flatten&.length} provided DiagnosticReport resource(s)"
-        skip_if missing_must_support_references.present?,
-                "Could not find the following resource type references:#{missing_must_support_references.map { |path, resource_types| path + ':' + resource_types.join(',') }.join(';')}"
-
         @instance.save!
       end
 

--- a/lib/modules/uscore_v3.1.0/us_core_diagnosticreport_lab_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_diagnosticreport_lab_sequence.rb
@@ -621,8 +621,6 @@ module Inferno
             * DiagnosticReport.category:LaboratorySlice
             * category
             * code
-            * effectiveDateTime
-            * effectivePeriod
             * effective[x]
             * issued
             * performer

--- a/lib/modules/uscore_v3.1.0/us_core_diagnosticreport_note_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_diagnosticreport_note_sequence.rb
@@ -620,8 +620,6 @@ module Inferno
 
             * category
             * code
-            * effectiveDateTime
-            * effectivePeriod
             * effective[x]
             * encounter
             * issued

--- a/lib/modules/uscore_v3.1.0/us_core_diagnosticreport_note_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_diagnosticreport_note_sequence.rb
@@ -628,29 +628,12 @@ module Inferno
             * status
             * subject
 
-
-          For elements of type 'reference' with one or more target profiles from US Core, this test will ensure that at least one of each resource type
-          associated with each US Core target profile is provided as a reference.  This test will not validate those references against their associated
-          US Core profile to reduce test complexity.
-
           )
           versions :r4
         end
 
         skip_if_not_found(resource_type: 'DiagnosticReport', delayed: false)
         must_supports = USCore310DiagnosticreportNoteSequenceDefinitions::MUST_SUPPORTS
-
-        missing_must_support_references = must_supports[:references].each_with_object({}) do |reference, missing_types_by_path|
-          missing_resource_types = reference[:resource_types].reject do |resource_type|
-            @diagnostic_report_ary&.values&.flatten&.any? do |resource|
-              value_found = resolve_element_from_path(resource, reference[:path]) do |value|
-                value.is_a?(FHIR::Reference) && value.reference.include?("#{resource_type}/")
-              end
-              value_found.present?
-            end
-          end
-          missing_types_by_path[reference[:path]] = missing_resource_types if missing_resource_types.present?
-        end
 
         missing_must_support_elements = must_supports[:elements].reject do |element|
           @diagnostic_report_ary&.values&.flatten&.any? do |resource|
@@ -666,9 +649,6 @@ module Inferno
 
         skip_if missing_must_support_elements.present?,
                 "Could not find #{missing_must_support_elements.join(', ')} in the #{@diagnostic_report_ary&.values&.flatten&.length} provided DiagnosticReport resource(s)"
-        skip_if missing_must_support_references.present?,
-                "Could not find the following resource type references:#{missing_must_support_references.map { |path, resource_types| path + ':' + resource_types.join(',') }.join(';')}"
-
         @instance.save!
       end
 

--- a/lib/modules/uscore_v3.1.0/us_core_documentreference_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_documentreference_sequence.rb
@@ -690,29 +690,12 @@ module Inferno
             * subject
             * type
 
-
-          For elements of type 'reference' with one or more target profiles from US Core, this test will ensure that at least one of each resource type
-          associated with each US Core target profile is provided as a reference.  This test will not validate those references against their associated
-          US Core profile to reduce test complexity.
-
           )
           versions :r4
         end
 
         skip_if_not_found(resource_type: 'DocumentReference', delayed: false)
         must_supports = USCore310DocumentreferenceSequenceDefinitions::MUST_SUPPORTS
-
-        missing_must_support_references = must_supports[:references].each_with_object({}) do |reference, missing_types_by_path|
-          missing_resource_types = reference[:resource_types].reject do |resource_type|
-            @document_reference_ary&.values&.flatten&.any? do |resource|
-              value_found = resolve_element_from_path(resource, reference[:path]) do |value|
-                value.is_a?(FHIR::Reference) && value.reference.include?("#{resource_type}/")
-              end
-              value_found.present?
-            end
-          end
-          missing_types_by_path[reference[:path]] = missing_resource_types if missing_resource_types.present?
-        end
 
         missing_must_support_elements = must_supports[:elements].reject do |element|
           @document_reference_ary&.values&.flatten&.any? do |resource|
@@ -728,9 +711,6 @@ module Inferno
 
         skip_if missing_must_support_elements.present?,
                 "Could not find #{missing_must_support_elements.join(', ')} in the #{@document_reference_ary&.values&.flatten&.length} provided DocumentReference resource(s)"
-        skip_if missing_must_support_references.present?,
-                "Could not find the following resource type references:#{missing_must_support_references.map { |path, resource_types| path + ':' + resource_types.join(',') }.join(';')}"
-
         @instance.save!
       end
 

--- a/lib/modules/uscore_v3.1.0/us_core_encounter_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_encounter_sequence.rb
@@ -262,29 +262,12 @@ module Inferno
             * subject
             * type
 
-
-          For elements of type 'reference' with one or more target profiles from US Core, this test will ensure that at least one of each resource type
-          associated with each US Core target profile is provided as a reference.  This test will not validate those references against their associated
-          US Core profile to reduce test complexity.
-
           )
           versions :r4
         end
 
         skip_if_not_found(resource_type: 'Encounter', delayed: true)
         must_supports = USCore310EncounterSequenceDefinitions::MUST_SUPPORTS
-
-        missing_must_support_references = must_supports[:references].each_with_object({}) do |reference, missing_types_by_path|
-          missing_resource_types = reference[:resource_types].reject do |resource_type|
-            @encounter_ary&.any? do |resource|
-              value_found = resolve_element_from_path(resource, reference[:path]) do |value|
-                value.is_a?(FHIR::Reference) && value.reference.include?("#{resource_type}/")
-              end
-              value_found.present?
-            end
-          end
-          missing_types_by_path[reference[:path]] = missing_resource_types if missing_resource_types.present?
-        end
 
         missing_must_support_elements = must_supports[:elements].reject do |element|
           @encounter_ary&.any? do |resource|
@@ -300,9 +283,6 @@ module Inferno
 
         skip_if missing_must_support_elements.present?,
                 "Could not find #{missing_must_support_elements.join(', ')} in the #{@encounter_ary&.length} provided Encounter resource(s)"
-        skip_if missing_must_support_references.present?,
-                "Could not find the following resource type references:#{missing_must_support_references.map { |path, resource_types| path + ':' + resource_types.join(',') }.join(';')}"
-
         @instance.save!
       end
 

--- a/lib/modules/uscore_v3.1.0/us_core_goal_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_goal_sequence.rb
@@ -439,11 +439,6 @@ module Inferno
             * subject
             * target
 
-
-          For elements of type 'reference' with one or more target profiles from US Core, this test will ensure that at least one of each resource type
-          associated with each US Core target profile is provided as a reference.  This test will not validate those references against their associated
-          US Core profile to reduce test complexity.
-
           )
           versions :r4
         end
@@ -456,18 +451,6 @@ module Inferno
             slice_found = find_slice(resource, slice[:path], slice[:discriminator])
             slice_found.present?
           end
-        end
-
-        missing_must_support_references = must_supports[:references].each_with_object({}) do |reference, missing_types_by_path|
-          missing_resource_types = reference[:resource_types].reject do |resource_type|
-            @goal_ary&.values&.flatten&.any? do |resource|
-              value_found = resolve_element_from_path(resource, reference[:path]) do |value|
-                value.is_a?(FHIR::Reference) && value.reference.include?("#{resource_type}/")
-              end
-              value_found.present?
-            end
-          end
-          missing_types_by_path[reference[:path]] = missing_resource_types if missing_resource_types.present?
         end
 
         missing_must_support_elements = must_supports[:elements].reject do |element|
@@ -486,9 +469,6 @@ module Inferno
 
         skip_if missing_must_support_elements.present?,
                 "Could not find #{missing_must_support_elements.join(', ')} in the #{@goal_ary&.values&.flatten&.length} provided Goal resource(s)"
-        skip_if missing_must_support_references.present?,
-                "Could not find the following resource type references:#{missing_must_support_references.map { |path, resource_types| path + ':' + resource_types.join(',') }.join(';')}"
-
         @instance.save!
       end
 

--- a/lib/modules/uscore_v3.1.0/us_core_immunization_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_immunization_sequence.rb
@@ -433,8 +433,6 @@ module Inferno
             US Core Responders SHALL be capable of populating all data elements as part of the query results as specified by the US Core Server Capability Statement.
             This will look through the Immunization resources found previously for the following must support elements:
 
-            * occurrenceDateTime
-            * occurrenceString
             * occurrence[x]
             * patient
             * primarySource

--- a/lib/modules/uscore_v3.1.0/us_core_immunization_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_immunization_sequence.rb
@@ -440,29 +440,12 @@ module Inferno
             * statusReason
             * vaccineCode
 
-
-          For elements of type 'reference' with one or more target profiles from US Core, this test will ensure that at least one of each resource type
-          associated with each US Core target profile is provided as a reference.  This test will not validate those references against their associated
-          US Core profile to reduce test complexity.
-
           )
           versions :r4
         end
 
         skip_if_not_found(resource_type: 'Immunization', delayed: false)
         must_supports = USCore310ImmunizationSequenceDefinitions::MUST_SUPPORTS
-
-        missing_must_support_references = must_supports[:references].each_with_object({}) do |reference, missing_types_by_path|
-          missing_resource_types = reference[:resource_types].reject do |resource_type|
-            @immunization_ary&.values&.flatten&.any? do |resource|
-              value_found = resolve_element_from_path(resource, reference[:path]) do |value|
-                value.is_a?(FHIR::Reference) && value.reference.include?("#{resource_type}/")
-              end
-              value_found.present?
-            end
-          end
-          missing_types_by_path[reference[:path]] = missing_resource_types if missing_resource_types.present?
-        end
 
         missing_must_support_elements = must_supports[:elements].reject do |element|
           @immunization_ary&.values&.flatten&.any? do |resource|
@@ -478,9 +461,6 @@ module Inferno
 
         skip_if missing_must_support_elements.present?,
                 "Could not find #{missing_must_support_elements.join(', ')} in the #{@immunization_ary&.values&.flatten&.length} provided Immunization resource(s)"
-        skip_if missing_must_support_references.present?,
-                "Could not find the following resource type references:#{missing_must_support_references.map { |path, resource_types| path + ':' + resource_types.join(',') }.join(';')}"
-
         @instance.save!
       end
 

--- a/lib/modules/uscore_v3.1.0/us_core_implantable_device_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_implantable_device_sequence.rb
@@ -378,29 +378,12 @@ module Inferno
             * udiCarrier.carrierHRF
             * udiCarrier.deviceIdentifier
 
-
-          For elements of type 'reference' with one or more target profiles from US Core, this test will ensure that at least one of each resource type
-          associated with each US Core target profile is provided as a reference.  This test will not validate those references against their associated
-          US Core profile to reduce test complexity.
-
           )
           versions :r4
         end
 
         skip_if_not_found(resource_type: 'Device', delayed: false)
         must_supports = USCore310ImplantableDeviceSequenceDefinitions::MUST_SUPPORTS
-
-        missing_must_support_references = must_supports[:references].each_with_object({}) do |reference, missing_types_by_path|
-          missing_resource_types = reference[:resource_types].reject do |resource_type|
-            @device_ary&.values&.flatten&.any? do |resource|
-              value_found = resolve_element_from_path(resource, reference[:path]) do |value|
-                value.is_a?(FHIR::Reference) && value.reference.include?("#{resource_type}/")
-              end
-              value_found.present?
-            end
-          end
-          missing_types_by_path[reference[:path]] = missing_resource_types if missing_resource_types.present?
-        end
 
         missing_must_support_elements = must_supports[:elements].reject do |element|
           @device_ary&.values&.flatten&.any? do |resource|
@@ -416,9 +399,6 @@ module Inferno
 
         skip_if missing_must_support_elements.present?,
                 "Could not find #{missing_must_support_elements.join(', ')} in the #{@device_ary&.values&.flatten&.length} provided Device resource(s)"
-        skip_if missing_must_support_references.present?,
-                "Could not find the following resource type references:#{missing_must_support_references.map { |path, resource_types| path + ':' + resource_types.join(',') }.join(';')}"
-
         @instance.save!
       end
 

--- a/lib/modules/uscore_v3.1.0/us_core_location_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_location_sequence.rb
@@ -205,29 +205,12 @@ module Inferno
             * status
             * telecom
 
-
-          For elements of type 'reference' with one or more target profiles from US Core, this test will ensure that at least one of each resource type
-          associated with each US Core target profile is provided as a reference.  This test will not validate those references against their associated
-          US Core profile to reduce test complexity.
-
           )
           versions :r4
         end
 
         skip_if_not_found(resource_type: 'Location', delayed: true)
         must_supports = USCore310LocationSequenceDefinitions::MUST_SUPPORTS
-
-        missing_must_support_references = must_supports[:references].each_with_object({}) do |reference, missing_types_by_path|
-          missing_resource_types = reference[:resource_types].reject do |resource_type|
-            @location_ary&.any? do |resource|
-              value_found = resolve_element_from_path(resource, reference[:path]) do |value|
-                value.is_a?(FHIR::Reference) && value.reference.include?("#{resource_type}/")
-              end
-              value_found.present?
-            end
-          end
-          missing_types_by_path[reference[:path]] = missing_resource_types if missing_resource_types.present?
-        end
 
         missing_must_support_elements = must_supports[:elements].reject do |element|
           @location_ary&.any? do |resource|
@@ -243,9 +226,6 @@ module Inferno
 
         skip_if missing_must_support_elements.present?,
                 "Could not find #{missing_must_support_elements.join(', ')} in the #{@location_ary&.length} provided Location resource(s)"
-        skip_if missing_must_support_references.present?,
-                "Could not find the following resource type references:#{missing_must_support_references.map { |path, resource_types| path + ':' + resource_types.join(',') }.join(';')}"
-
         @instance.save!
       end
 

--- a/lib/modules/uscore_v3.1.0/us_core_medicationrequest_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_medicationrequest_sequence.rb
@@ -616,29 +616,12 @@ module Inferno
             * status
             * subject
 
-
-          For elements of type 'reference' with one or more target profiles from US Core, this test will ensure that at least one of each resource type
-          associated with each US Core target profile is provided as a reference.  This test will not validate those references against their associated
-          US Core profile to reduce test complexity.
-
           )
           versions :r4
         end
 
         skip_if_not_found(resource_type: 'MedicationRequest', delayed: false)
         must_supports = USCore310MedicationrequestSequenceDefinitions::MUST_SUPPORTS
-
-        missing_must_support_references = must_supports[:references].each_with_object({}) do |reference, missing_types_by_path|
-          missing_resource_types = reference[:resource_types].reject do |resource_type|
-            @medication_request_ary&.values&.flatten&.any? do |resource|
-              value_found = resolve_element_from_path(resource, reference[:path]) do |value|
-                value.is_a?(FHIR::Reference) && value.reference.include?("#{resource_type}/")
-              end
-              value_found.present?
-            end
-          end
-          missing_types_by_path[reference[:path]] = missing_resource_types if missing_resource_types.present?
-        end
 
         missing_must_support_elements = must_supports[:elements].reject do |element|
           @medication_request_ary&.values&.flatten&.any? do |resource|
@@ -654,9 +637,6 @@ module Inferno
 
         skip_if missing_must_support_elements.present?,
                 "Could not find #{missing_must_support_elements.join(', ')} in the #{@medication_request_ary&.values&.flatten&.length} provided MedicationRequest resource(s)"
-        skip_if missing_must_support_references.present?,
-                "Could not find the following resource type references:#{missing_must_support_references.map { |path, resource_types| path + ':' + resource_types.join(',') }.join(';')}"
-
         @instance.save!
       end
 

--- a/lib/modules/uscore_v3.1.0/us_core_observation_lab_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_observation_lab_sequence.rb
@@ -600,11 +600,6 @@ module Inferno
             * subject
             * value[x]
 
-
-          For elements of type 'reference' with one or more target profiles from US Core, this test will ensure that at least one of each resource type
-          associated with each US Core target profile is provided as a reference.  This test will not validate those references against their associated
-          US Core profile to reduce test complexity.
-
           )
           versions :r4
         end
@@ -617,18 +612,6 @@ module Inferno
             slice_found = find_slice(resource, slice[:path], slice[:discriminator])
             slice_found.present?
           end
-        end
-
-        missing_must_support_references = must_supports[:references].each_with_object({}) do |reference, missing_types_by_path|
-          missing_resource_types = reference[:resource_types].reject do |resource_type|
-            @observation_ary&.values&.flatten&.any? do |resource|
-              value_found = resolve_element_from_path(resource, reference[:path]) do |value|
-                value.is_a?(FHIR::Reference) && value.reference.include?("#{resource_type}/")
-              end
-              value_found.present?
-            end
-          end
-          missing_types_by_path[reference[:path]] = missing_resource_types if missing_resource_types.present?
         end
 
         missing_must_support_elements = must_supports[:elements].reject do |element|
@@ -647,9 +630,6 @@ module Inferno
 
         skip_if missing_must_support_elements.present?,
                 "Could not find #{missing_must_support_elements.join(', ')} in the #{@observation_ary&.values&.flatten&.length} provided Observation resource(s)"
-        skip_if missing_must_support_references.present?,
-                "Could not find the following resource type references:#{missing_must_support_references.map { |path, resource_types| path + ':' + resource_types.join(',') }.join(';')}"
-
         @instance.save!
       end
 

--- a/lib/modules/uscore_v3.1.0/us_core_observation_lab_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_observation_lab_sequence.rb
@@ -595,22 +595,9 @@ module Inferno
             * category
             * code
             * dataAbsentReason
-            * effectiveDateTime
-            * effectivePeriod
             * effective[x]
             * status
             * subject
-            * valueBoolean
-            * valueCodeableConcept
-            * valueDateTime
-            * valueInteger
-            * valuePeriod
-            * valueQuantity
-            * valueRange
-            * valueRatio
-            * valueSampledData
-            * valueString
-            * valueTime
             * value[x]
 
 

--- a/lib/modules/uscore_v3.1.0/us_core_organization_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_organization_sequence.rb
@@ -192,8 +192,6 @@ module Inferno
             * name
             * telecom
 
-
-
           )
           versions :r4
         end

--- a/lib/modules/uscore_v3.1.0/us_core_patient_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_patient_sequence.rb
@@ -588,8 +588,6 @@ module Inferno
             * telecom.use
             * telecom.value
 
-
-
           )
           versions :r4
         end

--- a/lib/modules/uscore_v3.1.0/us_core_practitioner_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_practitioner_sequence.rb
@@ -188,8 +188,6 @@ module Inferno
             * name
             * name.family
 
-
-
           )
           versions :r4
         end

--- a/lib/modules/uscore_v3.1.0/us_core_practitionerrole_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_practitionerrole_sequence.rb
@@ -189,29 +189,12 @@ module Inferno
             * telecom.system
             * telecom.value
 
-
-          For elements of type 'reference' with one or more target profiles from US Core, this test will ensure that at least one of each resource type
-          associated with each US Core target profile is provided as a reference.  This test will not validate those references against their associated
-          US Core profile to reduce test complexity.
-
           )
           versions :r4
         end
 
         skip_if_not_found(resource_type: 'PractitionerRole', delayed: true)
         must_supports = USCore310PractitionerroleSequenceDefinitions::MUST_SUPPORTS
-
-        missing_must_support_references = must_supports[:references].each_with_object({}) do |reference, missing_types_by_path|
-          missing_resource_types = reference[:resource_types].reject do |resource_type|
-            @practitioner_role_ary&.any? do |resource|
-              value_found = resolve_element_from_path(resource, reference[:path]) do |value|
-                value.is_a?(FHIR::Reference) && value.reference.include?("#{resource_type}/")
-              end
-              value_found.present?
-            end
-          end
-          missing_types_by_path[reference[:path]] = missing_resource_types if missing_resource_types.present?
-        end
 
         missing_must_support_elements = must_supports[:elements].reject do |element|
           @practitioner_role_ary&.any? do |resource|
@@ -227,9 +210,6 @@ module Inferno
 
         skip_if missing_must_support_elements.present?,
                 "Could not find #{missing_must_support_elements.join(', ')} in the #{@practitioner_role_ary&.length} provided PractitionerRole resource(s)"
-        skip_if missing_must_support_references.present?,
-                "Could not find the following resource type references:#{missing_must_support_references.map { |path, resource_types| path + ':' + resource_types.join(',') }.join(';')}"
-
         @instance.save!
       end
 

--- a/lib/modules/uscore_v3.1.0/us_core_procedure_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_procedure_sequence.rb
@@ -504,8 +504,6 @@ module Inferno
             This will look through the Procedure resources found previously for the following must support elements:
 
             * code
-            * performedDateTime
-            * performedPeriod
             * performed[x]
             * status
             * subject

--- a/lib/modules/uscore_v3.1.0/us_core_procedure_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_procedure_sequence.rb
@@ -508,29 +508,12 @@ module Inferno
             * status
             * subject
 
-
-          For elements of type 'reference' with one or more target profiles from US Core, this test will ensure that at least one of each resource type
-          associated with each US Core target profile is provided as a reference.  This test will not validate those references against their associated
-          US Core profile to reduce test complexity.
-
           )
           versions :r4
         end
 
         skip_if_not_found(resource_type: 'Procedure', delayed: false)
         must_supports = USCore310ProcedureSequenceDefinitions::MUST_SUPPORTS
-
-        missing_must_support_references = must_supports[:references].each_with_object({}) do |reference, missing_types_by_path|
-          missing_resource_types = reference[:resource_types].reject do |resource_type|
-            @procedure_ary&.values&.flatten&.any? do |resource|
-              value_found = resolve_element_from_path(resource, reference[:path]) do |value|
-                value.is_a?(FHIR::Reference) && value.reference.include?("#{resource_type}/")
-              end
-              value_found.present?
-            end
-          end
-          missing_types_by_path[reference[:path]] = missing_resource_types if missing_resource_types.present?
-        end
 
         missing_must_support_elements = must_supports[:elements].reject do |element|
           @procedure_ary&.values&.flatten&.any? do |resource|
@@ -546,9 +529,6 @@ module Inferno
 
         skip_if missing_must_support_elements.present?,
                 "Could not find #{missing_must_support_elements.join(', ')} in the #{@procedure_ary&.values&.flatten&.length} provided Procedure resource(s)"
-        skip_if missing_must_support_references.present?,
-                "Could not find the following resource type references:#{missing_must_support_references.map { |path, resource_types| path + ':' + resource_types.join(',') }.join(';')}"
-
         @instance.save!
       end
 

--- a/lib/modules/uscore_v3.1.0/us_core_provenance_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_provenance_sequence.rb
@@ -164,11 +164,6 @@ module Inferno
             * recorded
             * target
 
-
-          For elements of type 'reference' with one or more target profiles from US Core, this test will ensure that at least one of each resource type
-          associated with each US Core target profile is provided as a reference.  This test will not validate those references against their associated
-          US Core profile to reduce test complexity.
-
           )
           versions :r4
         end
@@ -181,18 +176,6 @@ module Inferno
             slice_found = find_slice(resource, slice[:path], slice[:discriminator])
             slice_found.present?
           end
-        end
-
-        missing_must_support_references = must_supports[:references].each_with_object({}) do |reference, missing_types_by_path|
-          missing_resource_types = reference[:resource_types].reject do |resource_type|
-            @provenance_ary&.any? do |resource|
-              value_found = resolve_element_from_path(resource, reference[:path]) do |value|
-                value.is_a?(FHIR::Reference) && value.reference.include?("#{resource_type}/")
-              end
-              value_found.present?
-            end
-          end
-          missing_types_by_path[reference[:path]] = missing_resource_types if missing_resource_types.present?
         end
 
         missing_must_support_elements = must_supports[:elements].reject do |element|
@@ -211,9 +194,6 @@ module Inferno
 
         skip_if missing_must_support_elements.present?,
                 "Could not find #{missing_must_support_elements.join(', ')} in the #{@provenance_ary&.length} provided Provenance resource(s)"
-        skip_if missing_must_support_references.present?,
-                "Could not find the following resource type references:#{missing_must_support_references.map { |path, resource_types| path + ':' + resource_types.join(',') }.join(';')}"
-
         @instance.save!
       end
 

--- a/lib/modules/uscore_v3.1.0/us_core_pulse_oximetry_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_pulse_oximetry_sequence.rb
@@ -625,11 +625,6 @@ module Inferno
             * value[x].unit
             * value[x].value
 
-
-          For elements of type 'reference' with one or more target profiles from US Core, this test will ensure that at least one of each resource type
-          associated with each US Core target profile is provided as a reference.  This test will not validate those references against their associated
-          US Core profile to reduce test complexity.
-
           )
           versions :r4
         end
@@ -642,18 +637,6 @@ module Inferno
             slice_found = find_slice(resource, slice[:path], slice[:discriminator])
             slice_found.present?
           end
-        end
-
-        missing_must_support_references = must_supports[:references].each_with_object({}) do |reference, missing_types_by_path|
-          missing_resource_types = reference[:resource_types].reject do |resource_type|
-            @observation_ary&.values&.flatten&.any? do |resource|
-              value_found = resolve_element_from_path(resource, reference[:path]) do |value|
-                value.is_a?(FHIR::Reference) && value.reference.include?("#{resource_type}/")
-              end
-              value_found.present?
-            end
-          end
-          missing_types_by_path[reference[:path]] = missing_resource_types if missing_resource_types.present?
         end
 
         missing_must_support_elements = must_supports[:elements].reject do |element|
@@ -672,9 +655,6 @@ module Inferno
 
         skip_if missing_must_support_elements.present?,
                 "Could not find #{missing_must_support_elements.join(', ')} in the #{@observation_ary&.values&.flatten&.length} provided Observation resource(s)"
-        skip_if missing_must_support_references.present?,
-                "Could not find the following resource type references:#{missing_must_support_references.map { |path, resource_types| path + ':' + resource_types.join(',') }.join(';')}"
-
         @instance.save!
       end
 

--- a/lib/modules/uscore_v3.1.0/us_core_pulse_oximetry_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_pulse_oximetry_sequence.rb
@@ -609,7 +609,6 @@ module Inferno
             * component.code.coding.code
             * component.code.coding.code
             * component.dataAbsentReason
-            * component.valueQuantity
             * component.value[x]
             * component.value[x].code
             * component.value[x].code
@@ -617,12 +616,9 @@ module Inferno
             * component.value[x].unit
             * component.value[x].value
             * dataAbsentReason
-            * effectiveDateTime
-            * effectivePeriod
             * effective[x]
             * status
             * subject
-            * valueQuantity
             * value[x]
             * value[x].code
             * value[x].system

--- a/lib/modules/uscore_v3.1.0/us_core_smokingstatus_sequence.rb
+++ b/lib/modules/uscore_v3.1.0/us_core_smokingstatus_sequence.rb
@@ -400,11 +400,6 @@ module Inferno
             * status
             * subject
 
-
-          For elements of type 'reference' with one or more target profiles from US Core, this test will ensure that at least one of each resource type
-          associated with each US Core target profile is provided as a reference.  This test will not validate those references against their associated
-          US Core profile to reduce test complexity.
-
           )
           versions :r4
         end
@@ -417,18 +412,6 @@ module Inferno
             slice_found = find_slice(resource, slice[:path], slice[:discriminator])
             slice_found.present?
           end
-        end
-
-        missing_must_support_references = must_supports[:references].each_with_object({}) do |reference, missing_types_by_path|
-          missing_resource_types = reference[:resource_types].reject do |resource_type|
-            @observation_ary&.values&.flatten&.any? do |resource|
-              value_found = resolve_element_from_path(resource, reference[:path]) do |value|
-                value.is_a?(FHIR::Reference) && value.reference.include?("#{resource_type}/")
-              end
-              value_found.present?
-            end
-          end
-          missing_types_by_path[reference[:path]] = missing_resource_types if missing_resource_types.present?
         end
 
         missing_must_support_elements = must_supports[:elements].reject do |element|
@@ -447,9 +430,6 @@ module Inferno
 
         skip_if missing_must_support_elements.present?,
                 "Could not find #{missing_must_support_elements.join(', ')} in the #{@observation_ary&.values&.flatten&.length} provided Observation resource(s)"
-        skip_if missing_must_support_references.present?,
-                "Could not find the following resource type references:#{missing_must_support_references.map { |path, resource_types| path + ':' + resource_types.join(',') }.join(';')}"
-
         @instance.save!
       end
 


### PR DESCRIPTION
This PR just removes the change from FI 1014 [FI 1014](https://github.com/onc-healthit/inferno-program/pull/180).
It makes it so you only have to see one choice type instead of all of them for must support tests.

**Submitter:**
- [X] This pull request describes why these changes were made
- [X] Internal ticket for this PR:
- [X] Internal ticket links to this PR
- [X] Internal ticket is properly labeled (Community/Program)
- [X] Internal ticket has a justification for its Community/Program label
- [X] Code diff has been reviewed for extraneous/missing code
- [X] Tests are included and test edge cases
- [X] Tests/code quality metrics have been run locally and pass


**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
