### PR TITLE
FI-1082 make request_index not a key

### DIFF
--- a/lib/app/models/request_response.rb
+++ b/lib/app/models/request_response.rb
@@ -14,7 +14,7 @@ module Inferno
       property :response_body, Text
       property :direction, String
       property :instance_id, String
-      property :request_index, Serial, unique_index: true
+      property :request_index, Serial, unique_index: true, key: false
 
       property :timestamp, DateTime, default: proc { DateTime.now }
 


### PR DESCRIPTION
Currently, pressing the details button in the HTTP requests tab will fail to bring up the request details. This is because the request_index attribute is a Serial which defaults to being a key. Then the .get to retrieve the request_response expects both an id and a request_index. 

I address this by making request_index not a key. Changing the type to UUID instead of Serial also worked, but I don't know if that's the right to do it.  

btw, you also have to delete the database data in data/development_data.db before trying this.
**Submitter:**
- [X] This pull request describes why these changes were made
- [X] Internal ticket for this PR: https://oncprojectracking.healthit.gov/support/browse/FI-1082
- [X] Internal ticket links to this PR
- [X] Internal ticket is properly labeled (Community/Program)
- [X] Internal ticket has a justification for its Community/Program label
- [X] Code diff has been reviewed for extraneous/missing code
- [] Tests are included and test edge cases
- [X] Tests/code quality metrics have been run locally and pass


**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
