### PR TITLE
Update attestations for new ccg.

### DIFF
--- a/lib/app/views/onc_program.erb
+++ b/lib/app/views/onc_program.erb
@@ -364,12 +364,6 @@
             description: ''
           },
           {
-            field: :onc_visual_other_resources,
-            notes_field: :onc_visual_other_resources_notes, 
-            label: 'Health IT developer confirms support for the PractitionerRole and RelatedPerson resources to fulfill must support requirements of referenced elements within US Core profiles.',
-            description: ''
-          },
-          {
             field: :onc_visual_jwks_cache,
             notes_field: :onc_visual_jwks_cache_notes, 
             label: 'Health IT developer confirms the Health IT module does not cache the JWK Set received via a TLS-protected URL for longer than the cache-control header indicates.',
@@ -395,9 +389,9 @@
             description: ''
           },
           {
-            field: :onc_visual_allergy_reaction,
-            notes_field: :onc_visual_allergy_reaction_notes,
-            label: 'Health IT developer demonstrates support for the Allergy and Intolerances Reaction USCDI v1 element.',
+            field: :onc_visual_native_application,
+            notes_field: :onc_visual_native_application_notes,
+            label: 'Health IT developer demonstrates support for issuing refresh tokens to native applications.',
             description: ''
           }
             ].each do |field| %>

--- a/lib/modules/onc_program/onc_parameters.rb
+++ b/lib/modules/onc_program/onc_parameters.rb
@@ -52,6 +52,8 @@ module Inferno
 
       property :onc_visual_token_revocation, String, default: 'false'
       property :onc_visual_token_revocation_notes, String
+      property :onc_visual_native_application, String, default: 'false'
+      property :onc_visual_native_application_notes, String
     end
   end
 end

--- a/lib/modules/onc_program/onc_visual_inspection_sequence.rb
+++ b/lib/modules/onc_program/onc_visual_inspection_sequence.rb
@@ -25,7 +25,15 @@ module Inferno
                :onc_visual_multi_scopes_no_greater,
                :onc_visual_multi_scopes_no_greater_notes,
                :onc_visual_documentation,
-               :onc_visual_documentation_notes
+               :onc_visual_documentation_notes,
+               :onc_visual_jwks_cache,
+               :onc_visual_jwks_cache_notes,
+               :onc_visual_jwks_token_revocation,
+               :onc_visual_jwks_token_revocation_notes,
+               :onc_visual_patient_period,
+               :onc_visual_patient_period_notes,
+               :onc_visual_native_application,
+               :onc_visual_native_application_notes
 
       test 'Health IT Module demonstrated support for application registration for single patients.' do
         metadata do
@@ -144,22 +152,9 @@ module Inferno
         pass @instance.onc_visual_documentation_notes if @instance.onc_visual_documentation_notes.present?
       end
 
-      test 'Health IT developer confirms support for the PractitionerRole and RelatedPerson resources to fulfill must support requirements of referenced elements within US Core profiles.' do
-        metadata do
-          id '10'
-          link 'https://www.federalregister.gov/documents/2020/05/01/2020-07419/21st-century-cures-act-interoperability-information-blocking-and-the-onc-health-it-certification'
-          description %(
-            Health IT developer confirms support for the PractitionerRole and RelatedPerson resources to fulfill must support requirements of referenced elements within US Core profiles.
-          )
-        end
-
-        assert @instance.onc_visual_other_resources == 'true', 'Health IT developer did not confirm support for the PractitionerRole and RelatedPerson resources.'
-        pass @instance.onc_visual_other_resources_notes if @instance.onc_visual_other_resources_notes.present?
-      end
-
       test 'Health IT developer confirms the Health IT module does not cache the JWK Set received via a TLS-protected URL for longer than the cache-control header received by an application indicates.' do
         metadata do
