### PR TITLE
Update profile guesser to point to new head circumference profile.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
         source: "./resources/terminology/validators"
         target: "/var/www/inferno/resources/terminology/validators"
   validator_service:
-    image: infernocommunity/fhir-validator-service:v0.1.0
+    image: infernocommunity/fhir-validator-service:v0.1.1
     environment:
       DISABLE_TX: 'true'
   nginx_server:

--- a/lib/app/utils/validation.rb
+++ b/lib/app/utils/validation.rb
@@ -65,12 +65,12 @@ module Inferno
       lab_results: 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-lab',
       pediatric_bmi_age: 'http://hl7.org/fhir/us/core/StructureDefinition/pediatric-bmi-for-age',
       pediatric_weight_height: 'http://hl7.org/fhir/us/core/StructureDefinition/pediatric-weight-for-height',
+      head_circumference_percentile: 'http://hl7.org/fhir/us/core/StructureDefinition/head-occipital-frontal-circumference-percentile',
       pulse_oximetry: 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-pulse-oximetry',
       resp_rate: 'http://hl7.org/fhir/StructureDefinition/resprate',
       heart_rate: 'http://hl7.org/fhir/StructureDefinition/heartrate',
       body_temperature: 'http://hl7.org/fhir/StructureDefinition/bodytemp',
       body_height: 'http://hl7.org/fhir/StructureDefinition/bodyheight',
-      head_circumference: 'http://hl7.org/fhir/StructureDefinition/headcircum',
       body_weight: 'http://hl7.org/fhir/StructureDefinition/bodyweight',
       blood_pressure: 'http://hl7.org/fhir/StructureDefinition/bp'
     }.freeze
@@ -167,11 +167,13 @@ module Inferno
 
         return DEFINITIONS[US_CORE_R4_URIS[:pulse_oximetry]] if observation_contains_code(resource, '59408-5')
 
+        return DEFINITIONS[US_CORE_R4_URIS[:head_circumference_percentile]] if observation_contains_code(resource, '8289-1')
+
         # FHIR Vital Signs profiles: https://www.hl7.org/fhir/observation-vitalsigns.html
         # Vital Signs Panel, Oxygen Saturation are not required by USCDI
         # Body Mass Index is replaced by :pediatric_bmi_age Profile
         # Systolic Blood Pressure, Diastolic Blood Pressure are covered by :blood_pressure Profile
-        # Head Circumference will be replaced by US Core Head Occipital-frontal Circumference Percentile Profile
+        # Head Circumference is replaced by US Core Head Occipital-frontal Circumference Percentile Profile
         return DEFINITIONS[US_CORE_R4_URIS[:blood_pressure]] if observation_contains_code(resource, '85354-9')
 
         return DEFINITIONS[US_CORE_R4_URIS[:body_height]] if observation_contains_code(resource, '8302-2')
@@ -179,8 +181,6 @@ module Inferno
         return DEFINITIONS[US_CORE_R4_URIS[:body_temperature]] if observation_contains_code(resource, '8310-5')
 
         return DEFINITIONS[US_CORE_R4_URIS[:body_weight]] if observation_contains_code(resource, '29463-7')
-
-        return DEFINITIONS[US_CORE_R4_URIS[:head_circumference]] if observation_contains_code(resource, '9843-4')
 
         return DEFINITIONS[US_CORE_R4_URIS[:heart_rate]] if observation_contains_code(resource, '8867-4')
 

--- a/lib/modules/onc_program/bulk_data_group_validation_sequence.rb
+++ b/lib/modules/onc_program/bulk_data_group_validation_sequence.rb
@@ -728,18 +728,20 @@ module Inferno
           name 'Observation resources returned conform to the US Core Observation Profiles'
           link 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-lab'
           description %(
-            This test verifies that the resources returned from bulk data export conform to the following US Core profiles. This includes checking for missing data elements and value set verification.
+            This test verifies that the resources returned from bulk data
+            export conform to the following US Core profiles. This includes
+            checking for missing data elements and value set verification.
 
             * http://hl7.org/fhir/us/core/StructureDefinition/pediatric-bmi-for-age
             * http://hl7.org/fhir/us/core/StructureDefinition/pediatric-weight-for-height
             * http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-lab
             * http://hl7.org/fhir/us/core/StructureDefinition/us-core-pulse-oximetry
             * http://hl7.org/fhir/us/core/StructureDefinition/us-core-smokingstatus
+            * http://hl7.org/fhir/us/core/StructureDefinition/head-occipital-frontal-circumference-percentile
             * http://hl7.org/fhir/StructureDefinition/bp
             * http://hl7.org/fhir/StructureDefinition/bodyheight
             * http://hl7.org/fhir/StructureDefinition/bodytemp
             * http://hl7.org/fhir/StructureDefinition/bodyweight
-            * http://hl7.org/fhir/StructureDefinition/headcircum
             * http://hl7.org/fhir/StructureDefinition/heartrate
             * http://hl7.org/fhir/StructureDefinition/resprate
           )
@@ -792,7 +794,7 @@ module Inferno
             binding_info: USCore311BodyweightSequenceDefinitions::BINDINGS.dup
           },
           {
-            profile: US_CORE_R4_URIS[:head_circumference],
+            profile: US_CORE_R4_URIS[:head_circumference_percentile],
             must_support_info: USCore311HeadOccipitalFrontalCircumferencePercentileSequenceDefinitions::MUST_SUPPORTS.dup,
             binding_info: USCore311HeadOccipitalFrontalCircumferencePercentileSequenceDefinitions::BINDINGS.dup
           },

--- a/lib/modules/us_core_guidance/us_core_r4_capability_statement_sequence.rb
+++ b/lib/modules/us_core_guidance/us_core_r4_capability_statement_sequence.rb
@@ -83,7 +83,7 @@ module Inferno
           'http://hl7.org/fhir/StructureDefinition/heartrate',
           'http://hl7.org/fhir/StructureDefinition/resprate',
           'http://hl7.org/fhir/StructureDefinition/bodytemp',
-          'http://hl7.org/fhir/StructureDefinition/headcircum'
+          'http://hl7.org/fhir/us/core/StructureDefinition/head-occipital-frontal-circumference-percentile'
         ],
         'Organization' => ['http://hl7.org/fhir/us/core/StructureDefinition/us-core-organization'],
         'Patient' => ['http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient'],


### PR DESCRIPTION
Builds on update to v3.1.1 to ensure that the profile identification tool chooses the right profile head circumference profile to validate against based on the code.

FYI @yunwwang 