### PR TITLE
FI-1078 Scrub scopes of PractitionerRole and RelatedPerson

### DIFF
--- a/generator/uscore/templates/access_verify_sequence.rb.erb
+++ b/generator/uscore/templates/access_verify_sequence.rb.erb
@@ -11,32 +11,41 @@ module Inferno
       description 'Verify that patients have control over which resource types can be accessed.'
       test_id_prefix 'AVR'
       details %(
-        This test ensures that patients are able to grant or deny access to a subset of resources to an app.
-        It also verifies that patients can prevent issuance of a refresh token by denying the `offline_access` scope.  The tester provides a list of resources
-        that will be granted during the SMART App Launch process, and this test verifies that the scopes granted
-        are consistent with what the tester provided.  It also formulates queries to ensure that the app
-        is either given access to, or denied access to, the appropriate resource types based on those chosen
-        by the tester.
-        
+        This test ensures that patients are able to grant or deny access to a
+        subset of resources to an app. It also verifies that patients can
+        prevent issuance of a refresh token by denying the `offline_access`
+        scope. The tester provides a list of resources that will be granted
+        during the SMART App Launch process, and this test verifies that the
+        scopes granted are consistent with what the tester provided. It also
+        formulates queries to ensure that the app is either given access to,
+        or denied access to, the appropriate resource types based on those
+        chosen by the tester.
+ 
         Resources that can be mapped to USCDI are checked in this test, including:
         <% non_delayed_sequences.group_by{|sequence| sequence[:resource]}.values.map(&:first).each do |resource| %>
           * <%= resource[:resource]%><% end %>
 
-        For each of the resources that can be mapped to USCDI data class or elements, this set of tests
-        performs a minimum number of requests to determine if access to the resource type is appropriately allowed or denied given the
-        scope granted.  In the case of the Patient resource, this test simply performs a read request.
-        For other resources, it performs a search by patient that must be supported by the server.  In some cases,
-        servers can return an error message if a status search parameter is not provided.  For these, the
-        test will perform an additional search with the required status search parameter.
+        For each of the resources that can be mapped to USCDI data class or
+        elements, this set of tests performs a minimum number of requests to
+        determine if access to the resource type is appropriately allowed or
+        denied given the scope granted. In the case of the Patient resource,
+        this test simply performs a read request. For other resources, it
+        performs a search by patient that must be supported by the server. In
+        some cases, servers can return an error message if a status search
+        parameter is not provided. For these, the test will perform an
+        additional search with the required status search parameter.
+ 
+        This set of tests does not attempt to access resources that do not
+        directly map to USCDI v1, including Encounter, Location,
+        Organization, and Practitioner. It also does not test Provenance, as
+        this resource type is accessed by queries through other resource
+        types. These resource types are accessed in the more comprehensive
+        Single Patient Query tests.
 
-        This set of tests does not attempt to access resources that do not directly map to USCDI v1, including Encounter, Location,
-        Organization, Practitioner, PractionerRole, and RelatedPerson.  It also does not test Provenance, as this
-        resource type is accessed by queries through other resource types.  These resource types are accessed in the more
-        comprehensive Single Patient Query tests.
-
-        If the tester chooses to not grant access to a resource, the queries associated with that resource must
-        result in either a 401 (Unauthorized) or 403 (Forbidden) status code.  The flexiblity provided here
-        is due to some ambiguity in the specifications tested.
+        If the tester chooses to not grant access to a resource, the queries
+        associated with that resource must result in either a 401
+        (Unauthorized) or 403 (Forbidden) status code. The flexiblity
+        provided here is due to some ambiguity in the specifications tested.
       )
       <% else %>
       <%# METADATA FOR FULL ACCESS TEST %>
@@ -62,7 +71,7 @@ module Inferno
         test will perform an additional search with the required status search parameter.
   
         This set of tests does not attempt to access resources that do not directly map to USCDI v1, including Encounter, Location,
-        Organization, Practitioner, PractionerRole, and RelatedPerson.  It also does not test Provenance, as this
+        Organization, and Practitioner.  It also does not test Provenance, as this
         resource type is accessed by queries through other resource types. These resources types are accessed in the more
         comprehensive Single Patient Query tests.
 
@@ -134,10 +143,13 @@ module Inferno
 
 
        <% if access_verify_restriction == 'restricted' %>
