### PR TITLE
FI-1084: Remove refreshing the refresh token test.

### DIFF
--- a/lib/modules/onc_program/onc_token_refresh_sequence.rb
+++ b/lib/modules/onc_program/onc_token_refresh_sequence.rb
@@ -195,31 +195,6 @@ module Inferno
       end
 
       patient_context_test(index: '05', refresh: true)
-
-      test :refresh_token_refreshed do
-        metadata do
-          id '06'
-          name 'Server supplies new refresh token as required by ONC certification criteria.'
-          link 'https://www.federalregister.gov/documents/2020/05/01/2020-07419/21st-century-cures-act-interoperability-information-blocking-and-the-onc-health-it-certification'
-          description %(
-            The ONC certification criteria requires that refresh tokens can be refreshed.  While `refresh_token`
-            is optional in the refresh token response in the OAuth 2.0 specification, this test requires that a
-            new refresh token is provided that does not match the previous refresh token.
-
-            ```
-            An application capable of storing a client secret must be issued a new refresh token valid for a new
-            period of no less than three months.
-            ```
-
-          )
-        end
-
-        omit 'Applies to confidential clients only' unless instance_confidential_client
-
-        skip_if @previous_refresh_token.blank? && @instance.refresh_token.blank?, 'No refresh token was received during the SMART launch'
-
-        assert @previous_refresh_token != @instance.refresh_token, "Refresh response did not provide a new refresh token as required by ONC certification criteria.  Old Refresh Token: `#{@previous_refresh_token}`; New Refresh Token: `#{@instance.refresh_token}`"
-      end
     end
   end
 end

--- a/lib/modules/onc_program/test/onc_token_refresh_sequence_test.rb
+++ b/lib/modules/onc_program/test/onc_token_refresh_sequence_test.rb
@@ -314,18 +314,6 @@ class OncTokenRefreshSequenceTest < MiniTest::Test
       body_response_code = 400
     when :disallows_scope
       body_with_scope_response_code = 400
-    when :stale_refresh_token
-      @instance.update(
-        client_secret: @confidential_client_secret,
-        confidential_client: true
-      )
-      exchange_response['refresh_token'] = @instance.refresh_token
-    when :no_refresh_token
-      @instance.update(
-        client_secret: @confidential_client_secret,
-        confidential_client: true
-      )
-      exchange_response.delete('refresh_token')
     end
 
     # can't do this above because we are altering the content of hash in other error modes
@@ -460,20 +448,6 @@ class OncTokenRefreshSequenceTest < MiniTest::Test
 
   def test_fail_if_scope_cannot_be_in_payload
     setup_mocks(:disallows_scope)
-
-    sequence_result = @sequence.start
-    assert sequence_result.fail?
-  end
-
-  def test_fail_if_stale_refresh_token
-    setup_mocks(:stale_refresh_token)
-
-    sequence_result = @sequence.start
-    assert sequence_result.fail?
-  end
-
-  def test_fail_if_no_refresh_token
-    setup_mocks(:no_refresh_token)
 
     sequence_result = @sequence.start
     assert sequence_result.fail?

--- a/lib/modules/onc_program_procedure.yml
+++ b/lib/modules/onc_program_procedure.yml
@@ -624,7 +624,6 @@ procedure:
           in § 170.215(a)(3).
         inferno_supported: 'yes'
         inferno_tests:
-          - SPD-TR-06
           - ATT-05
         inferno_notes: |
           Inferno requires that a new refresh token is presented along with

--- a/lib/modules/onc_program_procedure.yml
+++ b/lib/modules/onc_program_procedure.yml
@@ -626,11 +626,8 @@ procedure:
         inferno_tests:
           - ATT-05
         inferno_notes: |
-          Inferno requires that a new refresh token is presented along with
-          a new access token during a successful token refresh.  This is not
-          strictly required by the OAuth 2.0 specification but is required
-          as part of the certification criteria.  Inferno cannot verify the
-          three month token expiration requirement, but the tester can
+          Inferno cannot verify the three month token expiration requirement
+          automatically during the token refresh tests, but the tester can
           register an attestation that this requirement is met.
       - id: AUTH-PATIENT-23
         SUT: |


### PR DESCRIPTION
Remove 'refreshing the refresh token' tests because ONC guidance states that is not a requirement.  This includes the check that the refresh token is present after the refresh token exchange, and the check that the refresh token is different than the previous one.  There does not appear to be a requirement that the refresh token needs to be present at all after the exchange, even if its duration is being extended.

**Submitter:**
- [x] This pull request describes why these changes were made
- [x] Internal ticket for this PR: 1084
- [x] Internal ticket links to this PR
- [x] Internal ticket is properly labeled (Community/Program)
- [x] Internal ticket has a justification for its Community/Program label
- [x] Code diff has been reviewed for extraneous/missing code
- [x] Tests are included and test edge cases
- [x] Tests/code quality metrics have been run locally and pass


**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
