### PR TITLE
FI-1086: Modify test prefix code to not include dashes.

### DIFF
--- a/generator/uscore/metadata_extractor.rb
+++ b/generator/uscore/metadata_extractor.rb
@@ -36,7 +36,7 @@ module Inferno
 
       def generate_unique_test_id_prefix(title)
         module_prefix = 'USC'
-        test_id_prefix = module_prefix + title.chars.select { |c| c.upcase == c && c != ' ' }.join
+        test_id_prefix = module_prefix + title.chars.select { |c| ('A'..'Z').include?(c) }.join
         last_title_word = title.split(test_id_prefix.last).last
         index = 0
 

--- a/lib/modules/uscore_v3.1.1/head_occipital_frontal_circumference_percentile_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/head_occipital_frontal_circumference_percentile_sequence.rb
@@ -63,7 +63,7 @@ module Inferno
         and will fail if any attempted read fails.
       )
 
-      test_id_prefix 'USCPHO-CP'
+      test_id_prefix 'USCPHOCP'
 
       requires :token, :patient_ids
       conformance_supports :Observation


### PR DESCRIPTION
Slight update to generator to not include dashes in the test prefix to be consistent.

**Submitter:**
- [x] This pull request describes why these changes were made
- [x] Internal ticket for this PR: 1086
- [x] Internal ticket links to this PR
- [x] Internal ticket is properly labeled (Community/Program)
- [x] Internal ticket has a justification for its Community/Program label
- [x] Code diff has been reviewed for extraneous/missing code
- [x] Tests are included and test edge cases
- [x] Tests/code quality metrics have been run locally and pass


**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
