### PR TITLE
Add Content-Type check for metadata response

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -39,7 +39,7 @@ resource_validator: external
 
 # The url where the external validator can be reached. Ignored when using the
 # internal validator.
-external_resource_validator_url: http://validator_service:4567
+external_resource_validator_url: http://localhost:8887
 
 # The list of testing modules which will be made available. These entries must
 # match the "name" field in the .yml files in lib/modules.

--- a/config.yml
+++ b/config.yml
@@ -39,7 +39,7 @@ resource_validator: external
 
 # The url where the external validator can be reached. Ignored when using the
 # internal validator.
-external_resource_validator_url: http://localhost:8887
+external_resource_validator_url: http://validator_service:4567
 
 # The list of testing modules which will be made available. These entries must
 # match the "name" field in the .yml files in lib/modules.

--- a/lib/modules/onc_program/bulk_data_export_sequence.rb
+++ b/lib/modules/onc_program/bulk_data_export_sequence.rb
@@ -39,6 +39,7 @@ module Inferno
         headers = { accept: 'application/fhir+json' }
         reply = LoggedRestClient.get(url, headers)
         assert_response_ok(reply)
+        assert_response_content_type(reply, 'application/fhir+json')
 
         conformance = versioned_resource_class.from_contents(reply.body)
         assert conformance.present?, 'Cannot read server CapabilityStatement.'

--- a/lib/modules/onc_program/bulk_data_export_sequence.rb
+++ b/lib/modules/onc_program/bulk_data_export_sequence.rb
@@ -28,21 +28,10 @@ module Inferno
       end
 
       def check_capability_statement
-        if @instance.bulk_url.present?
-          url = @instance.bulk_url
-          url = url.chop if url.end_with?('/')
-        else
-          url = ''
-        end
-
-        url += '/metadata'
-        headers = { accept: 'application/fhir+json' }
-        reply = LoggedRestClient.get(url, headers)
-        assert_response_ok(reply)
-        assert_response_content_type(reply, 'application/fhir+json')
-
-        conformance = versioned_resource_class.from_contents(reply.body)
-        assert conformance.present?, 'Cannot read server CapabilityStatement.'
+        @client = FHIR::Client.for_testing_instance(@instance, url_property: 'bulk_url')
+        conformance = @client.conformance_statement
+        assert_response_ok @client.reply
+        assert_response_content_type(@client.reply, 'application/fhir+json')
 
         operation = nil
 

--- a/lib/modules/onc_program/test/bulk_patient_export_sequence_test.rb
+++ b/lib/modules/onc_program/test/bulk_patient_export_sequence_test.rb
@@ -60,7 +60,7 @@ describe Inferno::Sequence::BulkDataPatientExportSequence do
       @response_headers = { content_type: 'application/fhir+json' }
     end
 
-    it 'fail if status code is not 200' do
+    it 'fails if status code is not 200' do
       stub_request(:get, @instance.bulk_url + '/metadata')
         .to_return(status: 400)
 
@@ -71,7 +71,7 @@ describe Inferno::Sequence::BulkDataPatientExportSequence do
       assert error.message == 'Bad response code: expected 200, 201, but found 400. '
     end
 
