### PR TITLE
Fi 1066-either carrieraidc carrierhrf must support

### DIFF
--- a/generator/uscore/metadata_extractor.rb
+++ b/generator/uscore/metadata_extractor.rb
@@ -559,6 +559,11 @@ module Inferno
           (path.start_with? 'component.value') && (!path.include? '[x]') && (path != 'component.valueQuantity')
         end
 
+        # remove carrierAIDC and carrierHRF from implantable device must supports
+        implantable_device_sequence = metadata[:sequences].find { |sequence| sequence[:profile] == 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-implantable-device'}
+          implantable_device_sequence[:must_supports][:elements].delete_if do |element|
+            ['udiCarrier.carrierAIDC', 'udiCarrier.carrierHRF'].include? element[:path]
+          end
         metadata
       end
 

--- a/generator/uscore/metadata_extractor.rb
+++ b/generator/uscore/metadata_extractor.rb
@@ -560,10 +560,10 @@ module Inferno
         end
 
         # remove carrierAIDC and carrierHRF from implantable device must supports
-        implantable_device_sequence = metadata[:sequences].find { |sequence| sequence[:profile] == 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-implantable-device'}
-          implantable_device_sequence[:must_supports][:elements].delete_if do |element|
-            ['udiCarrier.carrierAIDC', 'udiCarrier.carrierHRF'].include? element[:path]
-          end
+        implantable_device_sequence = metadata[:sequences].find { |sequence| sequence[:profile] == 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-implantable-device' }
+        implantable_device_sequence[:must_supports][:elements].delete_if do |element|
+          ['udiCarrier.carrierAIDC', 'udiCarrier.carrierHRF'].include? element[:path]
+        end
         metadata
       end
 

--- a/generator/uscore/uscore_generator.rb
+++ b/generator/uscore/uscore_generator.rb
@@ -647,9 +647,9 @@ module Inferno
 
           if is_implantable_device_sequence
             test[:test_code] += %(
-              carrierAIDC_found = #{resource_array}&.any? { |resource| resolve_element_from_path(resource, 'udiCarrier.carrierAIDC').present? }
-              carrierHRF_found = #{resource_array}&.any? { |resource| resolve_element_from_path(resource, 'udiCarrier.carrierHRF').present? }
-              missing_must_support_elements.append('udiCarrier.carrierAIDC or udiCarrier.carrierHRF') unless (carrierAIDC_found || carrierHRF_found)
+              carrier_aidc_found = #{resource_array}&.any? { |resource| resolve_element_from_path(resource, 'udiCarrier.carrierAIDC').present? }
+              carrier_hrf_found = #{resource_array}&.any? { |resource| resolve_element_from_path(resource, 'udiCarrier.carrierHRF').present? }
+              missing_must_support_elements.append('udiCarrier.carrierAIDC or udiCarrier.carrierHRF') unless carrier_aidc_found || carrier_hrf_found
             )
           end
 

--- a/generator/uscore/uscore_generator.rb
+++ b/generator/uscore/uscore_generator.rb
@@ -581,6 +581,9 @@ module Inferno
                             sequence[:must_supports][:extensions].map { |extension| "* #{extension[:id]}" } +
                             sequence[:must_supports][:slices].map { |slice| "* #{slice[:name]}" }
 
+        is_implantable_device_sequence = sequence[:profile] == 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-implantable-device'
+        must_support_list.append('* udiCarrier.carrierAIDC or udiCarrier.carrierHRF') if is_implantable_device_sequence
+
         test = {
           tests_that: "All must support elements are provided in the #{sequence[:resource]} resources returned.",
           index: sequence[:tests].length + 1,
@@ -641,6 +644,14 @@ module Inferno
             end
             missing_must_support_elements.map! { |must_support| "\#{must_support[:path]}\#{': ' + must_support[:fixed_value] if must_support[:fixed_value].present?}" }
           )
+
+          if is_implantable_device_sequence
+            test[:test_code] += %(
+              carrierAIDC_found = #{resource_array}&.any? { |resource| resolve_element_from_path(resource, 'udiCarrier.carrierAIDC').present? }
+              carrierHRF_found = #{resource_array}&.any? { |resource| resolve_element_from_path(resource, 'udiCarrier.carrierHRF').present? }
+              missing_must_support_elements.append('udiCarrier.carrierAIDC or udiCarrier.carrierHRF') unless (carrierAIDC_found || carrierHRF_found)
+            )
+          end
 
           if must_support_extensions.present?
             test[:test_code] += %(

--- a/lib/modules/uscore_v3.1.1/head_occipital_frontal_circumference_percentile_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/head_occipital_frontal_circumference_percentile_sequence.rb
@@ -193,7 +193,7 @@ module Inferno
             @observation = resources_returned.first
             @observation_ary[patient] += resources_returned
 
-            save_resource_references(versioned_resource_class('Observation'), @observation_ary[patient])
+            save_resource_references(versioned_resource_class('Observation'), @observation_ary[patient], Inferno::ValidationUtil::US_CORE_R4_URIS[:head_circumference_percentile])
             save_delayed_sequence_references(resources_returned, USCore311HeadOccipitalFrontalCircumferencePercentileSequenceDefinitions::DELAYED_REFERENCES)
             validate_reply_entries(resources_returned, search_params)
 
@@ -538,7 +538,7 @@ module Inferno
         end
 
         skip_if_not_found(resource_type: 'Observation', delayed: false)
-        test_resources_against_profile('Observation')
+        test_resources_against_profile('Observation', Inferno::ValidationUtil::US_CORE_R4_URIS[:head_circumference_percentile])
         bindings = USCore311HeadOccipitalFrontalCircumferencePercentileSequenceDefinitions::BINDINGS
         invalid_binding_messages = []
         invalid_binding_resources = Set.new

--- a/lib/modules/uscore_v3.1.1/profile_definitions/us_core_implantable_device_definitions.rb
+++ b/lib/modules/uscore_v3.1.1/profile_definitions/us_core_implantable_device_definitions.rb
@@ -14,12 +14,6 @@ module Inferno
             path: 'udiCarrier.deviceIdentifier'
           },
           {
-            path: 'udiCarrier.carrierAIDC'
-          },
-          {
-            path: 'udiCarrier.carrierHRF'
-          },
-          {
             path: 'distinctIdentifier'
           },
           {

--- a/lib/modules/uscore_v3.1.1/us_core_implantable_device_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_implantable_device_sequence.rb
@@ -374,8 +374,7 @@ module Inferno
             * serialNumber
             * type
             * udiCarrier
-            * udiCarrier.carrierAIDC
-            * udiCarrier.carrierHRF
+            * udiCarrier.carrierAIDC or udiCarrier.carrierHRF
             * udiCarrier.deviceIdentifier
 
           )
@@ -396,6 +395,10 @@ module Inferno
           end
         end
         missing_must_support_elements.map! { |must_support| "#{must_support[:path]}#{': ' + must_support[:fixed_value] if must_support[:fixed_value].present?}" }
+
+        carrierAIDC_found = @device_ary&.values&.flatten&.any? { |resource| resolve_element_from_path(resource, 'udiCarrier.carrierAIDC').present? }
+        carrierHRF_found = @device_ary&.values&.flatten&.any? { |resource| resolve_element_from_path(resource, 'udiCarrier.carrierHRF').present? }
+        missing_must_support_elements.append('udiCarrier.carrierAIDC or udiCarrier.carrierHRF') unless (carrierAIDC_found || carrierHRF_found)
 
         skip_if missing_must_support_elements.present?,
                 "Could not find #{missing_must_support_elements.join(', ')} in the #{@device_ary&.values&.flatten&.length} provided Device resource(s)"

--- a/lib/modules/uscore_v3.1.1/us_core_implantable_device_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_implantable_device_sequence.rb
@@ -396,9 +396,9 @@ module Inferno
         end
         missing_must_support_elements.map! { |must_support| "#{must_support[:path]}#{': ' + must_support[:fixed_value] if must_support[:fixed_value].present?}" }
 
-        carrierAIDC_found = @device_ary&.values&.flatten&.any? { |resource| resolve_element_from_path(resource, 'udiCarrier.carrierAIDC').present? }
-        carrierHRF_found = @device_ary&.values&.flatten&.any? { |resource| resolve_element_from_path(resource, 'udiCarrier.carrierHRF').present? }
-        missing_must_support_elements.append('udiCarrier.carrierAIDC or udiCarrier.carrierHRF') unless (carrierAIDC_found || carrierHRF_found)
+        carrier_aidc_found = @device_ary&.values&.flatten&.any? { |resource| resolve_element_from_path(resource, 'udiCarrier.carrierAIDC').present? }
+        carrier_hrf_found = @device_ary&.values&.flatten&.any? { |resource| resolve_element_from_path(resource, 'udiCarrier.carrierHRF').present? }
+        missing_must_support_elements.append('udiCarrier.carrierAIDC or udiCarrier.carrierHRF') unless carrier_aidc_found || carrier_hrf_found
 
         skip_if missing_must_support_elements.present?,
                 "Could not find #{missing_must_support_elements.join(', ')} in the #{@device_ary&.values&.flatten&.length} provided Device resource(s)"


### PR DESCRIPTION
This PR makes it so that either carrierAIDC or carrierHRF is found in the must support test. I take out both elements from the must support metadata and add a special check for udicarrier.carrierAIDC and udicarrier.carrierHRF. 

This PR also includes a change to head_occipital_frontal_circumference_percentile_sequence which was made by the generator. I'm guessing it was just not included in another PR.

**Submitter:**
- [X] This pull request describes why these changes were made
- [X] Internal ticket for this PR: https://oncprojectracking.healthit.gov/support/browse/FI-1066
- [X] Internal ticket links to this PR
- [X] Internal ticket is properly labeled (Community/Program)
- [X] Internal ticket has a justification for its Community/Program label
- [X] Code diff has been reviewed for extraneous/missing code
- [ ] Tests are included and test edge cases
- [X] Tests/code quality metrics have been run locally and pass


**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