-        # Consider all directly-mapped USCDI resources only.  Do not fail based on the inclusion/Exclusion of Encounter, Practitioner
-        # PractitionerRole, Location, Organization, or RelatedPerson because the SUT has flexibility to decide if those
-        # should be included or not based on whether other resources are selected (e.g. if Observation then maybe it makes
-        # sense to include Encounter scope) without having the user be in charge of that particular choice.
+        # Consider all directly-mapped USCDI resources only. Do not fail based
+        # on the inclusion/Exclusion of Encounter, Practitioner, Location or
+        # Organization, because the SUT has flexibility to decide if those
+        # should be included or not based on whether other resources are
+        # selected (e.g. if Observation then maybe it makes sense to include
+        # Encounter scope) without having the user be in charge of that
+        # particular choice.
         
         all_resources = [
         <%= non_delayed_sequences.group_by{|sequence| sequence[:resource]}.values.map(&:first).map{|resource| "'#{resource[:resource]}'"}.join(",\n") %>,
@@ -157,7 +169,7 @@ module Inferno
        <% else %>
        # Consider all directly-mapped USCDI resources, as well as Encounter, Practitioner and Organization
        # because they have US Core Profile references in the other US Core Profiles.  This excludes
-       # PractionerRole, Location and RelatedPerson because they do not have US Core Profile references
+       # Location because it does not have US Core Profile references
        # and therefore could be 'contained' and do not have a read interaction requirement.
        all_resources = [
        <%= non_delayed_sequences.group_by{|sequence| sequence[:resource]}.values.map(&:first).map{|resource| "'#{resource[:resource]}'"}.join(",\n") %>,

--- a/generator/uscore/templates/unit_tests/access_verify_restricted_unit_test.rb.erb
+++ b/generator/uscore/templates/unit_tests/access_verify_restricted_unit_test.rb.erb
@@ -70,8 +70,8 @@ describe Inferno::Sequence::USCore<%=reformatted_version%>ONCAccessVerifyRestric
       assert_raises(Inferno::PassException) { @sequence.run_test(@test) }
     end
 
-    it 'passes if Practitioner, Organization, Encounter, PractitionerRole, Location, RelatedPerson scope provided' do
-      @instance.received_scopes = 'patient/PractitionerRole.read patient/Location.read patient/RelatedPerson.read launch/patient openid fhirUser patient/Observation.read '\
+    it 'passes if Practitioner, Organization, Encounter, Location scope provided' do
+      @instance.received_scopes = 'patient/Location.read launch/patient openid fhirUser patient/Observation.read '\
                                   'patient/Condition.read patient/Patient.read patient/Encounter.read patient/Practitioner.read patient/Organization.read'
       assert_raises(Inferno::PassException) { @sequence.run_test(@test) }
     end
@@ -99,8 +99,8 @@ describe Inferno::Sequence::USCore<%=reformatted_version%>ONCAccessVerifyRestric
       @instance.received_scopes = 'launch/patient openid fhirUser offline_access patient/Medication.read patient/AllergyIntolerance.read patient/CarePlan.read '\
                                   'patient/CareTeam.read patient/Condition.read patient/Device.read patient/DiagnosticReport.read patient/DocumentReference.read '\
                                   'patient/Encounter.read patient/Goal.read patient/Immunization.read patient/Location.read patient/MedicationRequest.read '\
-                                  'patient/Observation.read patient/Organization.read patient/Patient.read patient/Practitioner.read patient/PractitionerRole.read '\
-                                  'patient/Procedure.read patient/Provenance.read patient/RelatedPerson.read'
+                                  'patient/Observation.read patient/Organization.read patient/Patient.read patient/Practitioner.read '\
+                                  'patient/Procedure.read patient/Provenance.read'
       @instance.onc_sl_expected_resources = 'Observation, Condition, Patient'
     end
 

--- a/generator/uscore/templates/unit_tests/access_verify_unrestricted_unit_test.rb.erb
+++ b/generator/uscore/templates/unit_tests/access_verify_unrestricted_unit_test.rb.erb
@@ -27,8 +27,8 @@ describe Inferno::Sequence::USCore<%=reformatted_version%>ONCAccessVerifyUnrestr
       @instance.received_scopes = 'launch/patient openid fhirUser offline_access patient/Medication.read patient/AllergyIntolerance.read patient/CarePlan.read '\
                                   'patient/CareTeam.read patient/Condition.read patient/Device.read patient/DiagnosticReport.read patient/DocumentReference.read '\
                                   'patient/Encounter.read patient/Goal.read patient/Immunization.read patient/Location.read patient/MedicationRequest.read '\
-                                  'patient/Observation.read patient/Organization.read patient/Patient.read patient/Practitioner.read patient/PractitionerRole.read '\
-                                  'patient/Procedure.read patient/Provenance.read patient/RelatedPerson.read'
+                                  'patient/Observation.read patient/Organization.read patient/Patient.read patient/Practitioner.read '\
+                                  'patient/Procedure.read patient/Provenance.read'
       assert_raises(Inferno::PassException) { @sequence.run_test(@test) }
     end
 
@@ -47,11 +47,11 @@ describe Inferno::Sequence::USCore<%=reformatted_version%>ONCAccessVerifyUnrestr
                                   'patient/CareTeam.* patient/Condition.* patient/Device.* patient/DiagnosticReport.* patient/DocumentReference.* '\
                                   'patient/Encounter.* patient/Goal.* patient/Immunization.* patient/Location.* patient/MedicationRequest.* '\
                                   'patient/Observation.* patient/Organization.* patient/Patient.* patient/Practitioner.* patient/PractitionerRole.* '\
-                                  'patient/Procedure.* patient/Provenance.* patient/RelatedPerson.*'
+                                  'patient/Procedure.* patient/Provenance.*'
       assert_raises(Inferno::PassException) { @sequence.run_test(@test) }
     end
 
-    it 'passes if Medication, PractitionerRole, Location and RelatedPerson are omitted' do
+    it 'passes if Medication and Location are omitted' do
       @instance.received_scopes = 'launch/patient openid fhirUser offline_access patient/AllergyIntolerance.read patient/CarePlan.read '\
                                   'patient/CareTeam.read patient/Condition.read patient/Device.read patient/DiagnosticReport.read patient/DocumentReference.read '\
                                   'patient/Encounter.read patient/Goal.read patient/Immunization.read patient/MedicationRequest.read '\
@@ -64,8 +64,8 @@ describe Inferno::Sequence::USCore<%=reformatted_version%>ONCAccessVerifyUnrestr
       @instance.received_scopes = 'launch/patient openid fhirUser offline_access patient/Medication.read patient/AllergyIntolerance.read patient/CarePlan.read '\
                                   'patient/CareTeam.read patient/Condition.read patient/Device.read patient/DiagnosticReport.read patient/DocumentReference.read '\
                                   'patient/Encounter.read patient/Goal.read patient/Immunization.read patient/Location.read patient/MedicationRequest.read '\
-                                  'patient/Observation.read patient/Organization.read patient/Patient.read patient/Practitioner.read patient/PractitionerRole.read '\
-                                  'patient/Procedure.read patient/Provenance.read patient/RelatedPerson.read proprietary_scope'
+                                  'patient/Observation.read patient/Organization.read patient/Patient.read patient/Practitioner.read '\
+                                  'patient/Procedure.read patient/Provenance.read proprietary_scope'
       assert_raises(Inferno::PassException) { @sequence.run_test(@test) }
     end
 
@@ -73,8 +73,8 @@ describe Inferno::Sequence::USCore<%=reformatted_version%>ONCAccessVerifyUnrestr
       @instance.received_scopes = 'launch/patient openid fhirUser offline_access patient/Medication.read patient/AllergyIntolerance.read patient/CarePlan.read '\
                                   'patient/CareTeam.read patient/Condition.read patient/Device.read patient/DiagnosticReport.read patient/DocumentReference.read '\
                                   'patient/Encounter.read patient/Goal.read patient/Immunization.read patient/Location.read patient/MedicationRequest.read '\
-                                  'patient/Observation.read patient/Organization.read patient/Practitioner.read patient/PractitionerRole.read '\
-                                  'patient/Procedure.read patient/Provenance.read patient/RelatedPerson.read'
+                                  'patient/Observation.read patient/Organization.read patient/Practitioner.read '\
+                                  'patient/Procedure.read patient/Provenance.read'
       assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
     end
 
@@ -82,8 +82,8 @@ describe Inferno::Sequence::USCore<%=reformatted_version%>ONCAccessVerifyUnrestr
       @instance.received_scopes = 'launch/patient openid fhirUser offline_access patient/Medication.read patient/CarePlan.read '\
                                   'patient/CareTeam.read patient/Condition.read patient/Device.read patient/DiagnosticReport.read patient/DocumentReference.read '\
                                   'patient/Encounter.read patient/Goal.read patient/Immunization.read patient/Location.read patient/MedicationRequest.read '\
-                                  'patient/Observation.read patient/Organization.read patient/Patient.read patient/Practitioner.read patient/PractitionerRole.read '\
-                                  'patient/Procedure.read patient/Provenance.read patient/RelatedPerson.read'
+                                  'patient/Observation.read patient/Organization.read patient/Patient.read patient/Practitioner.read '\
+                                  'patient/Procedure.read patient/Provenance.read'
       assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
     end
 
@@ -91,8 +91,8 @@ describe Inferno::Sequence::USCore<%=reformatted_version%>ONCAccessVerifyUnrestr
       @instance.received_scopes = 'launch/patient openid fhirUser offline_access patient/Medication.read patient/AllergyIntolerance.read patient/CarePlan.read '\
                                   'patient/CareTeam.read patient/Condition.read patient/Device.read patient/DiagnosticReport.read patient/DocumentReference.read '\
                                   'patient/Encounter.read patient/Goal.read patient/Immunization.read patient/Location.read patient/MedicationRequest.read '\
-                                  'patient/Observation.read patient/Organization.read patient/Patient.read patient/PractitionerRole.read '\
-                                  'patient/Procedure.read patient/Provenance.read patient/RelatedPerson.read'
+                                  'patient/Observation.read patient/Organization.read patient/Patient.read '\
+                                  'patient/Procedure.read patient/Provenance.read'
       assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
     end
   end
@@ -104,8 +104,8 @@ describe Inferno::Sequence::USCore<%=reformatted_version%>ONCAccessVerifyUnrestr
       @instance.received_scopes = 'launch/patient openid fhirUser offline_access patient/Medication.read patient/AllergyIntolerance.read patient/CarePlan.read '\
                                   'patient/CareTeam.read patient/Condition.read patient/Device.read patient/DiagnosticReport.read patient/DocumentReference.read '\
                                   'patient/Encounter.read patient/Goal.read patient/Immunization.read patient/Location.read patient/MedicationRequest.read '\
-                                  'patient/Observation.read patient/Organization.read patient/Patient.read patient/Practitioner.read patient/PractitionerRole.read '\
-                                  'patient/Procedure.read patient/Provenance.read patient/RelatedPerson.read'
+                                  'patient/Observation.read patient/Organization.read patient/Patient.read patient/Practitioner.read '\
+                                  'patient/Procedure.read patient/Provenance.read'
     end
 
     it 'passes if success response received' do
@@ -139,8 +139,8 @@ describe Inferno::Sequence::USCore<%=reformatted_version%>ONCAccessVerifyUnrestr
       @instance.received_scopes = 'launch/patient openid fhirUser offline_access patient/Medication.read patient/AllergyIntolerance.read patient/CarePlan.read '\
                                   'patient/CareTeam.read patient/Condition.read patient/Device.read patient/DiagnosticReport.read patient/DocumentReference.read '\
                                   'patient/Encounter.read patient/Goal.read patient/Immunization.read patient/Location.read patient/MedicationRequest.read '\
-                                  'patient/Observation.read patient/Organization.read patient/Patient.read patient/Practitioner.read patient/PractitionerRole.read '\
-                                  'patient/Procedure.read patient/Provenance.read patient/RelatedPerson.read'
+                                  'patient/Observation.read patient/Organization.read patient/Patient.read patient/Practitioner.read '\
+                                  'patient/Procedure.read patient/Provenance.read'
     end
 
     it 'passes if success response received' do

--- a/lib/app/views/onc_program.erb
+++ b/lib/app/views/onc_program.erb
@@ -560,7 +560,7 @@
               label: 'EHR-launched Scope',
               description: 'OAuth 2.0 scope provided by system to enable all required functionality',
               instance: instance,
-              value: instance.scopes || 'launch openid fhirUser offline_access user/Medication.read user/AllergyIntolerance.read user/CarePlan.read user/CareTeam.read user/Condition.read user/Device.read user/DiagnosticReport.read user/DocumentReference.read user/Encounter.read user/Goal.read user/Immunization.read user/Location.read user/MedicationRequest.read user/Observation.read user/Organization.read user/Patient.read user/Practitioner.read user/PractitionerRole.read user/Procedure.read user/Provenance.read user/RelatedPerson.read',
+              value: instance.scopes || 'launch openid fhirUser offline_access user/Medication.read user/AllergyIntolerance.read user/CarePlan.read user/CareTeam.read user/Condition.read user/Device.read user/DiagnosticReport.read user/DocumentReference.read user/Encounter.read user/Goal.read user/Immunization.read user/Location.read user/MedicationRequest.read user/Observation.read user/Organization.read user/Patient.read user/Practitioner.read user/Procedure.read user/Provenance.read',
               type: 'textarea',
               required: true,
               })%>