-          id '11'
+          id '10'
           link 'https://www.federalregister.gov/documents/2020/05/01/2020-07419/21st-century-cures-act-interoperability-information-blocking-and-the-onc-health-it-certification'
           description %(
             The Health IT developer confirms the Health IT module does not cache the JWK Set received via a TLS-protected URL for longer than the cache-control header indicates.
@@ -172,11 +167,11 @@ module Inferno
 
       test 'Health IT developer demonstrates support for the Patient Demographics Suffix USCDI v1 element.' do
         metadata do
-          id '12'
+          id '11'
           link 'https://www.healthit.gov/isa/united-states-core-data-interoperability-uscdi'
           description %(
             ONC certification criteria states that all USCDI v1 data classes and elements need to be supported, including Patient
-            Demographics - Suffix.However, US Core v3.1 does not currently tag the relevant element
+            Demographics - Suffix.However, US Core v3.1.1 does not tag the relevant element
             (Patient.name.suffix) as MUST SUPPORT. The Health IT developer must demonstrate support
             for this USCDI v1 element.
           )
@@ -188,11 +183,11 @@ module Inferno
 
       test 'Health IT developer demonstrates support for the Patient Demographics Previous Name USCDI v1 element.' do
         metadata do
-          id '13'
+          id '12'
           link 'https://www.healthit.gov/isa/united-states-core-data-interoperability-uscdi'
           description %(
             ONC certification criteria states that all USCDI v1 data classes and elements need to be supported, including Patient
-            Demographics - Previous Name. However, US Core v3.1 does not currently tag the relevant element
+            Demographics - Previous Name. However, US Core v3.1.1 does not tag the relevant element
             (Patient.name.period) as MUST SUPPORT. The Health IT developer must demonstrate support
             for this USCDI v1 element.
           )
@@ -202,20 +197,25 @@ module Inferno
         pass @instance.onc_visual_patient_period_notes if @instance.onc_visual_patient_period_notes.present?
       end
 
-      test 'Health IT developer demonstrates support for the Allergy and Intolerances Reaction USCDI v1 element.' do
+      test 'Health IT developer demonstrates support for issuing refresh tokens to native applications.' do
         metadata do
-          id '14'
-          link 'https://www.healthit.gov/isa/united-states-core-data-interoperability-uscdi'
+          id '13'
+          link 'https://www.federalregister.gov/documents/2020/11/04/2020-24376/information-blocking-and-the-onc-health-it-certification-program-extension-of-compliance-dates-and'
           description %(
-            ONC certification criteria states that all USCDI v1 needs to be supported, including Allergies
-            and Intolerances - Reaction. However, US Core v3.1 does not currently tag the relevant element
-            (AllergyIntolerance.reaction) as MUST SUPPORT. The Health IT developer must demonstrate support
-            for this USCDI v1 element.
+            The health IT developer demonstrates the ability of the Health IT
+            Module to grant a refresh token valid for a period of no less
+            than three months to native applications capable of storing a
+            refresh token.
+
+            This cannot be tested in an automated way because the health IT
+            developer may require use of additional security mechanisms within
+            the OAuth 2.0 authorization flow to ensure authorization is sufficiently
+            secure for native applications.
           )
         end
 
-        assert @instance.onc_visual_allergy_reaction == 'true', 'Health IT developer did not demonstrate that Allergy and Intolerance Reaction is supported.'
-        pass @instance.onc_visual_allergy_reaction_notes if @instance.onc_visual_allergy_reaction_notes.present?
+        assert @instance.onc_visual_native_application == 'true', 'Health IT developer did not demonstrate support for issuing refresh tokens to native applications.'
+        pass @instance.onc_visual_native_application_notes if @instance.onc_visual_native_application_notes.present?
       end
     end
   end

--- a/lib/modules/onc_program_procedure.yml
+++ b/lib/modules/onc_program_procedure.yml
@@ -593,18 +593,31 @@ procedure:
         inferno_tests:
           - SPD-TR-03 - SPD-TR-05
           - EHD-TR-03 - EHD-TR-05
+      - id: AUTH-PATIENT-21
+        SUT: |
+          [Both] The health IT developer demonstrates the ability of the
+          Health IT Module to grant a refresh token valid for a period of no
+          less than three months to native applications capable of storing a
+          refresh token.
+        TLV: |
+          [Both] The tester verifies the ability of the Health IT Module to
+          grant a refresh token valid for a period of no less than three
+          months to native applications capable of storing a refresh token.
+        inferno_supported: 'yes'
+        inferno_tests:
+          - ATT-13
       - group: 'Subsequent Connections: Authentication and Authorization for Patient and User Scopes'
-        id: AUTH-PATIENT-21
+        id: AUTH-PATIENT-22
         SUT: | 
           The health IT developer demonstrates the ability of the Health IT
-          Module to issue a new refresh token valid for a period of no
+          Module to issue a new refresh token valid for a new period of no
           shorter than three months without requiring re-authentication
           and re-authorization when a valid refresh token is supplied by the
           application according to the implementation specification adopted
           in § 170.215(a)(3).
         TLV: | 
           The tester verifies the ability of the Health IT
-          Module to issue a new refresh token valid for a period of no
+          Module to issue a new refresh token valid for a new period of no
           shorter than three months without requiring re-authentication
           and re-authorization when a valid refresh token is supplied by the
           application according to the implementation specification adopted
@@ -620,7 +633,7 @@ procedure:
           as part of the certification criteria.  Inferno cannot verify the
           three month token expiration requirement, but the tester can
           register an attestation that this requirement is met.
-      - id: AUTH-PATIENT-22
+      - id: AUTH-PATIENT-23
         SUT: |
           The health IT developer demonstrates the ability of the Health IT
           Module to return an error response when supplied an invalid
@@ -749,7 +762,7 @@ procedure:
           This test requires the tester to register an attestation from the
           Health IT Module that the "cache-control" header is obeyed.
         inferno_tests:
-          - ATT-11
+          - ATT-10
       - id: AUTH-SYSTEM-6
         SUT: |
           The health IT developer demonstrates the ability of the Health IT
@@ -1061,9 +1074,8 @@ procedure:
         inferno_supported: 'yes'
         inferno_tests:
           - ATT-07
+          - ATT-11
           - ATT-12
-          - ATT-13
-          - ATT-14
           - USCP-02
           - USCAI-02
           - USCCP-02


### PR DESCRIPTION
This does the following:

* Adds attestation for native clients
* Removes attestations for relatedperson / practitionerrole because they are no longer referenced by USCDI-mapped profiles
* Removes AllergyIntolerance reaction attestation becasue that is now handled by US Core v3.1.1 must supports
* Updates test procedure language to match newest published version
* Updates mapping to ensure test numbers are mapped to their appropriate test.