### PR TITLE
Update docker compose

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ before_install:
   - docker-compose build
 script:
   - bundle exec rake
-  - docker-compose run ruby_server bundle exec rake
+  - docker-compose run inferno bundle exec rake
   - bundle exec rubocop
 notifications:
   email:

--- a/README.md
+++ b/README.md
@@ -248,7 +248,10 @@ bundle exec rake inferno:tests_to_csv[onc_program]
 
 ## Running Tests from the Command Line
 Inferno provides two methods of running tests via the command line: by directly
-providing the sequences or running automated scripts
+providing the sequences or running automated scripts.  You can either run these commands
+within docker containers through `docker-compose`, or directly in your own environment
+using ruby natively.  We recommend using the `docker-compose` approach because it
+ensures that the appropriate validation services are in place.
 
 _Note: This feature is still in development and we are looking for feedback on
 features and improvements in ways it can be used_
@@ -258,17 +261,17 @@ features and improvements in ways it can be used_
 Testing sequences can be run from the command line via a rake task which takes
 the sequence (or sequences) to be run and server url as arguments:
 ```sh
-bundle exec rake inferno:execute[https://my-server.org/data,onc_program,ArgonautConformance]
+docker-compose run inferno bundle exec rake inferno:execute[https://inferno.healthit.gov/reference-server/r4,onc_program,UsCoreR4CapabilityStatement,USCore311Patient]
 ```
 
 ### Running Automated Command Line Interface Scripts
 For more complicated testing where passing arguments is unwieldy, Inferno
 provides the ability to use a script containing parameters to drive test
-execution. The provided `script_example.json` shows an example of this script
+execution. The provided `./batch/inferno.healthit.gov.json` shows an example of this script
 and how it can be used.  The `execute_batch` task runs the script:
 
 ```sh
-bundle exec rake inferno:execute_batch[script.json]
+docker-compose run inferno bundle exec rake inferno:execute_batch[./batch/inferno.healthit.gov.json]
 ```
 
 Inferno also provides a  `generate_script` rake task which prompts the user for
@@ -276,7 +279,7 @@ a series of inputs which are then used to generate a script. The user is
 expected to provide a url for the FHIR Server to be tested and the module name
 from which sequences will be pulled.
 ```sh
-bundle exec rake inferno:generate_script[https://my-server.org/data,onc]
+bundle exec rake inferno:generate_script[https://my-server.org/data,onc_program]
 ```
 
 ## Using with Continuous Integration Systems

--- a/batch/inferno.healthit.gov.json
+++ b/batch/inferno.healthit.gov.json
@@ -1,0 +1,107 @@
+{
+  "server": "https://inferno.healthit.gov/reference-server/r4",
+  "module": "onc_program",
+  "arguments": {
+    "token": "3de60083-43d4-4031-9c7c-49f5f8f2358e",
+    "patient_ids": "85,355",
+    "device_codes": ""
+  },
+  "sequences": [
+    {
+      "sequence": "UsCoreR4CapabilityStatementSequence"
+    },
+    {
+      "sequence": "USCore311PatientSequence"
+    },
+    {
+      "sequence": "USCore311AllergyintoleranceSequence"
+    },
+    {
+      "sequence": "USCore311CareplanSequence"
+    },
+    {
+      "sequence": "USCore311CareteamSequence"
+    },
+    {
+      "sequence": "USCore311ConditionSequence"
+    },
+    {
+      "sequence": "USCore311ImplantableDeviceSequence"
+    },
+    {
+      "sequence": "USCore311DiagnosticreportNoteSequence"
+    },
+    {
+      "sequence": "USCore311DiagnosticreportLabSequence"
+    },
+    {
+      "sequence": "USCore311DocumentreferenceSequence"
+    },
+    {
+      "sequence": "USCore311GoalSequence"
+    },
+    {
+      "sequence": "USCore311ImmunizationSequence"
+    },
+    {
+      "sequence": "USCore311MedicationrequestSequence"
+    },
+    {
+      "sequence": "USCore311SmokingstatusSequence"
+    },
+    {
+      "sequence": "USCore311PediatricWeightForHeightSequence"
+    },
+    {
+      "sequence": "USCore311ObservationLabSequence"
+    },
+    {
+      "sequence": "USCore311PediatricBmiForAgeSequence"
+    },
+    {
+      "sequence": "USCore311PulseOximetrySequence"
+    },
+    {
+      "sequence": "USCore311HeadOccipitalFrontalCircumferencePercentileSequence"
+    },
+    {
+      "sequence": "USCore311BodyheightSequence"
+    },
+    {
+      "sequence": "USCore311BodytempSequence"
+    },
+    {
+      "sequence": "USCore311BpSequence"
+    },
+    {
+      "sequence": "USCore311BodyweightSequence"
+    },
+    {
+      "sequence": "USCore311HeartrateSequence"
+    },
+    {
+      "sequence": "USCore311ResprateSequence"
+    },
+    {
+      "sequence": "USCore311ProcedureSequence"
+    },
+    {
+      "sequence": "USCoreR4ClinicalNotesSequence"
+    },
+    {
+      "sequence": "USCore311EncounterSequence"
+    },
+    {
+      "sequence": "USCore311OrganizationSequence"
+    },
+    {
+      "sequence": "USCore311PractitionerSequence"
+    },
+    {
+      "sequence": "USCore311ProvenanceSequence"
+    },
+    {
+      "sequence": "USCoreR4DataAbsentReasonSequence"
+    }
+  ]
+}