@@ -570,7 +570,7 @@
               description: 'OAuth 2.0 scope provided by system to enable all required functionality',
               instance: instance,
               type: 'textarea',
-              value: instance.onc_sl_scopes || 'launch/patient openid fhirUser offline_access patient/Medication.read patient/AllergyIntolerance.read patient/CarePlan.read patient/CareTeam.read patient/Condition.read patient/Device.read patient/DiagnosticReport.read patient/DocumentReference.read patient/Encounter.read patient/Goal.read patient/Immunization.read patient/Location.read patient/MedicationRequest.read patient/Observation.read patient/Organization.read patient/Patient.read patient/Practitioner.read patient/PractitionerRole.read patient/Procedure.read patient/Provenance.read patient/RelatedPerson.read'
+              value: instance.onc_sl_scopes || 'launch/patient openid fhirUser offline_access patient/Medication.read patient/AllergyIntolerance.read patient/CarePlan.read patient/CareTeam.read patient/Condition.read patient/Device.read patient/DiagnosticReport.read patient/DocumentReference.read patient/Encounter.read patient/Goal.read patient/Immunization.read patient/Location.read patient/MedicationRequest.read patient/Observation.read patient/Organization.read patient/Patient.read patient/Practitioner.read patient/Procedure.read patient/Provenance.read'
                })%>
 
         <%= erb(:prerequisite_field,{},{prerequisite: :onc_public_scopes,
@@ -578,7 +578,7 @@
               description: 'OAuth 2.0 scope provided by system to enable public client access for a patient standalone launch',
               instance: instance,
               type: 'textarea',
-              value: instance.onc_public_scopes || 'launch/patient openid fhirUser patient/Medication.read patient/AllergyIntolerance.read patient/CarePlan.read patient/CareTeam.read patient/Condition.read patient/Device.read patient/DiagnosticReport.read patient/DocumentReference.read patient/Encounter.read patient/Goal.read patient/Immunization.read patient/Location.read patient/MedicationRequest.read patient/Observation.read patient/Organization.read patient/Patient.read patient/Practitioner.read patient/PractitionerRole.read patient/Procedure.read patient/Provenance.read patient/RelatedPerson.read'
+              value: instance.onc_public_scopes || 'launch/patient openid fhirUser patient/Medication.read patient/AllergyIntolerance.read patient/CarePlan.read patient/CareTeam.read patient/Condition.read patient/Device.read patient/DiagnosticReport.read patient/DocumentReference.read patient/Encounter.read patient/Goal.read patient/Immunization.read patient/Location.read patient/MedicationRequest.read patient/Observation.read patient/Organization.read patient/Patient.read patient/Practitioner.read patient/Procedure.read patient/Provenance.read'
                })%>
 
         <%= erb(:prerequisite_field,{},{prerequisite: :onc_sl_expected_resources,

--- a/lib/app/views/onc_program.erb
+++ b/lib/app/views/onc_program.erb
@@ -667,7 +667,7 @@
               description: 'Bulk Data Scopes provided at registration to the Inferno application.',
               instance: instance,
               type: 'textarea',
-              value: instance.bulk_scope || 'system/Medication.read system/AllergyIntolerance.read system/CarePlan.read system/CareTeam.read system/Condition.read system/Device.read system/DiagnosticReport.read system/DocumentReference.read system/Encounter.read system/Goal.read system/Immunization.read system/Location.read system/MedicationRequest.read system/Observation.read system/Organization.read system/Practitioner.read system/PractitionerRole.read system/Procedure.read system/Provenance.read system/RelatedPerson.read',
+              value: instance.bulk_scope || 'system/Medication.read system/AllergyIntolerance.read system/CarePlan.read system/CareTeam.read system/Condition.read system/Device.read system/DiagnosticReport.read system/DocumentReference.read system/Encounter.read system/Goal.read system/Immunization.read system/Location.read system/MedicationRequest.read system/Observation.read system/Organization.read system/Practitioner.read system/Procedure.read system/Provenance.read',
               })%>  
 
         <div class="form-group"

