### PR TITLE
fi-1127: Fix issue where bulk data errors if empty chunk streamed back.

### DIFF
--- a/lib/modules/onc_program/bulk_data_group_validation_sequence.rb
+++ b/lib/modules/onc_program/bulk_data_group_validation_sequence.rb
@@ -357,6 +357,7 @@ module Inferno
 
             # Skip processing the last line since the it may not be complete (still appending from stream)
             next_block = resource_list.pop
+            next_block = String.new if next_block.nil?
 
             resource_list.each do |resource|
               # NDJSON does not specify that empty lines are NOT allowed.


### PR DESCRIPTION
Fixes issue in bulk data validation tests where empty chunk streamed back causes tests to error.

Could not add tests because our mocking library doesn't allow you to stream back chunks -- it just lets you send back the whole body.  So we cannot effectively self test this issue without a fair amount of work.

See internal JIRA ticket for example server configuration to replicate this issue.

**Submitter:**
- [x] This pull request describes why these changes were made
- [x] Internal ticket for this PR
- [x] Internal ticket links to this PR
- [x] Internal ticket is properly labeled (Community/Program)
- [x] Internal ticket has a justification for its Community/Program label
- [x] Code diff has been reviewed for extraneous/missing code
- n/a Tests are included and test edge cases
- [x] Tests/code quality metrics have been run locally and pass


**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