-    it 'fail if Content-Type is not application/fhir+json' do
+    it 'fails if Content-Type is not application/fhir+json' do
       stub_request(:get, @instance.bulk_url + '/metadata')
         .with(headers: @headers)
         .to_return(
@@ -87,7 +87,7 @@ describe Inferno::Sequence::BulkDataPatientExportSequence do
       assert error.message == 'Expected content-type application/fhir+json but found application/json'
     end
 
-    it 'fail if CapabilityStatement does not declare Group resoure' do
+    it 'fails if CapabilityStatement does not declare Group resoure' do
       @conformance['rest'][0]['resource'].delete_at(0)
       stub_request(:get, @instance.bulk_url + '/metadata')
         .with(headers: @headers)
@@ -104,7 +104,7 @@ describe Inferno::Sequence::BulkDataPatientExportSequence do
       assert error.message == 'Server CapabilityStatement did not declare support for export operation in Group resource.'
     end
 
-    it 'fail if CapabilityStatement does not declare operation in Group resoure' do
+    it 'fails if CapabilityStatement does not declare operation in Group resoure' do
       @conformance['rest'][0]['resource'][0].delete('operation')
       stub_request(:get, @instance.bulk_url + '/metadata')
         .with(headers: @headers)
@@ -121,7 +121,7 @@ describe Inferno::Sequence::BulkDataPatientExportSequence do
       assert error.message == 'Server CapabilityStatement did not declare support for export operation in Group resource.'
     end
 
-    it 'fail if CapabilityStatement does not declare export in Group resoure' do
+    it 'fails if CapabilityStatement does not declare export in Group resoure' do
       @conformance['rest'][0]['resource'][0]['operation'].delete_at(0)
       stub_request(:get, @instance.bulk_url + '/metadata')
         .with(headers: @headers)
@@ -138,7 +138,7 @@ describe Inferno::Sequence::BulkDataPatientExportSequence do
       assert error.message == 'Server CapabilityStatement did not declare support for export operation in Group resource.'
     end
 
-    it 'pass if CapabilityStatement declares export in Group resoure' do
+    it 'passes if CapabilityStatement declares export in Group resoure' do
       stub_request(:get, @instance.bulk_url + '/metadata')
         .with(headers: @headers)
         .to_return(

--- a/lib/modules/onc_program/test/bulk_patient_export_sequence_test.rb
+++ b/lib/modules/onc_program/test/bulk_patient_export_sequence_test.rb
@@ -62,7 +62,6 @@ describe Inferno::Sequence::BulkDataPatientExportSequence do
 
     it 'fail if status code is not 200' do
       stub_request(:get, @instance.bulk_url + '/metadata')
-        .with(headers: @headers)
         .to_return(status: 400)
 
       error = assert_raises(Inferno::AssertionException) do

--- a/lib/modules/us_core_guidance/test/us_core_r4_capability_statement_sequence_test.rb
+++ b/lib/modules/us_core_guidance/test/us_core_r4_capability_statement_sequence_test.rb
@@ -25,6 +25,20 @@ describe Inferno::Sequence::UsCoreR4CapabilityStatementSequence do
 
       assert test_result.fail?, "Test result should be fail but is #{test_result.result}"
     end
+
+    it 'fail if Content-Type is not application/fhir+json' do
+      stub_request(:get, /metadata/)
+        .to_return(
+          status: 200,
+          headers: { content_type: 'application/json' }
+        )
+
+      error = assert_raises(Inferno::AssertionException) do
+        @sequence.run_test(@test)
+      end
+
+      assert error.message == 'Expected content-type application/fhir+json but found application/json'
+    end
   end
 
   describe 'JSON support test' do

--- a/lib/modules/us_core_guidance/test/us_core_r4_capability_statement_sequence_test.rb
+++ b/lib/modules/us_core_guidance/test/us_core_r4_capability_statement_sequence_test.rb
@@ -26,7 +26,7 @@ describe Inferno::Sequence::UsCoreR4CapabilityStatementSequence do
       assert test_result.fail?, "Test result should be fail but is #{test_result.result}"
     end
 
-    it 'fail if Content-Type is not application/fhir+json' do
+    it 'fails if Content-Type is not application/fhir+json' do
       stub_request(:get, /metadata/)
         .to_return(
           status: 200,

--- a/lib/modules/us_core_guidance/us_core_r4_capability_statement_sequence.rb
+++ b/lib/modules/us_core_guidance/us_core_r4_capability_statement_sequence.rb
@@ -115,7 +115,7 @@ module Inferno
         metadata do
           id '02'
           name 'FHIR server supports the conformance interaction'
-          link 'http://hl7.org/fhir/DSTU2/http.html#conformance'
+          link 'http://hl7.org/fhir/R4/http.html#conformance'
           description %(
             The conformance 'whole system' interaction provides a method to get
             the conformance statement for the FHIR server. This test checks that

--- a/lib/modules/us_core_guidance/us_core_r4_capability_statement_sequence.rb
+++ b/lib/modules/us_core_guidance/us_core_r4_capability_statement_sequence.rb
@@ -146,6 +146,7 @@ module Inferno
         @client.set_no_auth
         @conformance = @client.conformance_statement
         assert_response_ok @client.reply
+        assert_response_content_type(@client.reply, 'application/fhir+json')
 
         assert_valid_conformance
 


### PR DESCRIPTION
This PR add checking Content-Type value for the metadata response. The Content-Type shall be 'application/fhir+json' according to http://hl7.org/fhir/http.html#mime-type

**Submitter:**
- [x] This pull request describes why these changes were made
- [x] Internal ticket for this PR:
- [x] Internal ticket links to this PR
- [x] Internal ticket is properly labeled (Community/Program)
- [x] Internal ticket has a justification for its Community/Program label
- [x] Code diff has been reviewed for extraneous/missing code
- [x] Tests are included and test edge cases
- [x] Tests/code quality metrics have been run locally and pass


**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