--- a/lib/modules/onc_program/bulk_data_group_validation_sequence.rb
+++ b/lib/modules/onc_program/bulk_data_group_validation_sequence.rb
@@ -20,7 +20,7 @@ module Inferno
       MAX_RECENT_LINE_SIZE = 100
       MIN_RESOURCE_COUNT = 2
 
-      NON_US_CORE_KLASS = ['Location', 'PractitionerRole', 'RelatedPerson'].freeze
+      NON_US_CORE_KLASS = ['Location'].freeze
       OMIT_KLASS = ['Medication'].concat(NON_US_CORE_KLASS)
 
       US_CORE_R4_URIS = Inferno::ValidationUtil::US_CORE_R4_URIS

--- a/lib/modules/uscore_v3.1.1/access_verify_restricted_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/access_verify_restricted_sequence.rb
@@ -8,12 +8,15 @@ module Inferno
       description 'Verify that patients have control over which resource types can be accessed.'
       test_id_prefix 'AVR'
       details %(
-        This test ensures that patients are able to grant or deny access to a subset of resources to an app.
-        It also verifies that patients can prevent issuance of a refresh token by denying the `offline_access` scope.  The tester provides a list of resources
-        that will be granted during the SMART App Launch process, and this test verifies that the scopes granted
-        are consistent with what the tester provided.  It also formulates queries to ensure that the app
-        is either given access to, or denied access to, the appropriate resource types based on those chosen
-        by the tester.
+        This test ensures that patients are able to grant or deny access to a
+        subset of resources to an app. It also verifies that patients can
+        prevent issuance of a refresh token by denying the `offline_access`
+        scope. The tester provides a list of resources that will be granted
+        during the SMART App Launch process, and this test verifies that the
+        scopes granted are consistent with what the tester provided. It also
+        formulates queries to ensure that the app is either given access to,
+        or denied access to, the appropriate resource types based on those
+        chosen by the tester.
 
         Resources that can be mapped to USCDI are checked in this test, including:
 
@@ -30,21 +33,27 @@ module Inferno
           * Observation
           * Procedure
 
-        For each of the resources that can be mapped to USCDI data class or elements, this set of tests
-        performs a minimum number of requests to determine if access to the resource type is appropriately allowed or denied given the
-        scope granted.  In the case of the Patient resource, this test simply performs a read request.
-        For other resources, it performs a search by patient that must be supported by the server.  In some cases,
-        servers can return an error message if a status search parameter is not provided.  For these, the
-        test will perform an additional search with the required status search parameter.
+        For each of the resources that can be mapped to USCDI data class or
+        elements, this set of tests performs a minimum number of requests to
+        determine if access to the resource type is appropriately allowed or
+        denied given the scope granted. In the case of the Patient resource,
+        this test simply performs a read request. For other resources, it
+        performs a search by patient that must be supported by the server. In
+        some cases, servers can return an error message if a status search
+        parameter is not provided. For these, the test will perform an
+        additional search with the required status search parameter.
 
-        This set of tests does not attempt to access resources that do not directly map to USCDI v1, including Encounter, Location,
-        Organization, Practitioner, PractionerRole, and RelatedPerson.  It also does not test Provenance, as this
-        resource type is accessed by queries through other resource types.  These resource types are accessed in the more
-        comprehensive Single Patient Query tests.
+        This set of tests does not attempt to access resources that do not
+        directly map to USCDI v1, including Encounter, Location,
+        Organization, and Practitioner. It also does not test Provenance, as
+        this resource type is accessed by queries through other resource
+        types. These resource types are accessed in the more comprehensive
+        Single Patient Query tests.
 
-        If the tester chooses to not grant access to a resource, the queries associated with that resource must
-        result in either a 401 (Unauthorized) or 403 (Forbidden) status code.  The flexiblity provided here
-        is due to some ambiguity in the specifications tested.
+        If the tester chooses to not grant access to a resource, the queries
+        associated with that resource must result in either a 401
+        (Unauthorized) or 403 (Forbidden) status code. The flexiblity
+        provided here is due to some ambiguity in the specifications tested.
       )
 
       requires :onc_sl_url, :token, :patient_id, :received_scopes, :onc_sl_expected_resources