--- a/batch/script_example.json
+++ b/batch/script_example.json
@@ -1,6 +1,6 @@
 {
   "server": "https://api-v8-dstu2.hspconsortium.org/InfernoDev/data",
-  "module": "onc",
+  "module": "onc_program",
   "arguments": {
     "client_name": "Inferno",
     "scopes": "launch launch/patient offline_access openid profile user/*.* patient/*.*",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,7 @@ services:
     volumes:
       - ./config.yml:/var/www/inferno/config.yml
       - ./data:/var/www/inferno/data
+      - ./batch:/var/www/inferno/batch
       - type: bind
         source: "./resources/terminology/validators"
         target: "/var/www/inferno/resources/terminology/validators"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 version: '3.2'
 services:
-  ruby_server:
+  inferno:
     build:
       context: ./
     volumes:
@@ -15,7 +15,7 @@ services:
     image: infernocommunity/fhir-validator-service:v0.1.1
     environment:
       DISABLE_TX: 'true'
-  nginx_server:
+  nginx:
     image: nginx
     volumes:
       - ./docker/nginx.conf:/etc/nginx/nginx.conf:ro
@@ -23,4 +23,4 @@ services:
       - "4567:80"
     command: [nginx, '-g', 'daemon off;']
     depends_on:
-      - ruby_server
+      - inferno

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,8 @@ services:
       - type: bind
         source: "./resources/terminology/validators"
         target: "/var/www/inferno/resources/terminology/validators"
+    depends_on:
+      - validator_service
   validator_service:
     image: infernocommunity/fhir-validator-service:v0.1.1
     environment:

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -69,7 +69,7 @@ http {
       proxy_cache off;
       proxy_hide_header X-Frame-Options;
    
-      # the port on ruby_server has to match the EXPOSE in Dockerfile
+      # the port on inferno has to match the EXPOSE in Dockerfile
       proxy_pass http://inferno:4567;
     }
   }

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -70,7 +70,7 @@ http {
       proxy_hide_header X-Frame-Options;
    
       # the port on ruby_server has to match the EXPOSE in Dockerfile
-      proxy_pass http://ruby_server:4567;
+      proxy_pass http://inferno:4567;
     }
   }
 }


### PR DESCRIPTION
If you are using `docker-compose run` to execute inferno from the command line (to run a script, for example), the `depends_on` is very important but wasn't included.

I also renamed the container names from `ruby_server` to `inferno` and `nginx_server` to `nginx` because they are better descriptions of the containers.  Docker may nag you to clean up orphaned containers due to this name change.