### PR TITLE
Update text of us-core-1 invariant in ISSUE_DETAILS_FILTER

### DIFF
--- a/lib/app/utils/hl7_validator.rb
+++ b/lib/app/utils/hl7_validator.rb
@@ -8,7 +8,7 @@ module Inferno
       %r{^Sub-extension url 'revoke' is not defined by the Extension http://fhir-registry\.smarthealthit\.org/StructureDefinition/oauth-uris$},
       /^URL value .* does not resolve$/,
       /^vs-1: if Observation\.effective\[x\] is dateTime and has a value then that value shall be precise to the day/, # Invalid invariant in FHIR v4.0.1
-      /^uscore-1: if Observation\.effective\[x\] is dateTime and has a value then that value shall be precise to the day/ # Invalid invariant in US Core v3.1.1
+      /^us-core-1: Datetime must be at least to day/ # Invalid invariant in US Core v3.1.1
     ].freeze
     @validator_url = nil
 


### PR DESCRIPTION
The `us-core-1` invariant in the US Core Laboratory Result Observation profile was still being let through the issue details filter, apparently due to some incorrect text in the filter. This PR updates the text.

**Submitter:**
- [x] This pull request describes why these changes were made
- [x] Internal ticket for this PR: N/A
- [x] Internal ticket links to this PR N/A
- [x] Internal ticket is properly labeled (Community/Program) N/A
- [x] Internal ticket has a justification for its Community/Program label N/A
- [x] Code diff has been reviewed for extraneous/missing code
- [x] Tests are included and test edge cases N/A
- [x] Tests/code quality metrics have been run locally and pass


**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