@@ -95,10 +104,13 @@ module Inferno
 
         skip_if @instance.received_scopes.nil?, 'A list of granted scopes was not provided to this test as required.'
 
-        # Consider all directly-mapped USCDI resources only.  Do not fail based on the inclusion/Exclusion of Encounter, Practitioner
-        # PractitionerRole, Location, Organization, or RelatedPerson because the SUT has flexibility to decide if those
-        # should be included or not based on whether other resources are selected (e.g. if Observation then maybe it makes
-        # sense to include Encounter scope) without having the user be in charge of that particular choice.
+        # Consider all directly-mapped USCDI resources only. Do not fail based
+        # on the inclusion/Exclusion of Encounter, Practitioner, Location or
+        # Organization, because the SUT has flexibility to decide if those
+        # should be included or not based on whether other resources are
+        # selected (e.g. if Observation then maybe it makes sense to include
+        # Encounter scope) without having the user be in charge of that
+        # particular choice.
 
         all_resources = [
           'AllergyIntolerance',

--- a/lib/modules/uscore_v3.1.1/access_verify_unrestricted_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/access_verify_unrestricted_sequence.rb
@@ -38,7 +38,7 @@ module Inferno
         test will perform an additional search with the required status search parameter.
 
         This set of tests does not attempt to access resources that do not directly map to USCDI v1, including Encounter, Location,
-        Organization, Practitioner, PractionerRole, and RelatedPerson.  It also does not test Provenance, as this
+        Organization, and Practitioner.  It also does not test Provenance, as this
         resource type is accessed by queries through other resource types. These resources types are accessed in the more
         comprehensive Single Patient Query tests.
 
@@ -111,7 +111,7 @@ module Inferno
 
         # Consider all directly-mapped USCDI resources, as well as Encounter, Practitioner and Organization
         # because they have US Core Profile references in the other US Core Profiles.  This excludes
-        # PractionerRole, Location and RelatedPerson because they do not have US Core Profile references
+        # Location because it does not have US Core Profile references
         # and therefore could be 'contained' and do not have a read interaction requirement.
         all_resources = [
           'AllergyIntolerance',

--- a/lib/modules/uscore_v3.1.1/test/access_verify_restricted_test.rb
+++ b/lib/modules/uscore_v3.1.1/test/access_verify_restricted_test.rb
@@ -70,8 +70,8 @@ describe Inferno::Sequence::USCore311ONCAccessVerifyRestrictedSequence do
       assert_raises(Inferno::PassException) { @sequence.run_test(@test) }
     end
 
-    it 'passes if Practitioner, Organization, Encounter, PractitionerRole, Location, RelatedPerson scope provided' do
-      @instance.received_scopes = 'patient/PractitionerRole.read patient/Location.read patient/RelatedPerson.read launch/patient openid fhirUser patient/Observation.read '\
+    it 'passes if Practitioner, Organization, Encounter, Location scope provided' do
+      @instance.received_scopes = 'patient/Location.read launch/patient openid fhirUser patient/Observation.read '\
                                   'patient/Condition.read patient/Patient.read patient/Encounter.read patient/Practitioner.read patient/Organization.read'
       assert_raises(Inferno::PassException) { @sequence.run_test(@test) }
     end
@@ -99,8 +99,8 @@ describe Inferno::Sequence::USCore311ONCAccessVerifyRestrictedSequence do
       @instance.received_scopes = 'launch/patient openid fhirUser offline_access patient/Medication.read patient/AllergyIntolerance.read patient/CarePlan.read '\
                                   'patient/CareTeam.read patient/Condition.read patient/Device.read patient/DiagnosticReport.read patient/DocumentReference.read '\
                                   'patient/Encounter.read patient/Goal.read patient/Immunization.read patient/Location.read patient/MedicationRequest.read '\
-                                  'patient/Observation.read patient/Organization.read patient/Patient.read patient/Practitioner.read patient/PractitionerRole.read '\
-                                  'patient/Procedure.read patient/Provenance.read patient/RelatedPerson.read'
+                                  'patient/Observation.read patient/Organization.read patient/Patient.read patient/Practitioner.read '\
+                                  'patient/Procedure.read patient/Provenance.read'
       @instance.onc_sl_expected_resources = 'Observation, Condition, Patient'
     end
 

--- a/lib/modules/uscore_v3.1.1/test/access_verify_unrestricted_test.rb
+++ b/lib/modules/uscore_v3.1.1/test/access_verify_unrestricted_test.rb
@@ -27,8 +27,8 @@ describe Inferno::Sequence::USCore311ONCAccessVerifyUnrestrictedSequence do
       @instance.received_scopes = 'launch/patient openid fhirUser offline_access patient/Medication.read patient/AllergyIntolerance.read patient/CarePlan.read '\
                                   'patient/CareTeam.read patient/Condition.read patient/Device.read patient/DiagnosticReport.read patient/DocumentReference.read '\
                                   'patient/Encounter.read patient/Goal.read patient/Immunization.read patient/Location.read patient/MedicationRequest.read '\
-                                  'patient/Observation.read patient/Organization.read patient/Patient.read patient/Practitioner.read patient/PractitionerRole.read '\
-                                  'patient/Procedure.read patient/Provenance.read patient/RelatedPerson.read'
+                                  'patient/Observation.read patient/Organization.read patient/Patient.read patient/Practitioner.read '\
+                                  'patient/Procedure.read patient/Provenance.read'
       assert_raises(Inferno::PassException) { @sequence.run_test(@test) }
     end
 
@@ -47,11 +47,11 @@ describe Inferno::Sequence::USCore311ONCAccessVerifyUnrestrictedSequence do
                                   'patient/CareTeam.* patient/Condition.* patient/Device.* patient/DiagnosticReport.* patient/DocumentReference.* '\
                                   'patient/Encounter.* patient/Goal.* patient/Immunization.* patient/Location.* patient/MedicationRequest.* '\
                                   'patient/Observation.* patient/Organization.* patient/Patient.* patient/Practitioner.* patient/PractitionerRole.* '\
-                                  'patient/Procedure.* patient/Provenance.* patient/RelatedPerson.*'
+                                  'patient/Procedure.* patient/Provenance.*'
       assert_raises(Inferno::PassException) { @sequence.run_test(@test) }
     end
 
-    it 'passes if Medication, PractitionerRole, Location and RelatedPerson are omitted' do
+    it 'passes if Medication and Location are omitted' do
       @instance.received_scopes = 'launch/patient openid fhirUser offline_access patient/AllergyIntolerance.read patient/CarePlan.read '\
                                   'patient/CareTeam.read patient/Condition.read patient/Device.read patient/DiagnosticReport.read patient/DocumentReference.read '\
                                   'patient/Encounter.read patient/Goal.read patient/Immunization.read patient/MedicationRequest.read '\
@@ -64,8 +64,8 @@ describe Inferno::Sequence::USCore311ONCAccessVerifyUnrestrictedSequence do
       @instance.received_scopes = 'launch/patient openid fhirUser offline_access patient/Medication.read patient/AllergyIntolerance.read patient/CarePlan.read '\
                                   'patient/CareTeam.read patient/Condition.read patient/Device.read patient/DiagnosticReport.read patient/DocumentReference.read '\
                                   'patient/Encounter.read patient/Goal.read patient/Immunization.read patient/Location.read patient/MedicationRequest.read '\
-                                  'patient/Observation.read patient/Organization.read patient/Patient.read patient/Practitioner.read patient/PractitionerRole.read '\
-                                  'patient/Procedure.read patient/Provenance.read patient/RelatedPerson.read proprietary_scope'
+                                  'patient/Observation.read patient/Organization.read patient/Patient.read patient/Practitioner.read '\
+                                  'patient/Procedure.read patient/Provenance.read proprietary_scope'
       assert_raises(Inferno::PassException) { @sequence.run_test(@test) }
     end
 
@@ -73,8 +73,8 @@ describe Inferno::Sequence::USCore311ONCAccessVerifyUnrestrictedSequence do
       @instance.received_scopes = 'launch/patient openid fhirUser offline_access patient/Medication.read patient/AllergyIntolerance.read patient/CarePlan.read '\
                                   'patient/CareTeam.read patient/Condition.read patient/Device.read patient/DiagnosticReport.read patient/DocumentReference.read '\
                                   'patient/Encounter.read patient/Goal.read patient/Immunization.read patient/Location.read patient/MedicationRequest.read '\
-                                  'patient/Observation.read patient/Organization.read patient/Practitioner.read patient/PractitionerRole.read '\
-                                  'patient/Procedure.read patient/Provenance.read patient/RelatedPerson.read'
+                                  'patient/Observation.read patient/Organization.read patient/Practitioner.read '\
+                                  'patient/Procedure.read patient/Provenance.read'
       assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
     end
 
@@ -82,8 +82,8 @@ describe Inferno::Sequence::USCore311ONCAccessVerifyUnrestrictedSequence do
       @instance.received_scopes = 'launch/patient openid fhirUser offline_access patient/Medication.read patient/CarePlan.read '\
                                   'patient/CareTeam.read patient/Condition.read patient/Device.read patient/DiagnosticReport.read patient/DocumentReference.read '\
                                   'patient/Encounter.read patient/Goal.read patient/Immunization.read patient/Location.read patient/MedicationRequest.read '\
-                                  'patient/Observation.read patient/Organization.read patient/Patient.read patient/Practitioner.read patient/PractitionerRole.read '\
-                                  'patient/Procedure.read patient/Provenance.read patient/RelatedPerson.read'
+                                  'patient/Observation.read patient/Organization.read patient/Patient.read patient/Practitioner.read '\
+                                  'patient/Procedure.read patient/Provenance.read'
       assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
     end
 
@@ -91,8 +91,8 @@ describe Inferno::Sequence::USCore311ONCAccessVerifyUnrestrictedSequence do
       @instance.received_scopes = 'launch/patient openid fhirUser offline_access patient/Medication.read patient/AllergyIntolerance.read patient/CarePlan.read '\
                                   'patient/CareTeam.read patient/Condition.read patient/Device.read patient/DiagnosticReport.read patient/DocumentReference.read '\
                                   'patient/Encounter.read patient/Goal.read patient/Immunization.read patient/Location.read patient/MedicationRequest.read '\
-                                  'patient/Observation.read patient/Organization.read patient/Patient.read patient/PractitionerRole.read '\
-                                  'patient/Procedure.read patient/Provenance.read patient/RelatedPerson.read'
+                                  'patient/Observation.read patient/Organization.read patient/Patient.read '\
+                                  'patient/Procedure.read patient/Provenance.read'
       assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
     end
   end
@@ -104,8 +104,8 @@ describe Inferno::Sequence::USCore311ONCAccessVerifyUnrestrictedSequence do
       @instance.received_scopes = 'launch/patient openid fhirUser offline_access patient/Medication.read patient/AllergyIntolerance.read patient/CarePlan.read '\
                                   'patient/CareTeam.read patient/Condition.read patient/Device.read patient/DiagnosticReport.read patient/DocumentReference.read '\
                                   'patient/Encounter.read patient/Goal.read patient/Immunization.read patient/Location.read patient/MedicationRequest.read '\
-                                  'patient/Observation.read patient/Organization.read patient/Patient.read patient/Practitioner.read patient/PractitionerRole.read '\
-                                  'patient/Procedure.read patient/Provenance.read patient/RelatedPerson.read'
+                                  'patient/Observation.read patient/Organization.read patient/Patient.read patient/Practitioner.read '\
+                                  'patient/Procedure.read patient/Provenance.read'
     end
 
     it 'passes if success response received' do
@@ -139,8 +139,8 @@ describe Inferno::Sequence::USCore311ONCAccessVerifyUnrestrictedSequence do
       @instance.received_scopes = 'launch/patient openid fhirUser offline_access patient/Medication.read patient/AllergyIntolerance.read patient/CarePlan.read '\
                                   'patient/CareTeam.read patient/Condition.read patient/Device.read patient/DiagnosticReport.read patient/DocumentReference.read '\
                                   'patient/Encounter.read patient/Goal.read patient/Immunization.read patient/Location.read patient/MedicationRequest.read '\
-                                  'patient/Observation.read patient/Organization.read patient/Patient.read patient/Practitioner.read patient/PractitionerRole.read '\
-                                  'patient/Procedure.read patient/Provenance.read patient/RelatedPerson.read'
+                                  'patient/Observation.read patient/Organization.read patient/Patient.read patient/Practitioner.read '\
+                                  'patient/Procedure.read patient/Provenance.read'
     end
 
     it 'passes if success response received' do


### PR DESCRIPTION
This removes PractitionerRole and RelatedPerson from the SMART Scopes, and related language.

**Submitter:**
- [x] This pull request describes why these changes were made
- [x] Internal ticket for this PR:
- [x] Internal ticket links to this PR
- [x] Internal ticket is properly labeled (Community/Program)
- [x] Internal ticket has a justification for its Community/Program label
- [x] Code diff has been reviewed for extraneous/missing code
- [x] Tests are included and test edge cases
- [x] Tests/code quality metrics have been run locally and pass


**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
