### PR TITLE
FI-1110 Fix reference resolution for contained references

### DIFF
--- a/lib/app/sequence_base.rb
+++ b/lib/app/sequence_base.rb
@@ -725,13 +725,13 @@ module Inferno
             reference_type = value.resource_type
             resolved_resource = value.read
 
-            raise InvalidReferenceResource if resolved_resource.resourceType != reference_type
+            raise InvalidReferenceResource if resolved_resource&.resourceType != reference_type
 
             resolved_references.add(value.reference)
           rescue ClientException => e
             problems << "#{path} did not resolve: #{e}"
           rescue InvalidReferenceResource
-            problems << "Expected #{reference} to refer to a #{reference_type} resource, but found a #{resolved_resource.resourceType} resource."
+            problems << "Expected #{reference} to refer to a #{reference_type} resource, but found a #{resolved_resource&.resourceType} resource."
           end
         end
 

--- a/lib/app/sequence_base.rb
+++ b/lib/app/sequence_base.rb
@@ -704,7 +704,7 @@ module Inferno
             next if value.reference_id.blank?
 
             # otherwise check to make sure the base resource has the contained element
-            valid_contained = resource.contained.any? {|contained_resource| contained_resource&.id == value.reference_id}
+            valid_contained = resource.contained.any? { |contained_resource| contained_resource&.id == value.reference_id }
             problems << "#{path} has contained reference to id '#{value.reference_id}' that does not exist" unless valid_contained
             next
           end


### PR DESCRIPTION
Fix for issue where contained references result in a hard error in the reference resolution tests.  See #221 for test data that exposes this issue (USCMR-14 has a purple error).  Before this fix, you would always fail if you were using contained resources.

**Submitter:**
- [x] This pull request describes why these changes were made
- [x] Internal ticket for this PR:
- [x] Internal ticket links to this PR
- [x] Internal ticket is properly labeled (Community/Program)
- [x] Internal ticket has a justification for its Community/Program label
- [x] Code diff has been reviewed for extraneous/missing code
- [x] Tests are included and test edge cases
- [x] Tests/code quality metrics have been run locally and pass


**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
