### PR TITLE
FI-1083 Fix invalid invariants in FHIR v4.0.1 and US Core v3.1.1

### DIFF
--- a/lib/app/utils/hl7_validator.rb
+++ b/lib/app/utils/hl7_validator.rb
@@ -7,8 +7,8 @@ module Inferno
       %r{^Sub-extension url 'introspect' is not defined by the Extension http://fhir-registry\.smarthealthit\.org/StructureDefinition/oauth-uris$},
       %r{^Sub-extension url 'revoke' is not defined by the Extension http://fhir-registry\.smarthealthit\.org/StructureDefinition/oauth-uris$},
       /^URL value .* does not resolve$/,
-      /^vs-1: if Observation.effective\[x\] is dateTime and has a value then that value shall be precise to the day/, # Invalid invariant in FHIR v4.0.1
-      /^uscore-1: if Observation.effective\[x\] is dateTime and has a value then that value shall be precise to the day/ # Invalid invariant in US Core v3.1.1
+      /^vs-1: if Observation\.effective\[x\] is dateTime and has a value then that value shall be precise to the day/, # Invalid invariant in FHIR v4.0.1
+      /^uscore-1: if Observation\.effective\[x\] is dateTime and has a value then that value shall be precise to the day/ # Invalid invariant in US Core v3.1.1
     ].freeze
     @validator_url = nil
 

--- a/lib/app/utils/hl7_validator.rb
+++ b/lib/app/utils/hl7_validator.rb
@@ -6,7 +6,9 @@ module Inferno
     ISSUE_DETAILS_FILTER = [
       %r{^Sub-extension url 'introspect' is not defined by the Extension http://fhir-registry\.smarthealthit\.org/StructureDefinition/oauth-uris$},
       %r{^Sub-extension url 'revoke' is not defined by the Extension http://fhir-registry\.smarthealthit\.org/StructureDefinition/oauth-uris$},
-      /^URL value .* does not resolve$/
+      /^URL value .* does not resolve$/,
+      /^vs-1: if Observation.effective\[x\] is dateTime and has a value then that value shall be precise to the day/, # Invalid invariant in FHIR v4.0.1
+      /^uscore-1: if Observation.effective\[x\] is dateTime and has a value then that value shall be precise to the day/ # Invalid invariant in US Core v3.1.1
     ].freeze
     @validator_url = nil
 


### PR DESCRIPTION
There is an invariant in FHIR and US Core vital signs that has been acknowledged to be invalid.  Hopefully this will be addressed in future versions of US Core, but in the meantime we will 'mute' the error from the validator.

```
vs-1: if Observation.effective[x] is dateTime and has a value then that value shall be precise to the day [($this as dateTime).toString().length() >= 8]

uscore-1: if Observation.effective[x] is dateTime and has a value then that value shall be precise to the day [($this as dateTime).toString().length() >= 8]
```

Note: I recognize that we could probably just key off of the invariant key (uscore-1, vs-1), but I am skeptical that these are globally unique forever, so instead of just keying off them, I do it plus the first N characters of the description (because rubocop gets mad if the line lengths are too long).  I see no downside to this, and in fact it is useful to see in the code a little bit of information about which invariant these are referring to).

**Submitter:**
- [x] This pull request describes why these changes were made
- [x] Internal ticket for this PR: FI-1083
- [x] Internal ticket links to this PR
- [x] Internal ticket is properly labeled (Community/Program)
- [x] Internal ticket has a justification for its Community/Program label
- [x] Code diff has been reviewed for extraneous/missing code
- [ ] Tests are included and test edge cases
- [x] Tests/code quality metrics have been run locally and pass


**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
