### PR TITLE
save only non-operation outcome results

### DIFF
--- a/generator/uscore/templates/unit_tests/search_unit_test.rb.erb
+++ b/generator/uscore/templates/unit_tests/search_unit_test.rb.erb
@@ -142,8 +142,33 @@ describe '<%= resource_type %> search by <%= search_params.keys.join('+') %> tes
     assert_match(/Invalid \w+:/, exception.message)
   end
 
+<% if is_first_search %>
+  it 'fails if the bundle contains a resource which is not the searched for resource nor an OperationOutcome' do
+  <% if is_fixed_value_search %>
+    [<%= fixed_value_search_string %>].each do |value|
+      query_params = {
+        'patient': @sequence.patient_ids.first,
+        '<%= fixed_value_search_param %>': value
+      }
+      stub_request(:get, "#{@base_url}/<%= resource_type %>")
+        .with(query: query_params, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle([FHIR::<%= resource_type %>.new, FHIR::Specimen.new]).to_json)
+    end
+  <% else %>
+    stub_request(:get, "#{@base_url}/<%= resource_type %>")
+      .with(query: @query, headers: @auth_header)
+      .to_return(status: 200, body: wrap_resources_in_bundle([FHIR::<%= resource_type %>.new, FHIR::Specimen.new]).to_json)
+  <% end %>
+
+    exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+    assert_equal 'All resources returned must be of the type <%= resource_type %> or OperationOutcome', exception.message
+  end
+<% end %>
+
 <% unless has_comparator_tests %>
   it 'succeeds when a bundle containing a valid resource matching the search parameters is returned' do
+    operation_outcome = FHIR.from_contents(load_fixture(:operationoutcome_example))
   <% if is_first_search && is_fixed_value_search %>
     [<%= fixed_value_search_string %>].each do |value|
       query_params = {
@@ -152,7 +177,7 @@ describe '<%= resource_type %> search by <%= search_params.keys.join('+') %> tes
       }
       body =
         if @sequence.resolve_element_from_path(@<%= resource_var_name %>, '<%= fixed_value_search_path %>') == value
-          wrap_resources_in_bundle([@<%= resource_var_name %>]).to_json
+          wrap_resources_in_bundle([@<%= resource_var_name %>, operation_outcome]).to_json
         else
           FHIR::Bundle.new.to_json
         end
@@ -167,18 +192,18 @@ describe '<%= resource_type %> search by <%= search_params.keys.join('+') %> tes
   <% else %>
     stub_request(:get, "#{@base_url}/<%= resource_type %>")
       .with(query: @query, headers: @auth_header)
-      .to_return(status: 200, body: wrap_resources_in_bundle(@<%= resource_var_name %>_ary<%='.values.flatten' unless delayed_sequence %>).to_json)
+      .to_return(status: 200, body: wrap_resources_in_bundle(@<%= resource_var_name %>_ary<%='.values.flatten' unless delayed_sequence %>.append(operation_outcome)).to_json)
     <% if is_first_search  && resource_type != 'Patient'%> 
       reference_with_type_params = @query.merge('patient': 'Patient/' + @query[:patient])
       stub_request(:get, "#{@base_url}/<%= resource_type %>")
         .with(query: reference_with_type_params, headers: @auth_header)
-      .to_return(status: 200, body: wrap_resources_in_bundle(@<%= resource_var_name %>_ary<%='.values.flatten' unless delayed_sequence %>).to_json)
+      .to_return(status: 200, body: wrap_resources_in_bundle(@<%= resource_var_name %>_ary<%='.values.flatten' unless delayed_sequence %>.append(operation_outcome)).to_json)
     <% end %>
   <% end %>
   <% if token_param %>
     stub_request(:get, "#{@base_url}/<%= resource_type %>")
       .with(query: @query_with_system, headers: @auth_header)
-      .to_return(status: 200, body: wrap_resources_in_bundle(@<%= resource_var_name %>_ary<%='.values.flatten' unless delayed_sequence %>).to_json)
+      .to_return(status: 200, body: wrap_resources_in_bundle(@<%= resource_var_name %>_ary<%='.values.flatten' unless delayed_sequence %>.append(operation_outcome)).to_json)
   <% end %>
 
     @sequence.run_test(@test)

--- a/lib/app/sequence_base.rb
+++ b/lib/app/sequence_base.rb
@@ -524,7 +524,7 @@ module Inferno
         assert_response_ok(reply)
         assert_bundle_response(reply)
 
-        entries = fetch_all_bundled_resources(reply).select { |entry| entry.class == klass }
+        entries = fetch_all_bundled_resources(reply).select { |entry| entry.class == klass }.reject { |resource| resource.resourceType == 'OperationOutcome' }
         validate_reply_entries(entries, search_params)
         assert entries.present?, 'No resources of this type were returned'
       end
@@ -869,10 +869,7 @@ module Inferno
         resources = []
         bundle = reply.resource
         until bundle.nil? || page_count == 20
-          resources += bundle
-                        &.entry
-                        &.map { |entry| entry&.resource }
-                        &.reject { |resource| resource.resourceType == 'OperationOutcome' }
+          resources += bundle&.entry&.map { |entry| entry&.resource }
           next_bundle_link = bundle&.link&.find { |link| link.relation == 'next' }&.url
           reply_handler&.call(reply)
           break if next_bundle_link.blank?

--- a/lib/app/sequence_base.rb
+++ b/lib/app/sequence_base.rb
@@ -869,7 +869,10 @@ module Inferno
         resources = []
         bundle = reply.resource
         until bundle.nil? || page_count == 20
-          resources += bundle&.entry&.map { |entry| entry&.resource }
+          resources += bundle
+                        &.entry
+                        &.map { |entry| entry&.resource }
+                        &.reject { |resource| resource.resourceType == 'OperationOutcome' }
           next_bundle_link = bundle&.link&.find { |link| link.relation == 'next' }&.url
           reply_handler&.call(reply)
           break if next_bundle_link.blank?

--- a/lib/app/sequence_base.rb
+++ b/lib/app/sequence_base.rb
@@ -524,7 +524,8 @@ module Inferno
         assert_response_ok(reply)
         assert_bundle_response(reply)
         entries = fetch_all_bundled_resources(reply)
-        assert entries.all? { |entry| entry.class == klass || entry.class == FHIR::OperationOutcome }
+        assert(entries.all? { |entry| entry.class == klass || entry.class == FHIR::OperationOutcome },
+               "All resources returned must be of the type #{klass.to_s.demodulize} or OperationOutcome")
         validate_reply_entries(entries.reject { |entry| entry.class == FHIR::OperationOutcome }, search_params)
         assert entries.present?, 'No resources of this type were returned'
       end

--- a/lib/app/sequence_base.rb
+++ b/lib/app/sequence_base.rb
@@ -523,9 +523,9 @@ module Inferno
       def validate_search_reply(klass, reply, search_params)
         assert_response_ok(reply)
         assert_bundle_response(reply)
-
-        entries = fetch_all_bundled_resources(reply).select { |entry| entry.class == klass }.reject { |resource| resource.resourceType == 'OperationOutcome' }
-        validate_reply_entries(entries, search_params)
+        entries = fetch_all_bundled_resources(reply)
+        assert entries.all? { |entry| entry.class == klass || entry.class == FHIR::OperationOutcome }
+        validate_reply_entries(entries.reject { |entry| entry.class == FHIR::OperationOutcome }, search_params)
         assert entries.present?, 'No resources of this type were returned'
       end
 

--- a/lib/modules/uscore_v3.1.1/bodyheight_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/bodyheight_sequence.rb
@@ -265,10 +265,6 @@ module Inferno
           reply = perform_search_with_status(reply, search_params) if reply.code == 400
 
           validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
-          resource_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
-          assert(resource_returned.all? { |resource| ['Observation', 'OperationOutcome'].include? resource.resourceType },
-                 'All resources returned must be of the type Observation or OperationOutcome')
-          resource_returned.reject! { |resource| resource.resourceType == 'OperationOutcome' }
 
           ['gt', 'ge', 'lt', 'le'].each do |comparator|
             comparator_val = date_comparator_value(comparator, resolve_element_from_path(@observation_ary[patient], 'effective') { |el| get_value_for_search_param(el).present? })
@@ -320,10 +316,6 @@ module Inferno
           reply = perform_search_with_status(reply, search_params) if reply.code == 400
 
           validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
-          resource_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
-          assert(resource_returned.all? { |resource| ['Observation', 'OperationOutcome'].include? resource.resourceType },
-                 'All resources returned must be of the type Observation or OperationOutcome')
-          resource_returned.reject! { |resource| resource.resourceType == 'OperationOutcome' }
 
           value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category'), true)
           token_with_system_search_params = search_params.merge('category': value_with_system)
@@ -368,10 +360,6 @@ module Inferno
           reply = get_resource_by_params(versioned_resource_class('Observation'), search_params)
 
           validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
-          resource_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
-          assert(resource_returned.all? { |resource| ['Observation', 'OperationOutcome'].include? resource.resourceType },
-                 'All resources returned must be of the type Observation or OperationOutcome')
-          resource_returned.reject! { |resource| resource.resourceType == 'OperationOutcome' }
 
           value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category'), true)
           token_with_system_search_params = search_params.merge('category': value_with_system)
@@ -422,10 +410,6 @@ module Inferno
           reply = perform_search_with_status(reply, search_params) if reply.code == 400
 
           validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
-          resource_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
-          assert(resource_returned.all? { |resource| ['Observation', 'OperationOutcome'].include? resource.resourceType },
-                 'All resources returned must be of the type Observation or OperationOutcome')
-          resource_returned.reject! { |resource| resource.resourceType == 'OperationOutcome' }
 
           ['gt', 'ge', 'lt', 'le'].each do |comparator|
             comparator_val = date_comparator_value(comparator, resolve_element_from_path(@observation_ary[patient], 'effective') { |el| get_value_for_search_param(el).present? })

--- a/lib/modules/uscore_v3.1.1/bodyheight_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/bodyheight_sequence.rb
@@ -190,6 +190,9 @@ module Inferno
 
             @resources_found = true
             resources_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
+            assert(resources_returned.all? { |resource| ['Observation', 'OperationOutcome'].include? resource.resourceType },
+                   'All resources returned must be of the type Observation or OperationOutcome')
+            resources_returned.reject! { |resource| resource.resourceType == 'OperationOutcome' }
             @observation = resources_returned.first
             @observation_ary[patient] += resources_returned
 
@@ -212,6 +215,9 @@ module Inferno
             assert_response_ok(reply)
             assert_bundle_response(reply)
             search_with_type = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
+            assert(search_with_type.all? { |resource| ['Observation', 'OperationOutcome'].include? resource.resourceType },
+                   'All resources returned must be of the type Observation or OperationOutcome.')
+            search_with_type.reject! { |resource| resource.resourceType == 'OperationOutcome' }
             assert search_with_type.length == resources_returned.length, 'Expected search by Patient/ID to have the same results as search by ID'
 
             search_query_variants_tested_once = true
@@ -259,6 +265,10 @@ module Inferno
           reply = perform_search_with_status(reply, search_params) if reply.code == 400
 
           validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
+          resource_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
+          assert(resource_returned.all? { |resource| ['Observation', 'OperationOutcome'].include? resource.resourceType },
+                 'All resources returned must be of the type Observation or OperationOutcome')
+          resource_returned.reject! { |resource| resource.resourceType == 'OperationOutcome' }
 
           ['gt', 'ge', 'lt', 'le'].each do |comparator|
             comparator_val = date_comparator_value(comparator, resolve_element_from_path(@observation_ary[patient], 'effective') { |el| get_value_for_search_param(el).present? })
@@ -310,6 +320,10 @@ module Inferno
           reply = perform_search_with_status(reply, search_params) if reply.code == 400
 
           validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
+          resource_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
+          assert(resource_returned.all? { |resource| ['Observation', 'OperationOutcome'].include? resource.resourceType },
+                 'All resources returned must be of the type Observation or OperationOutcome')
+          resource_returned.reject! { |resource| resource.resourceType == 'OperationOutcome' }
 
           value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category'), true)
           token_with_system_search_params = search_params.merge('category': value_with_system)
@@ -354,6 +368,10 @@ module Inferno
           reply = get_resource_by_params(versioned_resource_class('Observation'), search_params)
 
           validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
+          resource_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
+          assert(resource_returned.all? { |resource| ['Observation', 'OperationOutcome'].include? resource.resourceType },
+                 'All resources returned must be of the type Observation or OperationOutcome')
+          resource_returned.reject! { |resource| resource.resourceType == 'OperationOutcome' }
 
           value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category'), true)
           token_with_system_search_params = search_params.merge('category': value_with_system)
@@ -404,6 +422,10 @@ module Inferno
           reply = perform_search_with_status(reply, search_params) if reply.code == 400
 
           validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
+          resource_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
+          assert(resource_returned.all? { |resource| ['Observation', 'OperationOutcome'].include? resource.resourceType },
+                 'All resources returned must be of the type Observation or OperationOutcome')
+          resource_returned.reject! { |resource| resource.resourceType == 'OperationOutcome' }
 
           ['gt', 'ge', 'lt', 'le'].each do |comparator|
             comparator_val = date_comparator_value(comparator, resolve_element_from_path(@observation_ary[patient], 'effective') { |el| get_value_for_search_param(el).present? })

--- a/lib/modules/uscore_v3.1.1/bodytemp_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/bodytemp_sequence.rb
@@ -265,10 +265,6 @@ module Inferno
           reply = perform_search_with_status(reply, search_params) if reply.code == 400
 
           validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
-          resource_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
-          assert(resource_returned.all? { |resource| ['Observation', 'OperationOutcome'].include? resource.resourceType },
-                 'All resources returned must be of the type Observation or OperationOutcome')
-          resource_returned.reject! { |resource| resource.resourceType == 'OperationOutcome' }
 
           ['gt', 'ge', 'lt', 'le'].each do |comparator|
             comparator_val = date_comparator_value(comparator, resolve_element_from_path(@observation_ary[patient], 'effective') { |el| get_value_for_search_param(el).present? })
@@ -320,10 +316,6 @@ module Inferno
           reply = perform_search_with_status(reply, search_params) if reply.code == 400
 
           validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
-          resource_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
-          assert(resource_returned.all? { |resource| ['Observation', 'OperationOutcome'].include? resource.resourceType },
-                 'All resources returned must be of the type Observation or OperationOutcome')
-          resource_returned.reject! { |resource| resource.resourceType == 'OperationOutcome' }
 
           value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category'), true)
           token_with_system_search_params = search_params.merge('category': value_with_system)
@@ -368,10 +360,6 @@ module Inferno
           reply = get_resource_by_params(versioned_resource_class('Observation'), search_params)
 
           validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
-          resource_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
-          assert(resource_returned.all? { |resource| ['Observation', 'OperationOutcome'].include? resource.resourceType },
-                 'All resources returned must be of the type Observation or OperationOutcome')
-          resource_returned.reject! { |resource| resource.resourceType == 'OperationOutcome' }
 
           value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category'), true)
           token_with_system_search_params = search_params.merge('category': value_with_system)
@@ -422,10 +410,6 @@ module Inferno
           reply = perform_search_with_status(reply, search_params) if reply.code == 400
 
           validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
-          resource_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
-          assert(resource_returned.all? { |resource| ['Observation', 'OperationOutcome'].include? resource.resourceType },
-                 'All resources returned must be of the type Observation or OperationOutcome')
-          resource_returned.reject! { |resource| resource.resourceType == 'OperationOutcome' }
 
           ['gt', 'ge', 'lt', 'le'].each do |comparator|
             comparator_val = date_comparator_value(comparator, resolve_element_from_path(@observation_ary[patient], 'effective') { |el| get_value_for_search_param(el).present? })

--- a/lib/modules/uscore_v3.1.1/bodytemp_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/bodytemp_sequence.rb
@@ -190,6 +190,9 @@ module Inferno
 
             @resources_found = true
             resources_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
+            assert(resources_returned.all? { |resource| ['Observation', 'OperationOutcome'].include? resource.resourceType },
+                   'All resources returned must be of the type Observation or OperationOutcome')
+            resources_returned.reject! { |resource| resource.resourceType == 'OperationOutcome' }
             @observation = resources_returned.first
             @observation_ary[patient] += resources_returned
 
@@ -212,6 +215,9 @@ module Inferno
             assert_response_ok(reply)
             assert_bundle_response(reply)
             search_with_type = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
+            assert(search_with_type.all? { |resource| ['Observation', 'OperationOutcome'].include? resource.resourceType },
+                   'All resources returned must be of the type Observation or OperationOutcome.')
+            search_with_type.reject! { |resource| resource.resourceType == 'OperationOutcome' }
             assert search_with_type.length == resources_returned.length, 'Expected search by Patient/ID to have the same results as search by ID'
 
             search_query_variants_tested_once = true
@@ -259,6 +265,10 @@ module Inferno
           reply = perform_search_with_status(reply, search_params) if reply.code == 400
 
           validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
+          resource_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
+          assert(resource_returned.all? { |resource| ['Observation', 'OperationOutcome'].include? resource.resourceType },
+                 'All resources returned must be of the type Observation or OperationOutcome')
+          resource_returned.reject! { |resource| resource.resourceType == 'OperationOutcome' }
 
           ['gt', 'ge', 'lt', 'le'].each do |comparator|
             comparator_val = date_comparator_value(comparator, resolve_element_from_path(@observation_ary[patient], 'effective') { |el| get_value_for_search_param(el).present? })
@@ -310,6 +320,10 @@ module Inferno
           reply = perform_search_with_status(reply, search_params) if reply.code == 400
 
           validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
+          resource_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
+          assert(resource_returned.all? { |resource| ['Observation', 'OperationOutcome'].include? resource.resourceType },
+                 'All resources returned must be of the type Observation or OperationOutcome')
+          resource_returned.reject! { |resource| resource.resourceType == 'OperationOutcome' }
 
           value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category'), true)
           token_with_system_search_params = search_params.merge('category': value_with_system)
@@ -354,6 +368,10 @@ module Inferno
           reply = get_resource_by_params(versioned_resource_class('Observation'), search_params)
 
           validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
+          resource_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
+          assert(resource_returned.all? { |resource| ['Observation', 'OperationOutcome'].include? resource.resourceType },
+                 'All resources returned must be of the type Observation or OperationOutcome')
+          resource_returned.reject! { |resource| resource.resourceType == 'OperationOutcome' }
 
           value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category'), true)
           token_with_system_search_params = search_params.merge('category': value_with_system)
@@ -404,6 +422,10 @@ module Inferno
           reply = perform_search_with_status(reply, search_params) if reply.code == 400
 
           validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
+          resource_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
+          assert(resource_returned.all? { |resource| ['Observation', 'OperationOutcome'].include? resource.resourceType },
+                 'All resources returned must be of the type Observation or OperationOutcome')
+          resource_returned.reject! { |resource| resource.resourceType == 'OperationOutcome' }
 
           ['gt', 'ge', 'lt', 'le'].each do |comparator|
             comparator_val = date_comparator_value(comparator, resolve_element_from_path(@observation_ary[patient], 'effective') { |el| get_value_for_search_param(el).present? })

--- a/lib/modules/uscore_v3.1.1/bodyweight_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/bodyweight_sequence.rb
@@ -265,10 +265,6 @@ module Inferno
           reply = perform_search_with_status(reply, search_params) if reply.code == 400
 
           validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
-          resource_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
-          assert(resource_returned.all? { |resource| ['Observation', 'OperationOutcome'].include? resource.resourceType },
-                 'All resources returned must be of the type Observation or OperationOutcome')
-          resource_returned.reject! { |resource| resource.resourceType == 'OperationOutcome' }
 
           ['gt', 'ge', 'lt', 'le'].each do |comparator|
             comparator_val = date_comparator_value(comparator, resolve_element_from_path(@observation_ary[patient], 'effective') { |el| get_value_for_search_param(el).present? })
@@ -320,10 +316,6 @@ module Inferno
           reply = perform_search_with_status(reply, search_params) if reply.code == 400
 
           validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
-          resource_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
-          assert(resource_returned.all? { |resource| ['Observation', 'OperationOutcome'].include? resource.resourceType },
-                 'All resources returned must be of the type Observation or OperationOutcome')
-          resource_returned.reject! { |resource| resource.resourceType == 'OperationOutcome' }
 
           value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category'), true)
           token_with_system_search_params = search_params.merge('category': value_with_system)
@@ -368,10 +360,6 @@ module Inferno
           reply = get_resource_by_params(versioned_resource_class('Observation'), search_params)
 
           validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
-          resource_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
-          assert(resource_returned.all? { |resource| ['Observation', 'OperationOutcome'].include? resource.resourceType },
-                 'All resources returned must be of the type Observation or OperationOutcome')
-          resource_returned.reject! { |resource| resource.resourceType == 'OperationOutcome' }
 
           value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category'), true)
           token_with_system_search_params = search_params.merge('category': value_with_system)
@@ -422,10 +410,6 @@ module Inferno
           reply = perform_search_with_status(reply, search_params) if reply.code == 400
 
           validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
-          resource_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
-          assert(resource_returned.all? { |resource| ['Observation', 'OperationOutcome'].include? resource.resourceType },
-                 'All resources returned must be of the type Observation or OperationOutcome')
-          resource_returned.reject! { |resource| resource.resourceType == 'OperationOutcome' }
 
           ['gt', 'ge', 'lt', 'le'].each do |comparator|
             comparator_val = date_comparator_value(comparator, resolve_element_from_path(@observation_ary[patient], 'effective') { |el| get_value_for_search_param(el).present? })

--- a/lib/modules/uscore_v3.1.1/bodyweight_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/bodyweight_sequence.rb
@@ -190,6 +190,9 @@ module Inferno
 
             @resources_found = true
             resources_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
+            assert(resources_returned.all? { |resource| ['Observation', 'OperationOutcome'].include? resource.resourceType },
+                   'All resources returned must be of the type Observation or OperationOutcome')
+            resources_returned.reject! { |resource| resource.resourceType == 'OperationOutcome' }
             @observation = resources_returned.first
             @observation_ary[patient] += resources_returned
 
@@ -212,6 +215,9 @@ module Inferno
             assert_response_ok(reply)
             assert_bundle_response(reply)
             search_with_type = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
+            assert(search_with_type.all? { |resource| ['Observation', 'OperationOutcome'].include? resource.resourceType },
+                   'All resources returned must be of the type Observation or OperationOutcome.')
+            search_with_type.reject! { |resource| resource.resourceType == 'OperationOutcome' }
             assert search_with_type.length == resources_returned.length, 'Expected search by Patient/ID to have the same results as search by ID'
 
             search_query_variants_tested_once = true
@@ -259,6 +265,10 @@ module Inferno
           reply = perform_search_with_status(reply, search_params) if reply.code == 400
 
           validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
+          resource_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
+          assert(resource_returned.all? { |resource| ['Observation', 'OperationOutcome'].include? resource.resourceType },
+                 'All resources returned must be of the type Observation or OperationOutcome')
+          resource_returned.reject! { |resource| resource.resourceType == 'OperationOutcome' }
 
           ['gt', 'ge', 'lt', 'le'].each do |comparator|
             comparator_val = date_comparator_value(comparator, resolve_element_from_path(@observation_ary[patient], 'effective') { |el| get_value_for_search_param(el).present? })
@@ -310,6 +320,10 @@ module Inferno
           reply = perform_search_with_status(reply, search_params) if reply.code == 400
 
           validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
+          resource_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
+          assert(resource_returned.all? { |resource| ['Observation', 'OperationOutcome'].include? resource.resourceType },
+                 'All resources returned must be of the type Observation or OperationOutcome')
+          resource_returned.reject! { |resource| resource.resourceType == 'OperationOutcome' }
 
           value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category'), true)
           token_with_system_search_params = search_params.merge('category': value_with_system)
@@ -354,6 +368,10 @@ module Inferno
           reply = get_resource_by_params(versioned_resource_class('Observation'), search_params)
 
           validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
+          resource_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
+          assert(resource_returned.all? { |resource| ['Observation', 'OperationOutcome'].include? resource.resourceType },
+                 'All resources returned must be of the type Observation or OperationOutcome')
+          resource_returned.reject! { |resource| resource.resourceType == 'OperationOutcome' }
 
           value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category'), true)
           token_with_system_search_params = search_params.merge('category': value_with_system)
@@ -404,6 +422,10 @@ module Inferno
           reply = perform_search_with_status(reply, search_params) if reply.code == 400
 
           validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
+          resource_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
+          assert(resource_returned.all? { |resource| ['Observation', 'OperationOutcome'].include? resource.resourceType },
+                 'All resources returned must be of the type Observation or OperationOutcome')
+          resource_returned.reject! { |resource| resource.resourceType == 'OperationOutcome' }
 
           ['gt', 'ge', 'lt', 'le'].each do |comparator|
             comparator_val = date_comparator_value(comparator, resolve_element_from_path(@observation_ary[patient], 'effective') { |el| get_value_for_search_param(el).present? })

--- a/lib/modules/uscore_v3.1.1/bp_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/bp_sequence.rb
@@ -265,10 +265,6 @@ module Inferno
           reply = perform_search_with_status(reply, search_params) if reply.code == 400
 
           validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
-          resource_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
-          assert(resource_returned.all? { |resource| ['Observation', 'OperationOutcome'].include? resource.resourceType },
-                 'All resources returned must be of the type Observation or OperationOutcome')
-          resource_returned.reject! { |resource| resource.resourceType == 'OperationOutcome' }
 
           ['gt', 'ge', 'lt', 'le'].each do |comparator|
             comparator_val = date_comparator_value(comparator, resolve_element_from_path(@observation_ary[patient], 'effective') { |el| get_value_for_search_param(el).present? })
@@ -320,10 +316,6 @@ module Inferno
           reply = perform_search_with_status(reply, search_params) if reply.code == 400
 
           validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
-          resource_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
-          assert(resource_returned.all? { |resource| ['Observation', 'OperationOutcome'].include? resource.resourceType },
-                 'All resources returned must be of the type Observation or OperationOutcome')
-          resource_returned.reject! { |resource| resource.resourceType == 'OperationOutcome' }
 
           value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category'), true)
           token_with_system_search_params = search_params.merge('category': value_with_system)
@@ -368,10 +360,6 @@ module Inferno
           reply = get_resource_by_params(versioned_resource_class('Observation'), search_params)
 
           validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
-          resource_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
-          assert(resource_returned.all? { |resource| ['Observation', 'OperationOutcome'].include? resource.resourceType },
-                 'All resources returned must be of the type Observation or OperationOutcome')
-          resource_returned.reject! { |resource| resource.resourceType == 'OperationOutcome' }
 
           value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category'), true)
           token_with_system_search_params = search_params.merge('category': value_with_system)
@@ -422,10 +410,6 @@ module Inferno
           reply = perform_search_with_status(reply, search_params) if reply.code == 400
 
           validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
-          resource_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
-          assert(resource_returned.all? { |resource| ['Observation', 'OperationOutcome'].include? resource.resourceType },
-                 'All resources returned must be of the type Observation or OperationOutcome')
-          resource_returned.reject! { |resource| resource.resourceType == 'OperationOutcome' }
 
           ['gt', 'ge', 'lt', 'le'].each do |comparator|
             comparator_val = date_comparator_value(comparator, resolve_element_from_path(@observation_ary[patient], 'effective') { |el| get_value_for_search_param(el).present? })

--- a/lib/modules/uscore_v3.1.1/bp_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/bp_sequence.rb
@@ -190,6 +190,9 @@ module Inferno
 
             @resources_found = true
             resources_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
+            assert(resources_returned.all? { |resource| ['Observation', 'OperationOutcome'].include? resource.resourceType },
+                   'All resources returned must be of the type Observation or OperationOutcome')
+            resources_returned.reject! { |resource| resource.resourceType == 'OperationOutcome' }
             @observation = resources_returned.first
             @observation_ary[patient] += resources_returned
 
@@ -212,6 +215,9 @@ module Inferno
             assert_response_ok(reply)
             assert_bundle_response(reply)
             search_with_type = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
+            assert(search_with_type.all? { |resource| ['Observation', 'OperationOutcome'].include? resource.resourceType },
+                   'All resources returned must be of the type Observation or OperationOutcome.')
+            search_with_type.reject! { |resource| resource.resourceType == 'OperationOutcome' }
             assert search_with_type.length == resources_returned.length, 'Expected search by Patient/ID to have the same results as search by ID'
 
             search_query_variants_tested_once = true
@@ -259,6 +265,10 @@ module Inferno
           reply = perform_search_with_status(reply, search_params) if reply.code == 400
 
           validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
+          resource_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
+          assert(resource_returned.all? { |resource| ['Observation', 'OperationOutcome'].include? resource.resourceType },
+                 'All resources returned must be of the type Observation or OperationOutcome')
+          resource_returned.reject! { |resource| resource.resourceType == 'OperationOutcome' }
 
           ['gt', 'ge', 'lt', 'le'].each do |comparator|
             comparator_val = date_comparator_value(comparator, resolve_element_from_path(@observation_ary[patient], 'effective') { |el| get_value_for_search_param(el).present? })
@@ -310,6 +320,10 @@ module Inferno
           reply = perform_search_with_status(reply, search_params) if reply.code == 400
 
           validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
+          resource_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
+          assert(resource_returned.all? { |resource| ['Observation', 'OperationOutcome'].include? resource.resourceType },
+                 'All resources returned must be of the type Observation or OperationOutcome')
+          resource_returned.reject! { |resource| resource.resourceType == 'OperationOutcome' }
 
           value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category'), true)
           token_with_system_search_params = search_params.merge('category': value_with_system)
@@ -354,6 +368,10 @@ module Inferno
           reply = get_resource_by_params(versioned_resource_class('Observation'), search_params)
 
           validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
+          resource_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
+          assert(resource_returned.all? { |resource| ['Observation', 'OperationOutcome'].include? resource.resourceType },
+                 'All resources returned must be of the type Observation or OperationOutcome')
+          resource_returned.reject! { |resource| resource.resourceType == 'OperationOutcome' }
 
           value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category'), true)
           token_with_system_search_params = search_params.merge('category': value_with_system)
@@ -404,6 +422,10 @@ module Inferno
           reply = perform_search_with_status(reply, search_params) if reply.code == 400
 
           validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
+          resource_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
+          assert(resource_returned.all? { |resource| ['Observation', 'OperationOutcome'].include? resource.resourceType },
+                 'All resources returned must be of the type Observation or OperationOutcome')
+          resource_returned.reject! { |resource| resource.resourceType == 'OperationOutcome' }
 
           ['gt', 'ge', 'lt', 'le'].each do |comparator|
             comparator_val = date_comparator_value(comparator, resolve_element_from_path(@observation_ary[patient], 'effective') { |el| get_value_for_search_param(el).present? })

--- a/lib/modules/uscore_v3.1.1/head_occipital_frontal_circumference_percentile_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/head_occipital_frontal_circumference_percentile_sequence.rb
@@ -265,10 +265,6 @@ module Inferno
           reply = perform_search_with_status(reply, search_params) if reply.code == 400
 
           validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
-          resource_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
-          assert(resource_returned.all? { |resource| ['Observation', 'OperationOutcome'].include? resource.resourceType },
-                 'All resources returned must be of the type Observation or OperationOutcome')
-          resource_returned.reject! { |resource| resource.resourceType == 'OperationOutcome' }
 
           ['gt', 'ge', 'lt', 'le'].each do |comparator|
             comparator_val = date_comparator_value(comparator, resolve_element_from_path(@observation_ary[patient], 'effective') { |el| get_value_for_search_param(el).present? })
@@ -320,10 +316,6 @@ module Inferno
           reply = perform_search_with_status(reply, search_params) if reply.code == 400
 
           validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
-          resource_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
-          assert(resource_returned.all? { |resource| ['Observation', 'OperationOutcome'].include? resource.resourceType },
-                 'All resources returned must be of the type Observation or OperationOutcome')
-          resource_returned.reject! { |resource| resource.resourceType == 'OperationOutcome' }
 
           value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category'), true)
           token_with_system_search_params = search_params.merge('category': value_with_system)
@@ -368,10 +360,6 @@ module Inferno
           reply = get_resource_by_params(versioned_resource_class('Observation'), search_params)
 
           validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
-          resource_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
-          assert(resource_returned.all? { |resource| ['Observation', 'OperationOutcome'].include? resource.resourceType },
-                 'All resources returned must be of the type Observation or OperationOutcome')
-          resource_returned.reject! { |resource| resource.resourceType == 'OperationOutcome' }
 
           value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category'), true)
           token_with_system_search_params = search_params.merge('category': value_with_system)
@@ -422,10 +410,6 @@ module Inferno
           reply = perform_search_with_status(reply, search_params) if reply.code == 400
 
           validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
-          resource_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
-          assert(resource_returned.all? { |resource| ['Observation', 'OperationOutcome'].include? resource.resourceType },
-                 'All resources returned must be of the type Observation or OperationOutcome')
-          resource_returned.reject! { |resource| resource.resourceType == 'OperationOutcome' }
 
           ['gt', 'ge', 'lt', 'le'].each do |comparator|
             comparator_val = date_comparator_value(comparator, resolve_element_from_path(@observation_ary[patient], 'effective') { |el| get_value_for_search_param(el).present? })

--- a/lib/modules/uscore_v3.1.1/head_occipital_frontal_circumference_percentile_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/head_occipital_frontal_circumference_percentile_sequence.rb
@@ -190,6 +190,9 @@ module Inferno
 
             @resources_found = true
             resources_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
+            assert(resources_returned.all? { |resource| ['Observation', 'OperationOutcome'].include? resource.resourceType },
+                   'All resources returned must be of the type Observation or OperationOutcome')
+            resources_returned.reject! { |resource| resource.resourceType == 'OperationOutcome' }
             @observation = resources_returned.first
             @observation_ary[patient] += resources_returned
 
@@ -212,6 +215,9 @@ module Inferno
             assert_response_ok(reply)
             assert_bundle_response(reply)
             search_with_type = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
+            assert(search_with_type.all? { |resource| ['Observation', 'OperationOutcome'].include? resource.resourceType },
+                   'All resources returned must be of the type Observation or OperationOutcome.')
+            search_with_type.reject! { |resource| resource.resourceType == 'OperationOutcome' }
             assert search_with_type.length == resources_returned.length, 'Expected search by Patient/ID to have the same results as search by ID'
 
             search_query_variants_tested_once = true
@@ -259,6 +265,10 @@ module Inferno
           reply = perform_search_with_status(reply, search_params) if reply.code == 400
 
           validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
+          resource_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
+          assert(resource_returned.all? { |resource| ['Observation', 'OperationOutcome'].include? resource.resourceType },
+                 'All resources returned must be of the type Observation or OperationOutcome')
+          resource_returned.reject! { |resource| resource.resourceType == 'OperationOutcome' }
 
           ['gt', 'ge', 'lt', 'le'].each do |comparator|
             comparator_val = date_comparator_value(comparator, resolve_element_from_path(@observation_ary[patient], 'effective') { |el| get_value_for_search_param(el).present? })
@@ -310,6 +320,10 @@ module Inferno
           reply = perform_search_with_status(reply, search_params) if reply.code == 400
 
           validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
+          resource_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
+          assert(resource_returned.all? { |resource| ['Observation', 'OperationOutcome'].include? resource.resourceType },
+                 'All resources returned must be of the type Observation or OperationOutcome')
+          resource_returned.reject! { |resource| resource.resourceType == 'OperationOutcome' }
 
           value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category'), true)
           token_with_system_search_params = search_params.merge('category': value_with_system)
@@ -354,6 +368,10 @@ module Inferno
           reply = get_resource_by_params(versioned_resource_class('Observation'), search_params)
 
           validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
+          resource_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
+          assert(resource_returned.all? { |resource| ['Observation', 'OperationOutcome'].include? resource.resourceType },
+                 'All resources returned must be of the type Observation or OperationOutcome')
+          resource_returned.reject! { |resource| resource.resourceType == 'OperationOutcome' }
 
           value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category'), true)
           token_with_system_search_params = search_params.merge('category': value_with_system)
@@ -404,6 +422,10 @@ module Inferno
           reply = perform_search_with_status(reply, search_params) if reply.code == 400
 
           validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
+          resource_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
+          assert(resource_returned.all? { |resource| ['Observation', 'OperationOutcome'].include? resource.resourceType },
+                 'All resources returned must be of the type Observation or OperationOutcome')
+          resource_returned.reject! { |resource| resource.resourceType == 'OperationOutcome' }
 
           ['gt', 'ge', 'lt', 'le'].each do |comparator|
             comparator_val = date_comparator_value(comparator, resolve_element_from_path(@observation_ary[patient], 'effective') { |el| get_value_for_search_param(el).present? })

--- a/lib/modules/uscore_v3.1.1/heartrate_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/heartrate_sequence.rb
@@ -265,10 +265,6 @@ module Inferno
           reply = perform_search_with_status(reply, search_params) if reply.code == 400
 
           validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
-          resource_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
-          assert(resource_returned.all? { |resource| ['Observation', 'OperationOutcome'].include? resource.resourceType },
-                 'All resources returned must be of the type Observation or OperationOutcome')
-          resource_returned.reject! { |resource| resource.resourceType == 'OperationOutcome' }
 
           ['gt', 'ge', 'lt', 'le'].each do |comparator|
             comparator_val = date_comparator_value(comparator, resolve_element_from_path(@observation_ary[patient], 'effective') { |el| get_value_for_search_param(el).present? })
@@ -320,10 +316,6 @@ module Inferno
           reply = perform_search_with_status(reply, search_params) if reply.code == 400
 
           validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
-          resource_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
-          assert(resource_returned.all? { |resource| ['Observation', 'OperationOutcome'].include? resource.resourceType },
-                 'All resources returned must be of the type Observation or OperationOutcome')
-          resource_returned.reject! { |resource| resource.resourceType == 'OperationOutcome' }
 
           value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category'), true)
           token_with_system_search_params = search_params.merge('category': value_with_system)
@@ -368,10 +360,6 @@ module Inferno
           reply = get_resource_by_params(versioned_resource_class('Observation'), search_params)
 
           validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
-          resource_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
-          assert(resource_returned.all? { |resource| ['Observation', 'OperationOutcome'].include? resource.resourceType },
-                 'All resources returned must be of the type Observation or OperationOutcome')
-          resource_returned.reject! { |resource| resource.resourceType == 'OperationOutcome' }
 
           value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category'), true)
           token_with_system_search_params = search_params.merge('category': value_with_system)
@@ -422,10 +410,6 @@ module Inferno
           reply = perform_search_with_status(reply, search_params) if reply.code == 400
 
           validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
-          resource_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
-          assert(resource_returned.all? { |resource| ['Observation', 'OperationOutcome'].include? resource.resourceType },
-                 'All resources returned must be of the type Observation or OperationOutcome')
-          resource_returned.reject! { |resource| resource.resourceType == 'OperationOutcome' }
 
           ['gt', 'ge', 'lt', 'le'].each do |comparator|
             comparator_val = date_comparator_value(comparator, resolve_element_from_path(@observation_ary[patient], 'effective') { |el| get_value_for_search_param(el).present? })

--- a/lib/modules/uscore_v3.1.1/heartrate_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/heartrate_sequence.rb
@@ -190,6 +190,9 @@ module Inferno
 
             @resources_found = true
             resources_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
+            assert(resources_returned.all? { |resource| ['Observation', 'OperationOutcome'].include? resource.resourceType },
+                   'All resources returned must be of the type Observation or OperationOutcome')
+            resources_returned.reject! { |resource| resource.resourceType == 'OperationOutcome' }
             @observation = resources_returned.first
             @observation_ary[patient] += resources_returned
 
@@ -212,6 +215,9 @@ module Inferno
             assert_response_ok(reply)
             assert_bundle_response(reply)
             search_with_type = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
+            assert(search_with_type.all? { |resource| ['Observation', 'OperationOutcome'].include? resource.resourceType },
+                   'All resources returned must be of the type Observation or OperationOutcome.')
+            search_with_type.reject! { |resource| resource.resourceType == 'OperationOutcome' }
             assert search_with_type.length == resources_returned.length, 'Expected search by Patient/ID to have the same results as search by ID'
 
             search_query_variants_tested_once = true
@@ -259,6 +265,10 @@ module Inferno
           reply = perform_search_with_status(reply, search_params) if reply.code == 400
 
           validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
+          resource_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
+          assert(resource_returned.all? { |resource| ['Observation', 'OperationOutcome'].include? resource.resourceType },
+                 'All resources returned must be of the type Observation or OperationOutcome')
+          resource_returned.reject! { |resource| resource.resourceType == 'OperationOutcome' }
 
           ['gt', 'ge', 'lt', 'le'].each do |comparator|
             comparator_val = date_comparator_value(comparator, resolve_element_from_path(@observation_ary[patient], 'effective') { |el| get_value_for_search_param(el).present? })
@@ -310,6 +320,10 @@ module Inferno
           reply = perform_search_with_status(reply, search_params) if reply.code == 400
 
           validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
+          resource_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
+          assert(resource_returned.all? { |resource| ['Observation', 'OperationOutcome'].include? resource.resourceType },
+                 'All resources returned must be of the type Observation or OperationOutcome')
+          resource_returned.reject! { |resource| resource.resourceType == 'OperationOutcome' }
 
           value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category'), true)
           token_with_system_search_params = search_params.merge('category': value_with_system)
@@ -354,6 +368,10 @@ module Inferno
           reply = get_resource_by_params(versioned_resource_class('Observation'), search_params)
 
           validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
+          resource_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
+          assert(resource_returned.all? { |resource| ['Observation', 'OperationOutcome'].include? resource.resourceType },
+                 'All resources returned must be of the type Observation or OperationOutcome')
+          resource_returned.reject! { |resource| resource.resourceType == 'OperationOutcome' }
 
           value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category'), true)
           token_with_system_search_params = search_params.merge('category': value_with_system)
@@ -404,6 +422,10 @@ module Inferno
           reply = perform_search_with_status(reply, search_params) if reply.code == 400
 
           validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
+          resource_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
+          assert(resource_returned.all? { |resource| ['Observation', 'OperationOutcome'].include? resource.resourceType },
+                 'All resources returned must be of the type Observation or OperationOutcome')
+          resource_returned.reject! { |resource| resource.resourceType == 'OperationOutcome' }
 
           ['gt', 'ge', 'lt', 'le'].each do |comparator|
             comparator_val = date_comparator_value(comparator, resolve_element_from_path(@observation_ary[patient], 'effective') { |el| get_value_for_search_param(el).present? })

--- a/lib/modules/uscore_v3.1.1/pediatric_bmi_for_age_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/pediatric_bmi_for_age_sequence.rb
@@ -265,10 +265,6 @@ module Inferno
           reply = perform_search_with_status(reply, search_params) if reply.code == 400
 
           validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
-          resource_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
-          assert(resource_returned.all? { |resource| ['Observation', 'OperationOutcome'].include? resource.resourceType },
-                 'All resources returned must be of the type Observation or OperationOutcome')
-          resource_returned.reject! { |resource| resource.resourceType == 'OperationOutcome' }
 
           ['gt', 'ge', 'lt', 'le'].each do |comparator|
             comparator_val = date_comparator_value(comparator, resolve_element_from_path(@observation_ary[patient], 'effective') { |el| get_value_for_search_param(el).present? })
@@ -320,10 +316,6 @@ module Inferno
           reply = perform_search_with_status(reply, search_params) if reply.code == 400
 
           validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
-          resource_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
-          assert(resource_returned.all? { |resource| ['Observation', 'OperationOutcome'].include? resource.resourceType },
-                 'All resources returned must be of the type Observation or OperationOutcome')
-          resource_returned.reject! { |resource| resource.resourceType == 'OperationOutcome' }
 
           value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category'), true)
           token_with_system_search_params = search_params.merge('category': value_with_system)
@@ -368,10 +360,6 @@ module Inferno
           reply = get_resource_by_params(versioned_resource_class('Observation'), search_params)
 
           validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
-          resource_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
-          assert(resource_returned.all? { |resource| ['Observation', 'OperationOutcome'].include? resource.resourceType },
-                 'All resources returned must be of the type Observation or OperationOutcome')
-          resource_returned.reject! { |resource| resource.resourceType == 'OperationOutcome' }
 
           value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category'), true)
           token_with_system_search_params = search_params.merge('category': value_with_system)
@@ -422,10 +410,6 @@ module Inferno
           reply = perform_search_with_status(reply, search_params) if reply.code == 400
 
           validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
-          resource_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
-          assert(resource_returned.all? { |resource| ['Observation', 'OperationOutcome'].include? resource.resourceType },
-                 'All resources returned must be of the type Observation or OperationOutcome')
-          resource_returned.reject! { |resource| resource.resourceType == 'OperationOutcome' }
 
           ['gt', 'ge', 'lt', 'le'].each do |comparator|
             comparator_val = date_comparator_value(comparator, resolve_element_from_path(@observation_ary[patient], 'effective') { |el| get_value_for_search_param(el).present? })

--- a/lib/modules/uscore_v3.1.1/pediatric_bmi_for_age_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/pediatric_bmi_for_age_sequence.rb
@@ -190,6 +190,9 @@ module Inferno
 
             @resources_found = true
             resources_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
+            assert(resources_returned.all? { |resource| ['Observation', 'OperationOutcome'].include? resource.resourceType },
+                   'All resources returned must be of the type Observation or OperationOutcome')
+            resources_returned.reject! { |resource| resource.resourceType == 'OperationOutcome' }
             @observation = resources_returned.first
             @observation_ary[patient] += resources_returned
 
@@ -212,6 +215,9 @@ module Inferno
             assert_response_ok(reply)
             assert_bundle_response(reply)
             search_with_type = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
+            assert(search_with_type.all? { |resource| ['Observation', 'OperationOutcome'].include? resource.resourceType },
+                   'All resources returned must be of the type Observation or OperationOutcome.')
+            search_with_type.reject! { |resource| resource.resourceType == 'OperationOutcome' }
             assert search_with_type.length == resources_returned.length, 'Expected search by Patient/ID to have the same results as search by ID'
 
             search_query_variants_tested_once = true
@@ -259,6 +265,10 @@ module Inferno
           reply = perform_search_with_status(reply, search_params) if reply.code == 400
 
           validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
+          resource_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
+          assert(resource_returned.all? { |resource| ['Observation', 'OperationOutcome'].include? resource.resourceType },
+                 'All resources returned must be of the type Observation or OperationOutcome')
+          resource_returned.reject! { |resource| resource.resourceType == 'OperationOutcome' }
 
           ['gt', 'ge', 'lt', 'le'].each do |comparator|
             comparator_val = date_comparator_value(comparator, resolve_element_from_path(@observation_ary[patient], 'effective') { |el| get_value_for_search_param(el).present? })
@@ -310,6 +320,10 @@ module Inferno
           reply = perform_search_with_status(reply, search_params) if reply.code == 400
 
           validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
+          resource_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
+          assert(resource_returned.all? { |resource| ['Observation', 'OperationOutcome'].include? resource.resourceType },
+                 'All resources returned must be of the type Observation or OperationOutcome')
+          resource_returned.reject! { |resource| resource.resourceType == 'OperationOutcome' }
 
           value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category'), true)
           token_with_system_search_params = search_params.merge('category': value_with_system)
@@ -354,6 +368,10 @@ module Inferno
           reply = get_resource_by_params(versioned_resource_class('Observation'), search_params)
 
           validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
+          resource_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
+          assert(resource_returned.all? { |resource| ['Observation', 'OperationOutcome'].include? resource.resourceType },
+                 'All resources returned must be of the type Observation or OperationOutcome')
+          resource_returned.reject! { |resource| resource.resourceType == 'OperationOutcome' }
 
           value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category'), true)
           token_with_system_search_params = search_params.merge('category': value_with_system)
@@ -404,6 +422,10 @@ module Inferno
           reply = perform_search_with_status(reply, search_params) if reply.code == 400
 
           validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
+          resource_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
+          assert(resource_returned.all? { |resource| ['Observation', 'OperationOutcome'].include? resource.resourceType },
+                 'All resources returned must be of the type Observation or OperationOutcome')
+          resource_returned.reject! { |resource| resource.resourceType == 'OperationOutcome' }
 
           ['gt', 'ge', 'lt', 'le'].each do |comparator|
             comparator_val = date_comparator_value(comparator, resolve_element_from_path(@observation_ary[patient], 'effective') { |el| get_value_for_search_param(el).present? })

--- a/lib/modules/uscore_v3.1.1/pediatric_weight_for_height_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/pediatric_weight_for_height_sequence.rb
@@ -265,10 +265,6 @@ module Inferno
           reply = perform_search_with_status(reply, search_params) if reply.code == 400
 
           validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
-          resource_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
-          assert(resource_returned.all? { |resource| ['Observation', 'OperationOutcome'].include? resource.resourceType },
-                 'All resources returned must be of the type Observation or OperationOutcome')
-          resource_returned.reject! { |resource| resource.resourceType == 'OperationOutcome' }
 
           ['gt', 'ge', 'lt', 'le'].each do |comparator|
             comparator_val = date_comparator_value(comparator, resolve_element_from_path(@observation_ary[patient], 'effective') { |el| get_value_for_search_param(el).present? })
@@ -320,10 +316,6 @@ module Inferno
           reply = perform_search_with_status(reply, search_params) if reply.code == 400
 
           validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
-          resource_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
-          assert(resource_returned.all? { |resource| ['Observation', 'OperationOutcome'].include? resource.resourceType },
-                 'All resources returned must be of the type Observation or OperationOutcome')
-          resource_returned.reject! { |resource| resource.resourceType == 'OperationOutcome' }
 
           value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category'), true)
           token_with_system_search_params = search_params.merge('category': value_with_system)
@@ -368,10 +360,6 @@ module Inferno
           reply = get_resource_by_params(versioned_resource_class('Observation'), search_params)
 
           validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
-          resource_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
-          assert(resource_returned.all? { |resource| ['Observation', 'OperationOutcome'].include? resource.resourceType },
-                 'All resources returned must be of the type Observation or OperationOutcome')
-          resource_returned.reject! { |resource| resource.resourceType == 'OperationOutcome' }
 
           value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category'), true)
           token_with_system_search_params = search_params.merge('category': value_with_system)
@@ -422,10 +410,6 @@ module Inferno
           reply = perform_search_with_status(reply, search_params) if reply.code == 400
 
           validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
-          resource_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
-          assert(resource_returned.all? { |resource| ['Observation', 'OperationOutcome'].include? resource.resourceType },
-                 'All resources returned must be of the type Observation or OperationOutcome')
-          resource_returned.reject! { |resource| resource.resourceType == 'OperationOutcome' }
 
           ['gt', 'ge', 'lt', 'le'].each do |comparator|
             comparator_val = date_comparator_value(comparator, resolve_element_from_path(@observation_ary[patient], 'effective') { |el| get_value_for_search_param(el).present? })

--- a/lib/modules/uscore_v3.1.1/pediatric_weight_for_height_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/pediatric_weight_for_height_sequence.rb
@@ -190,6 +190,9 @@ module Inferno
 
             @resources_found = true
             resources_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
+            assert(resources_returned.all? { |resource| ['Observation', 'OperationOutcome'].include? resource.resourceType },
+                   'All resources returned must be of the type Observation or OperationOutcome')
+            resources_returned.reject! { |resource| resource.resourceType == 'OperationOutcome' }
             @observation = resources_returned.first
             @observation_ary[patient] += resources_returned
 
@@ -212,6 +215,9 @@ module Inferno
             assert_response_ok(reply)
             assert_bundle_response(reply)
             search_with_type = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
+            assert(search_with_type.all? { |resource| ['Observation', 'OperationOutcome'].include? resource.resourceType },
+                   'All resources returned must be of the type Observation or OperationOutcome.')
+            search_with_type.reject! { |resource| resource.resourceType == 'OperationOutcome' }
             assert search_with_type.length == resources_returned.length, 'Expected search by Patient/ID to have the same results as search by ID'
 
             search_query_variants_tested_once = true
@@ -259,6 +265,10 @@ module Inferno
           reply = perform_search_with_status(reply, search_params) if reply.code == 400
 
           validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
+          resource_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
+          assert(resource_returned.all? { |resource| ['Observation', 'OperationOutcome'].include? resource.resourceType },
+                 'All resources returned must be of the type Observation or OperationOutcome')
+          resource_returned.reject! { |resource| resource.resourceType == 'OperationOutcome' }
 
           ['gt', 'ge', 'lt', 'le'].each do |comparator|
             comparator_val = date_comparator_value(comparator, resolve_element_from_path(@observation_ary[patient], 'effective') { |el| get_value_for_search_param(el).present? })
@@ -310,6 +320,10 @@ module Inferno
           reply = perform_search_with_status(reply, search_params) if reply.code == 400
 
           validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
+          resource_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
+          assert(resource_returned.all? { |resource| ['Observation', 'OperationOutcome'].include? resource.resourceType },
+                 'All resources returned must be of the type Observation or OperationOutcome')
+          resource_returned.reject! { |resource| resource.resourceType == 'OperationOutcome' }
 
           value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category'), true)
           token_with_system_search_params = search_params.merge('category': value_with_system)
@@ -354,6 +368,10 @@ module Inferno
           reply = get_resource_by_params(versioned_resource_class('Observation'), search_params)
 
           validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
+          resource_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
+          assert(resource_returned.all? { |resource| ['Observation', 'OperationOutcome'].include? resource.resourceType },
+                 'All resources returned must be of the type Observation or OperationOutcome')
+          resource_returned.reject! { |resource| resource.resourceType == 'OperationOutcome' }
 
           value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category'), true)
           token_with_system_search_params = search_params.merge('category': value_with_system)
@@ -404,6 +422,10 @@ module Inferno
           reply = perform_search_with_status(reply, search_params) if reply.code == 400
 
           validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
+          resource_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
+          assert(resource_returned.all? { |resource| ['Observation', 'OperationOutcome'].include? resource.resourceType },
+                 'All resources returned must be of the type Observation or OperationOutcome')
+          resource_returned.reject! { |resource| resource.resourceType == 'OperationOutcome' }
 
           ['gt', 'ge', 'lt', 'le'].each do |comparator|
             comparator_val = date_comparator_value(comparator, resolve_element_from_path(@observation_ary[patient], 'effective') { |el| get_value_for_search_param(el).present? })

--- a/lib/modules/uscore_v3.1.1/resprate_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/resprate_sequence.rb
@@ -265,10 +265,6 @@ module Inferno
           reply = perform_search_with_status(reply, search_params) if reply.code == 400
 
           validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
-          resource_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
-          assert(resource_returned.all? { |resource| ['Observation', 'OperationOutcome'].include? resource.resourceType },
-                 'All resources returned must be of the type Observation or OperationOutcome')
-          resource_returned.reject! { |resource| resource.resourceType == 'OperationOutcome' }
 
           ['gt', 'ge', 'lt', 'le'].each do |comparator|
             comparator_val = date_comparator_value(comparator, resolve_element_from_path(@observation_ary[patient], 'effective') { |el| get_value_for_search_param(el).present? })
@@ -320,10 +316,6 @@ module Inferno
           reply = perform_search_with_status(reply, search_params) if reply.code == 400
 
           validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
-          resource_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
-          assert(resource_returned.all? { |resource| ['Observation', 'OperationOutcome'].include? resource.resourceType },
-                 'All resources returned must be of the type Observation or OperationOutcome')
-          resource_returned.reject! { |resource| resource.resourceType == 'OperationOutcome' }
 
           value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category'), true)
           token_with_system_search_params = search_params.merge('category': value_with_system)
@@ -368,10 +360,6 @@ module Inferno
           reply = get_resource_by_params(versioned_resource_class('Observation'), search_params)
 
           validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
-          resource_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
-          assert(resource_returned.all? { |resource| ['Observation', 'OperationOutcome'].include? resource.resourceType },
-                 'All resources returned must be of the type Observation or OperationOutcome')
-          resource_returned.reject! { |resource| resource.resourceType == 'OperationOutcome' }
 
           value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category'), true)
           token_with_system_search_params = search_params.merge('category': value_with_system)
@@ -422,10 +410,6 @@ module Inferno
           reply = perform_search_with_status(reply, search_params) if reply.code == 400
 
           validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
-          resource_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
-          assert(resource_returned.all? { |resource| ['Observation', 'OperationOutcome'].include? resource.resourceType },
-                 'All resources returned must be of the type Observation or OperationOutcome')
-          resource_returned.reject! { |resource| resource.resourceType == 'OperationOutcome' }
 
           ['gt', 'ge', 'lt', 'le'].each do |comparator|
             comparator_val = date_comparator_value(comparator, resolve_element_from_path(@observation_ary[patient], 'effective') { |el| get_value_for_search_param(el).present? })

--- a/lib/modules/uscore_v3.1.1/resprate_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/resprate_sequence.rb
@@ -190,6 +190,9 @@ module Inferno
 
             @resources_found = true
             resources_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
+            assert(resources_returned.all? { |resource| ['Observation', 'OperationOutcome'].include? resource.resourceType },
+                   'All resources returned must be of the type Observation or OperationOutcome')
+            resources_returned.reject! { |resource| resource.resourceType == 'OperationOutcome' }
             @observation = resources_returned.first
             @observation_ary[patient] += resources_returned
 
@@ -212,6 +215,9 @@ module Inferno
             assert_response_ok(reply)
             assert_bundle_response(reply)
             search_with_type = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
+            assert(search_with_type.all? { |resource| ['Observation', 'OperationOutcome'].include? resource.resourceType },
+                   'All resources returned must be of the type Observation or OperationOutcome.')
+            search_with_type.reject! { |resource| resource.resourceType == 'OperationOutcome' }
             assert search_with_type.length == resources_returned.length, 'Expected search by Patient/ID to have the same results as search by ID'
 
             search_query_variants_tested_once = true
@@ -259,6 +265,10 @@ module Inferno
           reply = perform_search_with_status(reply, search_params) if reply.code == 400
 
           validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
+          resource_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
+          assert(resource_returned.all? { |resource| ['Observation', 'OperationOutcome'].include? resource.resourceType },
+                 'All resources returned must be of the type Observation or OperationOutcome')
+          resource_returned.reject! { |resource| resource.resourceType == 'OperationOutcome' }
 
           ['gt', 'ge', 'lt', 'le'].each do |comparator|
             comparator_val = date_comparator_value(comparator, resolve_element_from_path(@observation_ary[patient], 'effective') { |el| get_value_for_search_param(el).present? })
@@ -310,6 +320,10 @@ module Inferno
           reply = perform_search_with_status(reply, search_params) if reply.code == 400
 
           validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
+          resource_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
+          assert(resource_returned.all? { |resource| ['Observation', 'OperationOutcome'].include? resource.resourceType },
+                 'All resources returned must be of the type Observation or OperationOutcome')
+          resource_returned.reject! { |resource| resource.resourceType == 'OperationOutcome' }
 
           value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category'), true)
           token_with_system_search_params = search_params.merge('category': value_with_system)
@@ -354,6 +368,10 @@ module Inferno
           reply = get_resource_by_params(versioned_resource_class('Observation'), search_params)
 
           validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
+          resource_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
+          assert(resource_returned.all? { |resource| ['Observation', 'OperationOutcome'].include? resource.resourceType },
+                 'All resources returned must be of the type Observation or OperationOutcome')
+          resource_returned.reject! { |resource| resource.resourceType == 'OperationOutcome' }
 
           value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category'), true)
           token_with_system_search_params = search_params.merge('category': value_with_system)
@@ -404,6 +422,10 @@ module Inferno
           reply = perform_search_with_status(reply, search_params) if reply.code == 400
 
           validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
+          resource_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
+          assert(resource_returned.all? { |resource| ['Observation', 'OperationOutcome'].include? resource.resourceType },
+                 'All resources returned must be of the type Observation or OperationOutcome')
+          resource_returned.reject! { |resource| resource.resourceType == 'OperationOutcome' }
 
           ['gt', 'ge', 'lt', 'le'].each do |comparator|
             comparator_val = date_comparator_value(comparator, resolve_element_from_path(@observation_ary[patient], 'effective') { |el| get_value_for_search_param(el).present? })

--- a/lib/modules/uscore_v3.1.1/test/bodyheight_test.rb
+++ b/lib/modules/uscore_v3.1.1/test/bodyheight_test.rb
@@ -113,7 +113,25 @@ describe Inferno::Sequence::USCore311BodyheightSequence do
       assert_match(/Invalid \w+:/, exception.message)
     end
 
+    it 'fails if the bundle contains a resource which is not the searched for resource nor an OperationOutcome' do
+      ['8302-2'].each do |value|
+        query_params = {
+          'patient': @sequence.patient_ids.first,
+          'code': value
+        }
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: query_params, headers: @auth_header)
+          .to_return(status: 200, body: wrap_resources_in_bundle([FHIR::Observation.new, FHIR::Specimen.new]).to_json)
+      end
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'All resources returned must be of the type Observation or OperationOutcome', exception.message
+    end
+
     it 'succeeds when a bundle containing a valid resource matching the search parameters is returned' do
+      operation_outcome = FHIR.from_contents(load_fixture(:operationoutcome_example))
+
       ['8302-2'].each do |value|
         query_params = {
           'patient': @sequence.patient_ids.first,
@@ -121,7 +139,7 @@ describe Inferno::Sequence::USCore311BodyheightSequence do
         }
         body =
           if @sequence.resolve_element_from_path(@observation, 'code.coding.code') == value
-            wrap_resources_in_bundle([@observation]).to_json
+            wrap_resources_in_bundle([@observation, operation_outcome]).to_json
           else
             FHIR::Bundle.new.to_json
           end
@@ -136,7 +154,7 @@ describe Inferno::Sequence::USCore311BodyheightSequence do
 
       stub_request(:get, "#{@base_url}/Observation")
         .with(query: @query_with_system, headers: @auth_header)
-        .to_return(status: 200, body: wrap_resources_in_bundle(@observation_ary.values.flatten).to_json)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@observation_ary.values.flatten.append(operation_outcome)).to_json)
 
       @sequence.run_test(@test)
     end
@@ -464,13 +482,15 @@ describe Inferno::Sequence::USCore311BodyheightSequence do
     end
 
     it 'succeeds when a bundle containing a valid resource matching the search parameters is returned' do
+      operation_outcome = FHIR.from_contents(load_fixture(:operationoutcome_example))
+
       stub_request(:get, "#{@base_url}/Observation")
         .with(query: @query, headers: @auth_header)
-        .to_return(status: 200, body: wrap_resources_in_bundle(@observation_ary.values.flatten).to_json)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@observation_ary.values.flatten.append(operation_outcome)).to_json)
 
       stub_request(:get, "#{@base_url}/Observation")
         .with(query: @query_with_system, headers: @auth_header)
-        .to_return(status: 200, body: wrap_resources_in_bundle(@observation_ary.values.flatten).to_json)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@observation_ary.values.flatten.append(operation_outcome)).to_json)
 
       @sequence.run_test(@test)
     end
@@ -626,13 +646,15 @@ describe Inferno::Sequence::USCore311BodyheightSequence do
     end
 
     it 'succeeds when a bundle containing a valid resource matching the search parameters is returned' do
+      operation_outcome = FHIR.from_contents(load_fixture(:operationoutcome_example))
+
       stub_request(:get, "#{@base_url}/Observation")
         .with(query: @query, headers: @auth_header)
-        .to_return(status: 200, body: wrap_resources_in_bundle(@observation_ary.values.flatten).to_json)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@observation_ary.values.flatten.append(operation_outcome)).to_json)
 
       stub_request(:get, "#{@base_url}/Observation")
         .with(query: @query_with_system, headers: @auth_header)
-        .to_return(status: 200, body: wrap_resources_in_bundle(@observation_ary.values.flatten).to_json)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@observation_ary.values.flatten.append(operation_outcome)).to_json)
 
       @sequence.run_test(@test)
     end

--- a/lib/modules/uscore_v3.1.1/test/bodytemp_test.rb
+++ b/lib/modules/uscore_v3.1.1/test/bodytemp_test.rb
@@ -113,7 +113,25 @@ describe Inferno::Sequence::USCore311BodytempSequence do
       assert_match(/Invalid \w+:/, exception.message)
     end
 
+    it 'fails if the bundle contains a resource which is not the searched for resource nor an OperationOutcome' do
+      ['8310-5'].each do |value|
+        query_params = {
+          'patient': @sequence.patient_ids.first,
+          'code': value
+        }
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: query_params, headers: @auth_header)
+          .to_return(status: 200, body: wrap_resources_in_bundle([FHIR::Observation.new, FHIR::Specimen.new]).to_json)
+      end
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'All resources returned must be of the type Observation or OperationOutcome', exception.message
+    end
+
     it 'succeeds when a bundle containing a valid resource matching the search parameters is returned' do
+      operation_outcome = FHIR.from_contents(load_fixture(:operationoutcome_example))
+
       ['8310-5'].each do |value|
         query_params = {
           'patient': @sequence.patient_ids.first,
@@ -121,7 +139,7 @@ describe Inferno::Sequence::USCore311BodytempSequence do
         }
         body =
           if @sequence.resolve_element_from_path(@observation, 'code.coding.code') == value
-            wrap_resources_in_bundle([@observation]).to_json
+            wrap_resources_in_bundle([@observation, operation_outcome]).to_json
           else
             FHIR::Bundle.new.to_json
           end
@@ -136,7 +154,7 @@ describe Inferno::Sequence::USCore311BodytempSequence do
 
       stub_request(:get, "#{@base_url}/Observation")
         .with(query: @query_with_system, headers: @auth_header)
-        .to_return(status: 200, body: wrap_resources_in_bundle(@observation_ary.values.flatten).to_json)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@observation_ary.values.flatten.append(operation_outcome)).to_json)
 
       @sequence.run_test(@test)
     end
@@ -464,13 +482,15 @@ describe Inferno::Sequence::USCore311BodytempSequence do
     end
 
     it 'succeeds when a bundle containing a valid resource matching the search parameters is returned' do
+      operation_outcome = FHIR.from_contents(load_fixture(:operationoutcome_example))
+
       stub_request(:get, "#{@base_url}/Observation")
         .with(query: @query, headers: @auth_header)
-        .to_return(status: 200, body: wrap_resources_in_bundle(@observation_ary.values.flatten).to_json)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@observation_ary.values.flatten.append(operation_outcome)).to_json)
 
       stub_request(:get, "#{@base_url}/Observation")
         .with(query: @query_with_system, headers: @auth_header)
-        .to_return(status: 200, body: wrap_resources_in_bundle(@observation_ary.values.flatten).to_json)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@observation_ary.values.flatten.append(operation_outcome)).to_json)
 
       @sequence.run_test(@test)
     end
@@ -626,13 +646,15 @@ describe Inferno::Sequence::USCore311BodytempSequence do
     end
 
     it 'succeeds when a bundle containing a valid resource matching the search parameters is returned' do
+      operation_outcome = FHIR.from_contents(load_fixture(:operationoutcome_example))
+
       stub_request(:get, "#{@base_url}/Observation")
         .with(query: @query, headers: @auth_header)
-        .to_return(status: 200, body: wrap_resources_in_bundle(@observation_ary.values.flatten).to_json)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@observation_ary.values.flatten.append(operation_outcome)).to_json)
 
       stub_request(:get, "#{@base_url}/Observation")
         .with(query: @query_with_system, headers: @auth_header)
-        .to_return(status: 200, body: wrap_resources_in_bundle(@observation_ary.values.flatten).to_json)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@observation_ary.values.flatten.append(operation_outcome)).to_json)
 
       @sequence.run_test(@test)
     end

--- a/lib/modules/uscore_v3.1.1/test/bodyweight_test.rb
+++ b/lib/modules/uscore_v3.1.1/test/bodyweight_test.rb
@@ -113,7 +113,25 @@ describe Inferno::Sequence::USCore311BodyweightSequence do
       assert_match(/Invalid \w+:/, exception.message)
     end
 
+    it 'fails if the bundle contains a resource which is not the searched for resource nor an OperationOutcome' do
+      ['29463-7'].each do |value|
+        query_params = {
+          'patient': @sequence.patient_ids.first,
+          'code': value
+        }
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: query_params, headers: @auth_header)
+          .to_return(status: 200, body: wrap_resources_in_bundle([FHIR::Observation.new, FHIR::Specimen.new]).to_json)
+      end
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'All resources returned must be of the type Observation or OperationOutcome', exception.message
+    end
+
     it 'succeeds when a bundle containing a valid resource matching the search parameters is returned' do
+      operation_outcome = FHIR.from_contents(load_fixture(:operationoutcome_example))
+
       ['29463-7'].each do |value|
         query_params = {
           'patient': @sequence.patient_ids.first,
@@ -121,7 +139,7 @@ describe Inferno::Sequence::USCore311BodyweightSequence do
         }
         body =
           if @sequence.resolve_element_from_path(@observation, 'code.coding.code') == value
-            wrap_resources_in_bundle([@observation]).to_json
+            wrap_resources_in_bundle([@observation, operation_outcome]).to_json
           else
             FHIR::Bundle.new.to_json
           end
@@ -136,7 +154,7 @@ describe Inferno::Sequence::USCore311BodyweightSequence do
 
       stub_request(:get, "#{@base_url}/Observation")
         .with(query: @query_with_system, headers: @auth_header)
-        .to_return(status: 200, body: wrap_resources_in_bundle(@observation_ary.values.flatten).to_json)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@observation_ary.values.flatten.append(operation_outcome)).to_json)
 
       @sequence.run_test(@test)
     end
@@ -464,13 +482,15 @@ describe Inferno::Sequence::USCore311BodyweightSequence do
     end
 
     it 'succeeds when a bundle containing a valid resource matching the search parameters is returned' do
+      operation_outcome = FHIR.from_contents(load_fixture(:operationoutcome_example))
+
       stub_request(:get, "#{@base_url}/Observation")
         .with(query: @query, headers: @auth_header)
-        .to_return(status: 200, body: wrap_resources_in_bundle(@observation_ary.values.flatten).to_json)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@observation_ary.values.flatten.append(operation_outcome)).to_json)
 
       stub_request(:get, "#{@base_url}/Observation")
         .with(query: @query_with_system, headers: @auth_header)
-        .to_return(status: 200, body: wrap_resources_in_bundle(@observation_ary.values.flatten).to_json)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@observation_ary.values.flatten.append(operation_outcome)).to_json)
 
       @sequence.run_test(@test)
     end
@@ -626,13 +646,15 @@ describe Inferno::Sequence::USCore311BodyweightSequence do
     end
 
     it 'succeeds when a bundle containing a valid resource matching the search parameters is returned' do
+      operation_outcome = FHIR.from_contents(load_fixture(:operationoutcome_example))
+
       stub_request(:get, "#{@base_url}/Observation")
         .with(query: @query, headers: @auth_header)
-        .to_return(status: 200, body: wrap_resources_in_bundle(@observation_ary.values.flatten).to_json)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@observation_ary.values.flatten.append(operation_outcome)).to_json)
 
       stub_request(:get, "#{@base_url}/Observation")
         .with(query: @query_with_system, headers: @auth_header)
-        .to_return(status: 200, body: wrap_resources_in_bundle(@observation_ary.values.flatten).to_json)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@observation_ary.values.flatten.append(operation_outcome)).to_json)
 
       @sequence.run_test(@test)
     end

--- a/lib/modules/uscore_v3.1.1/test/bp_test.rb
+++ b/lib/modules/uscore_v3.1.1/test/bp_test.rb
@@ -113,7 +113,25 @@ describe Inferno::Sequence::USCore311BpSequence do
       assert_match(/Invalid \w+:/, exception.message)
     end
 
+    it 'fails if the bundle contains a resource which is not the searched for resource nor an OperationOutcome' do
+      ['85354-9'].each do |value|
+        query_params = {
+          'patient': @sequence.patient_ids.first,
+          'code': value
+        }
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: query_params, headers: @auth_header)
+          .to_return(status: 200, body: wrap_resources_in_bundle([FHIR::Observation.new, FHIR::Specimen.new]).to_json)
+      end
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'All resources returned must be of the type Observation or OperationOutcome', exception.message
+    end
+
     it 'succeeds when a bundle containing a valid resource matching the search parameters is returned' do
+      operation_outcome = FHIR.from_contents(load_fixture(:operationoutcome_example))
+
       ['85354-9'].each do |value|
         query_params = {
           'patient': @sequence.patient_ids.first,
@@ -121,7 +139,7 @@ describe Inferno::Sequence::USCore311BpSequence do
         }
         body =
           if @sequence.resolve_element_from_path(@observation, 'code.coding.code') == value
-            wrap_resources_in_bundle([@observation]).to_json
+            wrap_resources_in_bundle([@observation, operation_outcome]).to_json
           else
             FHIR::Bundle.new.to_json
           end
@@ -136,7 +154,7 @@ describe Inferno::Sequence::USCore311BpSequence do
 
       stub_request(:get, "#{@base_url}/Observation")
         .with(query: @query_with_system, headers: @auth_header)
-        .to_return(status: 200, body: wrap_resources_in_bundle(@observation_ary.values.flatten).to_json)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@observation_ary.values.flatten.append(operation_outcome)).to_json)
 
       @sequence.run_test(@test)
     end
@@ -464,13 +482,15 @@ describe Inferno::Sequence::USCore311BpSequence do
     end
 
     it 'succeeds when a bundle containing a valid resource matching the search parameters is returned' do
+      operation_outcome = FHIR.from_contents(load_fixture(:operationoutcome_example))
+
       stub_request(:get, "#{@base_url}/Observation")
         .with(query: @query, headers: @auth_header)
-        .to_return(status: 200, body: wrap_resources_in_bundle(@observation_ary.values.flatten).to_json)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@observation_ary.values.flatten.append(operation_outcome)).to_json)
 
       stub_request(:get, "#{@base_url}/Observation")
         .with(query: @query_with_system, headers: @auth_header)
-        .to_return(status: 200, body: wrap_resources_in_bundle(@observation_ary.values.flatten).to_json)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@observation_ary.values.flatten.append(operation_outcome)).to_json)
 
       @sequence.run_test(@test)
     end
@@ -626,13 +646,15 @@ describe Inferno::Sequence::USCore311BpSequence do
     end
 
     it 'succeeds when a bundle containing a valid resource matching the search parameters is returned' do
+      operation_outcome = FHIR.from_contents(load_fixture(:operationoutcome_example))
+
       stub_request(:get, "#{@base_url}/Observation")
         .with(query: @query, headers: @auth_header)
-        .to_return(status: 200, body: wrap_resources_in_bundle(@observation_ary.values.flatten).to_json)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@observation_ary.values.flatten.append(operation_outcome)).to_json)
 
       stub_request(:get, "#{@base_url}/Observation")
         .with(query: @query_with_system, headers: @auth_header)
-        .to_return(status: 200, body: wrap_resources_in_bundle(@observation_ary.values.flatten).to_json)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@observation_ary.values.flatten.append(operation_outcome)).to_json)
 
       @sequence.run_test(@test)
     end

--- a/lib/modules/uscore_v3.1.1/test/fixtures/operationoutcome_example.json
+++ b/lib/modules/uscore_v3.1.1/test/fixtures/operationoutcome_example.json
@@ -1,0 +1,24 @@
+{
+  "resourceType": "OperationOutcome",
+  "id": "101",
+  "text": {
+    "status": "generated",
+    "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\">\n      <p>The code &quot;W&quot; is not known and not legal Patient.gender.</p>\n    </div>"
+  },
+  "issue": [
+    {
+      "severity": "error",
+      "code": "code-invalid",
+      "details": {
+        "text": "The code \"W\" is not known and not legal in this context"
+      },
+      "diagnostics": "Acme.Interop.FHIRProcessors.Patient.processGender line 2453",
+      "location": [
+        "/f:Patient/f:gender"
+      ],
+      "expression": [
+        "Patient.gender"
+      ]
+    }
+  ]
+}

--- a/lib/modules/uscore_v3.1.1/test/head_occipital_frontal_circumference_percentile_test.rb
+++ b/lib/modules/uscore_v3.1.1/test/head_occipital_frontal_circumference_percentile_test.rb
@@ -113,7 +113,25 @@ describe Inferno::Sequence::USCore311HeadOccipitalFrontalCircumferencePercentile
       assert_match(/Invalid \w+:/, exception.message)
     end
 
+    it 'fails if the bundle contains a resource which is not the searched for resource nor an OperationOutcome' do
+      ['8289-1'].each do |value|
+        query_params = {
+          'patient': @sequence.patient_ids.first,
+          'code': value
+        }
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: query_params, headers: @auth_header)
+          .to_return(status: 200, body: wrap_resources_in_bundle([FHIR::Observation.new, FHIR::Specimen.new]).to_json)
+      end
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'All resources returned must be of the type Observation or OperationOutcome', exception.message
+    end
+
     it 'succeeds when a bundle containing a valid resource matching the search parameters is returned' do
+      operation_outcome = FHIR.from_contents(load_fixture(:operationoutcome_example))
+
       ['8289-1'].each do |value|
         query_params = {
           'patient': @sequence.patient_ids.first,
@@ -121,7 +139,7 @@ describe Inferno::Sequence::USCore311HeadOccipitalFrontalCircumferencePercentile
         }
         body =
           if @sequence.resolve_element_from_path(@observation, 'code.coding.code') == value
-            wrap_resources_in_bundle([@observation]).to_json
+            wrap_resources_in_bundle([@observation, operation_outcome]).to_json
           else
             FHIR::Bundle.new.to_json
           end
@@ -136,7 +154,7 @@ describe Inferno::Sequence::USCore311HeadOccipitalFrontalCircumferencePercentile
 
       stub_request(:get, "#{@base_url}/Observation")
         .with(query: @query_with_system, headers: @auth_header)
-        .to_return(status: 200, body: wrap_resources_in_bundle(@observation_ary.values.flatten).to_json)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@observation_ary.values.flatten.append(operation_outcome)).to_json)
 
       @sequence.run_test(@test)
     end
@@ -464,13 +482,15 @@ describe Inferno::Sequence::USCore311HeadOccipitalFrontalCircumferencePercentile
     end
 
     it 'succeeds when a bundle containing a valid resource matching the search parameters is returned' do
+      operation_outcome = FHIR.from_contents(load_fixture(:operationoutcome_example))
+
       stub_request(:get, "#{@base_url}/Observation")
         .with(query: @query, headers: @auth_header)
-        .to_return(status: 200, body: wrap_resources_in_bundle(@observation_ary.values.flatten).to_json)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@observation_ary.values.flatten.append(operation_outcome)).to_json)
 
       stub_request(:get, "#{@base_url}/Observation")
         .with(query: @query_with_system, headers: @auth_header)
-        .to_return(status: 200, body: wrap_resources_in_bundle(@observation_ary.values.flatten).to_json)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@observation_ary.values.flatten.append(operation_outcome)).to_json)
 
       @sequence.run_test(@test)
     end
@@ -626,13 +646,15 @@ describe Inferno::Sequence::USCore311HeadOccipitalFrontalCircumferencePercentile
     end
 
     it 'succeeds when a bundle containing a valid resource matching the search parameters is returned' do
+      operation_outcome = FHIR.from_contents(load_fixture(:operationoutcome_example))
+
       stub_request(:get, "#{@base_url}/Observation")
         .with(query: @query, headers: @auth_header)
-        .to_return(status: 200, body: wrap_resources_in_bundle(@observation_ary.values.flatten).to_json)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@observation_ary.values.flatten.append(operation_outcome)).to_json)
 
       stub_request(:get, "#{@base_url}/Observation")
         .with(query: @query_with_system, headers: @auth_header)
-        .to_return(status: 200, body: wrap_resources_in_bundle(@observation_ary.values.flatten).to_json)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@observation_ary.values.flatten.append(operation_outcome)).to_json)
 
       @sequence.run_test(@test)
     end

--- a/lib/modules/uscore_v3.1.1/test/heartrate_test.rb
+++ b/lib/modules/uscore_v3.1.1/test/heartrate_test.rb
@@ -113,7 +113,25 @@ describe Inferno::Sequence::USCore311HeartrateSequence do
       assert_match(/Invalid \w+:/, exception.message)
     end
 
+    it 'fails if the bundle contains a resource which is not the searched for resource nor an OperationOutcome' do
+      ['8867-4'].each do |value|
+        query_params = {
+          'patient': @sequence.patient_ids.first,
+          'code': value
+        }
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: query_params, headers: @auth_header)
+          .to_return(status: 200, body: wrap_resources_in_bundle([FHIR::Observation.new, FHIR::Specimen.new]).to_json)
+      end
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'All resources returned must be of the type Observation or OperationOutcome', exception.message
+    end
+
     it 'succeeds when a bundle containing a valid resource matching the search parameters is returned' do
+      operation_outcome = FHIR.from_contents(load_fixture(:operationoutcome_example))
+
       ['8867-4'].each do |value|
         query_params = {
           'patient': @sequence.patient_ids.first,
@@ -121,7 +139,7 @@ describe Inferno::Sequence::USCore311HeartrateSequence do
         }
         body =
           if @sequence.resolve_element_from_path(@observation, 'code.coding.code') == value
-            wrap_resources_in_bundle([@observation]).to_json
+            wrap_resources_in_bundle([@observation, operation_outcome]).to_json
           else
             FHIR::Bundle.new.to_json
           end
@@ -136,7 +154,7 @@ describe Inferno::Sequence::USCore311HeartrateSequence do
 
       stub_request(:get, "#{@base_url}/Observation")
         .with(query: @query_with_system, headers: @auth_header)
-        .to_return(status: 200, body: wrap_resources_in_bundle(@observation_ary.values.flatten).to_json)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@observation_ary.values.flatten.append(operation_outcome)).to_json)
 
       @sequence.run_test(@test)
     end
@@ -464,13 +482,15 @@ describe Inferno::Sequence::USCore311HeartrateSequence do
     end
 
     it 'succeeds when a bundle containing a valid resource matching the search parameters is returned' do
+      operation_outcome = FHIR.from_contents(load_fixture(:operationoutcome_example))
+
       stub_request(:get, "#{@base_url}/Observation")
         .with(query: @query, headers: @auth_header)
-        .to_return(status: 200, body: wrap_resources_in_bundle(@observation_ary.values.flatten).to_json)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@observation_ary.values.flatten.append(operation_outcome)).to_json)
 
       stub_request(:get, "#{@base_url}/Observation")
         .with(query: @query_with_system, headers: @auth_header)
-        .to_return(status: 200, body: wrap_resources_in_bundle(@observation_ary.values.flatten).to_json)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@observation_ary.values.flatten.append(operation_outcome)).to_json)
 
       @sequence.run_test(@test)
     end
@@ -626,13 +646,15 @@ describe Inferno::Sequence::USCore311HeartrateSequence do
     end
 
     it 'succeeds when a bundle containing a valid resource matching the search parameters is returned' do
+      operation_outcome = FHIR.from_contents(load_fixture(:operationoutcome_example))
+
       stub_request(:get, "#{@base_url}/Observation")
         .with(query: @query, headers: @auth_header)
-        .to_return(status: 200, body: wrap_resources_in_bundle(@observation_ary.values.flatten).to_json)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@observation_ary.values.flatten.append(operation_outcome)).to_json)
 
       stub_request(:get, "#{@base_url}/Observation")
         .with(query: @query_with_system, headers: @auth_header)
-        .to_return(status: 200, body: wrap_resources_in_bundle(@observation_ary.values.flatten).to_json)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@observation_ary.values.flatten.append(operation_outcome)).to_json)
 
       @sequence.run_test(@test)
     end

--- a/lib/modules/uscore_v3.1.1/test/pediatric_bmi_for_age_test.rb
+++ b/lib/modules/uscore_v3.1.1/test/pediatric_bmi_for_age_test.rb
@@ -113,7 +113,25 @@ describe Inferno::Sequence::USCore311PediatricBmiForAgeSequence do
       assert_match(/Invalid \w+:/, exception.message)
     end
 
+    it 'fails if the bundle contains a resource which is not the searched for resource nor an OperationOutcome' do
+      ['59576-9'].each do |value|
+        query_params = {
+          'patient': @sequence.patient_ids.first,
+          'code': value
+        }
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: query_params, headers: @auth_header)
+          .to_return(status: 200, body: wrap_resources_in_bundle([FHIR::Observation.new, FHIR::Specimen.new]).to_json)
+      end
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'All resources returned must be of the type Observation or OperationOutcome', exception.message
+    end
+
     it 'succeeds when a bundle containing a valid resource matching the search parameters is returned' do
+      operation_outcome = FHIR.from_contents(load_fixture(:operationoutcome_example))
+
       ['59576-9'].each do |value|
         query_params = {
           'patient': @sequence.patient_ids.first,
@@ -121,7 +139,7 @@ describe Inferno::Sequence::USCore311PediatricBmiForAgeSequence do
         }
         body =
           if @sequence.resolve_element_from_path(@observation, 'code.coding.code') == value
-            wrap_resources_in_bundle([@observation]).to_json
+            wrap_resources_in_bundle([@observation, operation_outcome]).to_json
           else
             FHIR::Bundle.new.to_json
           end
@@ -136,7 +154,7 @@ describe Inferno::Sequence::USCore311PediatricBmiForAgeSequence do
 
       stub_request(:get, "#{@base_url}/Observation")
         .with(query: @query_with_system, headers: @auth_header)
-        .to_return(status: 200, body: wrap_resources_in_bundle(@observation_ary.values.flatten).to_json)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@observation_ary.values.flatten.append(operation_outcome)).to_json)
 
       @sequence.run_test(@test)
     end
@@ -464,13 +482,15 @@ describe Inferno::Sequence::USCore311PediatricBmiForAgeSequence do
     end
 
     it 'succeeds when a bundle containing a valid resource matching the search parameters is returned' do
+      operation_outcome = FHIR.from_contents(load_fixture(:operationoutcome_example))
+
       stub_request(:get, "#{@base_url}/Observation")
         .with(query: @query, headers: @auth_header)
-        .to_return(status: 200, body: wrap_resources_in_bundle(@observation_ary.values.flatten).to_json)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@observation_ary.values.flatten.append(operation_outcome)).to_json)
 
       stub_request(:get, "#{@base_url}/Observation")
         .with(query: @query_with_system, headers: @auth_header)
-        .to_return(status: 200, body: wrap_resources_in_bundle(@observation_ary.values.flatten).to_json)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@observation_ary.values.flatten.append(operation_outcome)).to_json)
 
       @sequence.run_test(@test)
     end
@@ -626,13 +646,15 @@ describe Inferno::Sequence::USCore311PediatricBmiForAgeSequence do
     end
 
     it 'succeeds when a bundle containing a valid resource matching the search parameters is returned' do
+      operation_outcome = FHIR.from_contents(load_fixture(:operationoutcome_example))
+
       stub_request(:get, "#{@base_url}/Observation")
         .with(query: @query, headers: @auth_header)
-        .to_return(status: 200, body: wrap_resources_in_bundle(@observation_ary.values.flatten).to_json)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@observation_ary.values.flatten.append(operation_outcome)).to_json)
 
       stub_request(:get, "#{@base_url}/Observation")
         .with(query: @query_with_system, headers: @auth_header)
-        .to_return(status: 200, body: wrap_resources_in_bundle(@observation_ary.values.flatten).to_json)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@observation_ary.values.flatten.append(operation_outcome)).to_json)
 
       @sequence.run_test(@test)
     end

--- a/lib/modules/uscore_v3.1.1/test/pediatric_weight_for_height_test.rb
+++ b/lib/modules/uscore_v3.1.1/test/pediatric_weight_for_height_test.rb
@@ -113,7 +113,25 @@ describe Inferno::Sequence::USCore311PediatricWeightForHeightSequence do
       assert_match(/Invalid \w+:/, exception.message)
     end
 
+    it 'fails if the bundle contains a resource which is not the searched for resource nor an OperationOutcome' do
+      ['77606-2'].each do |value|
+        query_params = {
+          'patient': @sequence.patient_ids.first,
+          'code': value
+        }
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: query_params, headers: @auth_header)
+          .to_return(status: 200, body: wrap_resources_in_bundle([FHIR::Observation.new, FHIR::Specimen.new]).to_json)
+      end
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'All resources returned must be of the type Observation or OperationOutcome', exception.message
+    end
+
     it 'succeeds when a bundle containing a valid resource matching the search parameters is returned' do
+      operation_outcome = FHIR.from_contents(load_fixture(:operationoutcome_example))
+
       ['77606-2'].each do |value|
         query_params = {
           'patient': @sequence.patient_ids.first,
@@ -121,7 +139,7 @@ describe Inferno::Sequence::USCore311PediatricWeightForHeightSequence do
         }
         body =
           if @sequence.resolve_element_from_path(@observation, 'code.coding.code') == value
-            wrap_resources_in_bundle([@observation]).to_json
+            wrap_resources_in_bundle([@observation, operation_outcome]).to_json
           else
             FHIR::Bundle.new.to_json
           end
@@ -136,7 +154,7 @@ describe Inferno::Sequence::USCore311PediatricWeightForHeightSequence do
 
       stub_request(:get, "#{@base_url}/Observation")
         .with(query: @query_with_system, headers: @auth_header)
-        .to_return(status: 200, body: wrap_resources_in_bundle(@observation_ary.values.flatten).to_json)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@observation_ary.values.flatten.append(operation_outcome)).to_json)
 
       @sequence.run_test(@test)
     end
@@ -464,13 +482,15 @@ describe Inferno::Sequence::USCore311PediatricWeightForHeightSequence do
     end
 
     it 'succeeds when a bundle containing a valid resource matching the search parameters is returned' do
+      operation_outcome = FHIR.from_contents(load_fixture(:operationoutcome_example))
+
       stub_request(:get, "#{@base_url}/Observation")
         .with(query: @query, headers: @auth_header)
-        .to_return(status: 200, body: wrap_resources_in_bundle(@observation_ary.values.flatten).to_json)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@observation_ary.values.flatten.append(operation_outcome)).to_json)
 
       stub_request(:get, "#{@base_url}/Observation")
         .with(query: @query_with_system, headers: @auth_header)
-        .to_return(status: 200, body: wrap_resources_in_bundle(@observation_ary.values.flatten).to_json)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@observation_ary.values.flatten.append(operation_outcome)).to_json)
 
       @sequence.run_test(@test)
     end
@@ -626,13 +646,15 @@ describe Inferno::Sequence::USCore311PediatricWeightForHeightSequence do
     end
 
     it 'succeeds when a bundle containing a valid resource matching the search parameters is returned' do
+      operation_outcome = FHIR.from_contents(load_fixture(:operationoutcome_example))
+
       stub_request(:get, "#{@base_url}/Observation")
         .with(query: @query, headers: @auth_header)
-        .to_return(status: 200, body: wrap_resources_in_bundle(@observation_ary.values.flatten).to_json)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@observation_ary.values.flatten.append(operation_outcome)).to_json)
 
       stub_request(:get, "#{@base_url}/Observation")
         .with(query: @query_with_system, headers: @auth_header)
-        .to_return(status: 200, body: wrap_resources_in_bundle(@observation_ary.values.flatten).to_json)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@observation_ary.values.flatten.append(operation_outcome)).to_json)
 
       @sequence.run_test(@test)
     end

--- a/lib/modules/uscore_v3.1.1/test/resprate_test.rb
+++ b/lib/modules/uscore_v3.1.1/test/resprate_test.rb
@@ -113,7 +113,25 @@ describe Inferno::Sequence::USCore311ResprateSequence do
       assert_match(/Invalid \w+:/, exception.message)
     end
 
+    it 'fails if the bundle contains a resource which is not the searched for resource nor an OperationOutcome' do
+      ['9279-1'].each do |value|
+        query_params = {
+          'patient': @sequence.patient_ids.first,
+          'code': value
+        }
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: query_params, headers: @auth_header)
+          .to_return(status: 200, body: wrap_resources_in_bundle([FHIR::Observation.new, FHIR::Specimen.new]).to_json)
+      end
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'All resources returned must be of the type Observation or OperationOutcome', exception.message
+    end
+
     it 'succeeds when a bundle containing a valid resource matching the search parameters is returned' do
+      operation_outcome = FHIR.from_contents(load_fixture(:operationoutcome_example))
+
       ['9279-1'].each do |value|
         query_params = {
           'patient': @sequence.patient_ids.first,
@@ -121,7 +139,7 @@ describe Inferno::Sequence::USCore311ResprateSequence do
         }
         body =
           if @sequence.resolve_element_from_path(@observation, 'code.coding.code') == value
-            wrap_resources_in_bundle([@observation]).to_json
+            wrap_resources_in_bundle([@observation, operation_outcome]).to_json
           else
             FHIR::Bundle.new.to_json
           end
@@ -136,7 +154,7 @@ describe Inferno::Sequence::USCore311ResprateSequence do
 
       stub_request(:get, "#{@base_url}/Observation")
         .with(query: @query_with_system, headers: @auth_header)
-        .to_return(status: 200, body: wrap_resources_in_bundle(@observation_ary.values.flatten).to_json)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@observation_ary.values.flatten.append(operation_outcome)).to_json)
 
       @sequence.run_test(@test)
     end
@@ -464,13 +482,15 @@ describe Inferno::Sequence::USCore311ResprateSequence do
     end
 
     it 'succeeds when a bundle containing a valid resource matching the search parameters is returned' do
+      operation_outcome = FHIR.from_contents(load_fixture(:operationoutcome_example))
+
       stub_request(:get, "#{@base_url}/Observation")
         .with(query: @query, headers: @auth_header)
-        .to_return(status: 200, body: wrap_resources_in_bundle(@observation_ary.values.flatten).to_json)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@observation_ary.values.flatten.append(operation_outcome)).to_json)
 
       stub_request(:get, "#{@base_url}/Observation")
         .with(query: @query_with_system, headers: @auth_header)
-        .to_return(status: 200, body: wrap_resources_in_bundle(@observation_ary.values.flatten).to_json)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@observation_ary.values.flatten.append(operation_outcome)).to_json)
 
       @sequence.run_test(@test)
     end
@@ -626,13 +646,15 @@ describe Inferno::Sequence::USCore311ResprateSequence do
     end
 
     it 'succeeds when a bundle containing a valid resource matching the search parameters is returned' do
+      operation_outcome = FHIR.from_contents(load_fixture(:operationoutcome_example))
+
       stub_request(:get, "#{@base_url}/Observation")
         .with(query: @query, headers: @auth_header)
-        .to_return(status: 200, body: wrap_resources_in_bundle(@observation_ary.values.flatten).to_json)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@observation_ary.values.flatten.append(operation_outcome)).to_json)
 
       stub_request(:get, "#{@base_url}/Observation")
         .with(query: @query_with_system, headers: @auth_header)
-        .to_return(status: 200, body: wrap_resources_in_bundle(@observation_ary.values.flatten).to_json)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@observation_ary.values.flatten.append(operation_outcome)).to_json)
 
       @sequence.run_test(@test)
     end

--- a/lib/modules/uscore_v3.1.1/test/us_core_allergyintolerance_test.rb
+++ b/lib/modules/uscore_v3.1.1/test/us_core_allergyintolerance_test.rb
@@ -83,15 +83,27 @@ describe Inferno::Sequence::USCore311AllergyintoleranceSequence do
       assert_match(/Invalid \w+:/, exception.message)
     end
 
-    it 'succeeds when a bundle containing a valid resource matching the search parameters is returned' do
+    it 'fails if the bundle contains a resource which is not the searched for resource nor an OperationOutcome' do
       stub_request(:get, "#{@base_url}/AllergyIntolerance")
         .with(query: @query, headers: @auth_header)
-        .to_return(status: 200, body: wrap_resources_in_bundle(@allergy_intolerance_ary.values.flatten).to_json)
+        .to_return(status: 200, body: wrap_resources_in_bundle([FHIR::AllergyIntolerance.new, FHIR::Specimen.new]).to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'All resources returned must be of the type AllergyIntolerance or OperationOutcome', exception.message
+    end
+
+    it 'succeeds when a bundle containing a valid resource matching the search parameters is returned' do
+      operation_outcome = FHIR.from_contents(load_fixture(:operationoutcome_example))
+
+      stub_request(:get, "#{@base_url}/AllergyIntolerance")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@allergy_intolerance_ary.values.flatten.append(operation_outcome)).to_json)
 
       reference_with_type_params = @query.merge('patient': 'Patient/' + @query[:patient])
       stub_request(:get, "#{@base_url}/AllergyIntolerance")
         .with(query: reference_with_type_params, headers: @auth_header)
-        .to_return(status: 200, body: wrap_resources_in_bundle(@allergy_intolerance_ary.values.flatten).to_json)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@allergy_intolerance_ary.values.flatten.append(operation_outcome)).to_json)
 
       @sequence.run_test(@test)
     end
@@ -245,13 +257,15 @@ describe Inferno::Sequence::USCore311AllergyintoleranceSequence do
     end
 
     it 'succeeds when a bundle containing a valid resource matching the search parameters is returned' do
+      operation_outcome = FHIR.from_contents(load_fixture(:operationoutcome_example))
+
       stub_request(:get, "#{@base_url}/AllergyIntolerance")
         .with(query: @query, headers: @auth_header)
-        .to_return(status: 200, body: wrap_resources_in_bundle(@allergy_intolerance_ary.values.flatten).to_json)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@allergy_intolerance_ary.values.flatten.append(operation_outcome)).to_json)
 
       stub_request(:get, "#{@base_url}/AllergyIntolerance")
         .with(query: @query_with_system, headers: @auth_header)
-        .to_return(status: 200, body: wrap_resources_in_bundle(@allergy_intolerance_ary.values.flatten).to_json)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@allergy_intolerance_ary.values.flatten.append(operation_outcome)).to_json)
 
       @sequence.run_test(@test)
     end

--- a/lib/modules/uscore_v3.1.1/test/us_core_careplan_test.rb
+++ b/lib/modules/uscore_v3.1.1/test/us_core_careplan_test.rb
@@ -113,7 +113,25 @@ describe Inferno::Sequence::USCore311CareplanSequence do
       assert_match(/Invalid \w+:/, exception.message)
     end
 
+    it 'fails if the bundle contains a resource which is not the searched for resource nor an OperationOutcome' do
+      ['assess-plan'].each do |value|
+        query_params = {
+          'patient': @sequence.patient_ids.first,
+          'category': value
+        }
+        stub_request(:get, "#{@base_url}/CarePlan")
+          .with(query: query_params, headers: @auth_header)
+          .to_return(status: 200, body: wrap_resources_in_bundle([FHIR::CarePlan.new, FHIR::Specimen.new]).to_json)
+      end
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'All resources returned must be of the type CarePlan or OperationOutcome', exception.message
+    end
+
     it 'succeeds when a bundle containing a valid resource matching the search parameters is returned' do
+      operation_outcome = FHIR.from_contents(load_fixture(:operationoutcome_example))
+
       ['assess-plan'].each do |value|
         query_params = {
           'patient': @sequence.patient_ids.first,
@@ -121,7 +139,7 @@ describe Inferno::Sequence::USCore311CareplanSequence do
         }
         body =
           if @sequence.resolve_element_from_path(@care_plan, 'category.coding.code') == value
-            wrap_resources_in_bundle([@care_plan]).to_json
+            wrap_resources_in_bundle([@care_plan, operation_outcome]).to_json
           else
             FHIR::Bundle.new.to_json
           end
@@ -136,7 +154,7 @@ describe Inferno::Sequence::USCore311CareplanSequence do
 
       stub_request(:get, "#{@base_url}/CarePlan")
         .with(query: @query_with_system, headers: @auth_header)
-        .to_return(status: 200, body: wrap_resources_in_bundle(@care_plan_ary.values.flatten).to_json)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@care_plan_ary.values.flatten.append(operation_outcome)).to_json)
 
       @sequence.run_test(@test)
     end
@@ -331,13 +349,15 @@ describe Inferno::Sequence::USCore311CareplanSequence do
     end
 
     it 'succeeds when a bundle containing a valid resource matching the search parameters is returned' do
+      operation_outcome = FHIR.from_contents(load_fixture(:operationoutcome_example))
+
       stub_request(:get, "#{@base_url}/CarePlan")
         .with(query: @query, headers: @auth_header)
-        .to_return(status: 200, body: wrap_resources_in_bundle(@care_plan_ary.values.flatten).to_json)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@care_plan_ary.values.flatten.append(operation_outcome)).to_json)
 
       stub_request(:get, "#{@base_url}/CarePlan")
         .with(query: @query_with_system, headers: @auth_header)
-        .to_return(status: 200, body: wrap_resources_in_bundle(@care_plan_ary.values.flatten).to_json)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@care_plan_ary.values.flatten.append(operation_outcome)).to_json)
 
       @sequence.run_test(@test)
     end

--- a/lib/modules/uscore_v3.1.1/test/us_core_condition_test.rb
+++ b/lib/modules/uscore_v3.1.1/test/us_core_condition_test.rb
@@ -83,15 +83,27 @@ describe Inferno::Sequence::USCore311ConditionSequence do
       assert_match(/Invalid \w+:/, exception.message)
     end
 
-    it 'succeeds when a bundle containing a valid resource matching the search parameters is returned' do
+    it 'fails if the bundle contains a resource which is not the searched for resource nor an OperationOutcome' do
       stub_request(:get, "#{@base_url}/Condition")
         .with(query: @query, headers: @auth_header)
-        .to_return(status: 200, body: wrap_resources_in_bundle(@condition_ary.values.flatten).to_json)
+        .to_return(status: 200, body: wrap_resources_in_bundle([FHIR::Condition.new, FHIR::Specimen.new]).to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'All resources returned must be of the type Condition or OperationOutcome', exception.message
+    end
+
+    it 'succeeds when a bundle containing a valid resource matching the search parameters is returned' do
+      operation_outcome = FHIR.from_contents(load_fixture(:operationoutcome_example))
+
+      stub_request(:get, "#{@base_url}/Condition")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@condition_ary.values.flatten.append(operation_outcome)).to_json)
 
       reference_with_type_params = @query.merge('patient': 'Patient/' + @query[:patient])
       stub_request(:get, "#{@base_url}/Condition")
         .with(query: reference_with_type_params, headers: @auth_header)
-        .to_return(status: 200, body: wrap_resources_in_bundle(@condition_ary.values.flatten).to_json)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@condition_ary.values.flatten.append(operation_outcome)).to_json)
 
       @sequence.run_test(@test)
     end
@@ -245,13 +257,15 @@ describe Inferno::Sequence::USCore311ConditionSequence do
     end
 
     it 'succeeds when a bundle containing a valid resource matching the search parameters is returned' do
+      operation_outcome = FHIR.from_contents(load_fixture(:operationoutcome_example))
+
       stub_request(:get, "#{@base_url}/Condition")
         .with(query: @query, headers: @auth_header)
-        .to_return(status: 200, body: wrap_resources_in_bundle(@condition_ary.values.flatten).to_json)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@condition_ary.values.flatten.append(operation_outcome)).to_json)
 
       stub_request(:get, "#{@base_url}/Condition")
         .with(query: @query_with_system, headers: @auth_header)
-        .to_return(status: 200, body: wrap_resources_in_bundle(@condition_ary.values.flatten).to_json)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@condition_ary.values.flatten.append(operation_outcome)).to_json)
 
       @sequence.run_test(@test)
     end
@@ -405,13 +419,15 @@ describe Inferno::Sequence::USCore311ConditionSequence do
     end
 
     it 'succeeds when a bundle containing a valid resource matching the search parameters is returned' do
+      operation_outcome = FHIR.from_contents(load_fixture(:operationoutcome_example))
+
       stub_request(:get, "#{@base_url}/Condition")
         .with(query: @query, headers: @auth_header)
-        .to_return(status: 200, body: wrap_resources_in_bundle(@condition_ary.values.flatten).to_json)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@condition_ary.values.flatten.append(operation_outcome)).to_json)
 
       stub_request(:get, "#{@base_url}/Condition")
         .with(query: @query_with_system, headers: @auth_header)
-        .to_return(status: 200, body: wrap_resources_in_bundle(@condition_ary.values.flatten).to_json)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@condition_ary.values.flatten.append(operation_outcome)).to_json)
 
       @sequence.run_test(@test)
     end
@@ -498,13 +514,15 @@ describe Inferno::Sequence::USCore311ConditionSequence do
     end
 
     it 'succeeds when a bundle containing a valid resource matching the search parameters is returned' do
+      operation_outcome = FHIR.from_contents(load_fixture(:operationoutcome_example))
+
       stub_request(:get, "#{@base_url}/Condition")
         .with(query: @query, headers: @auth_header)
-        .to_return(status: 200, body: wrap_resources_in_bundle(@condition_ary.values.flatten).to_json)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@condition_ary.values.flatten.append(operation_outcome)).to_json)
 
       stub_request(:get, "#{@base_url}/Condition")
         .with(query: @query_with_system, headers: @auth_header)
-        .to_return(status: 200, body: wrap_resources_in_bundle(@condition_ary.values.flatten).to_json)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@condition_ary.values.flatten.append(operation_outcome)).to_json)
 
       @sequence.run_test(@test)
     end

--- a/lib/modules/uscore_v3.1.1/test/us_core_diagnosticreport_lab_test.rb
+++ b/lib/modules/uscore_v3.1.1/test/us_core_diagnosticreport_lab_test.rb
@@ -113,7 +113,25 @@ describe Inferno::Sequence::USCore311DiagnosticreportLabSequence do
       assert_match(/Invalid \w+:/, exception.message)
     end
 
+    it 'fails if the bundle contains a resource which is not the searched for resource nor an OperationOutcome' do
+      ['LAB'].each do |value|
+        query_params = {
+          'patient': @sequence.patient_ids.first,
+          'category': value
+        }
+        stub_request(:get, "#{@base_url}/DiagnosticReport")
+          .with(query: query_params, headers: @auth_header)
+          .to_return(status: 200, body: wrap_resources_in_bundle([FHIR::DiagnosticReport.new, FHIR::Specimen.new]).to_json)
+      end
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'All resources returned must be of the type DiagnosticReport or OperationOutcome', exception.message
+    end
+
     it 'succeeds when a bundle containing a valid resource matching the search parameters is returned' do
+      operation_outcome = FHIR.from_contents(load_fixture(:operationoutcome_example))
+
       ['LAB'].each do |value|
         query_params = {
           'patient': @sequence.patient_ids.first,
@@ -121,7 +139,7 @@ describe Inferno::Sequence::USCore311DiagnosticreportLabSequence do
         }
         body =
           if @sequence.resolve_element_from_path(@diagnostic_report, 'category.coding.code') == value
-            wrap_resources_in_bundle([@diagnostic_report]).to_json
+            wrap_resources_in_bundle([@diagnostic_report, operation_outcome]).to_json
           else
             FHIR::Bundle.new.to_json
           end
@@ -136,7 +154,7 @@ describe Inferno::Sequence::USCore311DiagnosticreportLabSequence do
 
       stub_request(:get, "#{@base_url}/DiagnosticReport")
         .with(query: @query_with_system, headers: @auth_header)
-        .to_return(status: 200, body: wrap_resources_in_bundle(@diagnostic_report_ary.values.flatten).to_json)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@diagnostic_report_ary.values.flatten.append(operation_outcome)).to_json)
 
       @sequence.run_test(@test)
     end
@@ -315,9 +333,11 @@ describe Inferno::Sequence::USCore311DiagnosticreportLabSequence do
     end
 
     it 'succeeds when a bundle containing a valid resource matching the search parameters is returned' do
+      operation_outcome = FHIR.from_contents(load_fixture(:operationoutcome_example))
+
       stub_request(:get, "#{@base_url}/DiagnosticReport")
         .with(query: @query, headers: @auth_header)
-        .to_return(status: 200, body: wrap_resources_in_bundle(@diagnostic_report_ary.values.flatten).to_json)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@diagnostic_report_ary.values.flatten.append(operation_outcome)).to_json)
 
       @sequence.run_test(@test)
     end
@@ -602,13 +622,15 @@ describe Inferno::Sequence::USCore311DiagnosticreportLabSequence do
     end
 
     it 'succeeds when a bundle containing a valid resource matching the search parameters is returned' do
+      operation_outcome = FHIR.from_contents(load_fixture(:operationoutcome_example))
+
       stub_request(:get, "#{@base_url}/DiagnosticReport")
         .with(query: @query, headers: @auth_header)
-        .to_return(status: 200, body: wrap_resources_in_bundle(@diagnostic_report_ary.values.flatten).to_json)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@diagnostic_report_ary.values.flatten.append(operation_outcome)).to_json)
 
       stub_request(:get, "#{@base_url}/DiagnosticReport")
         .with(query: @query_with_system, headers: @auth_header)
-        .to_return(status: 200, body: wrap_resources_in_bundle(@diagnostic_report_ary.values.flatten).to_json)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@diagnostic_report_ary.values.flatten.append(operation_outcome)).to_json)
 
       @sequence.run_test(@test)
     end
@@ -757,9 +779,11 @@ describe Inferno::Sequence::USCore311DiagnosticreportLabSequence do
     end
 
     it 'succeeds when a bundle containing a valid resource matching the search parameters is returned' do
+      operation_outcome = FHIR.from_contents(load_fixture(:operationoutcome_example))
+
       stub_request(:get, "#{@base_url}/DiagnosticReport")
         .with(query: @query, headers: @auth_header)
-        .to_return(status: 200, body: wrap_resources_in_bundle(@diagnostic_report_ary.values.flatten).to_json)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@diagnostic_report_ary.values.flatten.append(operation_outcome)).to_json)
 
       @sequence.run_test(@test)
     end

--- a/lib/modules/uscore_v3.1.1/test/us_core_diagnosticreport_note_test.rb
+++ b/lib/modules/uscore_v3.1.1/test/us_core_diagnosticreport_note_test.rb
@@ -113,7 +113,25 @@ describe Inferno::Sequence::USCore311DiagnosticreportNoteSequence do
       assert_match(/Invalid \w+:/, exception.message)
     end
 
+    it 'fails if the bundle contains a resource which is not the searched for resource nor an OperationOutcome' do
+      ['LP29684-5', 'LP29708-2', 'LP7839-6'].each do |value|
+        query_params = {
+          'patient': @sequence.patient_ids.first,
+          'category': value
+        }
+        stub_request(:get, "#{@base_url}/DiagnosticReport")
+          .with(query: query_params, headers: @auth_header)
+          .to_return(status: 200, body: wrap_resources_in_bundle([FHIR::DiagnosticReport.new, FHIR::Specimen.new]).to_json)
+      end
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'All resources returned must be of the type DiagnosticReport or OperationOutcome', exception.message
+    end
+
     it 'succeeds when a bundle containing a valid resource matching the search parameters is returned' do
+      operation_outcome = FHIR.from_contents(load_fixture(:operationoutcome_example))
+
       ['LP29684-5', 'LP29708-2', 'LP7839-6'].each do |value|
         query_params = {
           'patient': @sequence.patient_ids.first,
@@ -121,7 +139,7 @@ describe Inferno::Sequence::USCore311DiagnosticreportNoteSequence do
         }
         body =
           if @sequence.resolve_element_from_path(@diagnostic_report, 'category.coding.code') == value
-            wrap_resources_in_bundle([@diagnostic_report]).to_json
+            wrap_resources_in_bundle([@diagnostic_report, operation_outcome]).to_json
           else
             FHIR::Bundle.new.to_json
           end
@@ -136,7 +154,7 @@ describe Inferno::Sequence::USCore311DiagnosticreportNoteSequence do
 
       stub_request(:get, "#{@base_url}/DiagnosticReport")
         .with(query: @query_with_system, headers: @auth_header)
-        .to_return(status: 200, body: wrap_resources_in_bundle(@diagnostic_report_ary.values.flatten).to_json)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@diagnostic_report_ary.values.flatten.append(operation_outcome)).to_json)
 
       @sequence.run_test(@test)
     end
@@ -315,9 +333,11 @@ describe Inferno::Sequence::USCore311DiagnosticreportNoteSequence do
     end
 
     it 'succeeds when a bundle containing a valid resource matching the search parameters is returned' do
+      operation_outcome = FHIR.from_contents(load_fixture(:operationoutcome_example))
+
       stub_request(:get, "#{@base_url}/DiagnosticReport")
         .with(query: @query, headers: @auth_header)
-        .to_return(status: 200, body: wrap_resources_in_bundle(@diagnostic_report_ary.values.flatten).to_json)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@diagnostic_report_ary.values.flatten.append(operation_outcome)).to_json)
 
       @sequence.run_test(@test)
     end
@@ -602,13 +622,15 @@ describe Inferno::Sequence::USCore311DiagnosticreportNoteSequence do
     end
 
     it 'succeeds when a bundle containing a valid resource matching the search parameters is returned' do
+      operation_outcome = FHIR.from_contents(load_fixture(:operationoutcome_example))
+
       stub_request(:get, "#{@base_url}/DiagnosticReport")
         .with(query: @query, headers: @auth_header)
-        .to_return(status: 200, body: wrap_resources_in_bundle(@diagnostic_report_ary.values.flatten).to_json)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@diagnostic_report_ary.values.flatten.append(operation_outcome)).to_json)
 
       stub_request(:get, "#{@base_url}/DiagnosticReport")
         .with(query: @query_with_system, headers: @auth_header)
-        .to_return(status: 200, body: wrap_resources_in_bundle(@diagnostic_report_ary.values.flatten).to_json)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@diagnostic_report_ary.values.flatten.append(operation_outcome)).to_json)
 
       @sequence.run_test(@test)
     end
@@ -757,9 +779,11 @@ describe Inferno::Sequence::USCore311DiagnosticreportNoteSequence do
     end
 
     it 'succeeds when a bundle containing a valid resource matching the search parameters is returned' do
+      operation_outcome = FHIR.from_contents(load_fixture(:operationoutcome_example))
+
       stub_request(:get, "#{@base_url}/DiagnosticReport")
         .with(query: @query, headers: @auth_header)
-        .to_return(status: 200, body: wrap_resources_in_bundle(@diagnostic_report_ary.values.flatten).to_json)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@diagnostic_report_ary.values.flatten.append(operation_outcome)).to_json)
 
       @sequence.run_test(@test)
     end

--- a/lib/modules/uscore_v3.1.1/test/us_core_documentreference_test.rb
+++ b/lib/modules/uscore_v3.1.1/test/us_core_documentreference_test.rb
@@ -83,15 +83,27 @@ describe Inferno::Sequence::USCore311DocumentreferenceSequence do
       assert_match(/Invalid \w+:/, exception.message)
     end
 
-    it 'succeeds when a bundle containing a valid resource matching the search parameters is returned' do
+    it 'fails if the bundle contains a resource which is not the searched for resource nor an OperationOutcome' do
       stub_request(:get, "#{@base_url}/DocumentReference")
         .with(query: @query, headers: @auth_header)
-        .to_return(status: 200, body: wrap_resources_in_bundle(@document_reference_ary.values.flatten).to_json)
+        .to_return(status: 200, body: wrap_resources_in_bundle([FHIR::DocumentReference.new, FHIR::Specimen.new]).to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'All resources returned must be of the type DocumentReference or OperationOutcome', exception.message
+    end
+
+    it 'succeeds when a bundle containing a valid resource matching the search parameters is returned' do
+      operation_outcome = FHIR.from_contents(load_fixture(:operationoutcome_example))
+
+      stub_request(:get, "#{@base_url}/DocumentReference")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@document_reference_ary.values.flatten.append(operation_outcome)).to_json)
 
       reference_with_type_params = @query.merge('patient': 'Patient/' + @query[:patient])
       stub_request(:get, "#{@base_url}/DocumentReference")
         .with(query: reference_with_type_params, headers: @auth_header)
-        .to_return(status: 200, body: wrap_resources_in_bundle(@document_reference_ary.values.flatten).to_json)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@document_reference_ary.values.flatten.append(operation_outcome)).to_json)
 
       @sequence.run_test(@test)
     end
@@ -239,9 +251,11 @@ describe Inferno::Sequence::USCore311DocumentreferenceSequence do
     end
 
     it 'succeeds when a bundle containing a valid resource matching the search parameters is returned' do
+      operation_outcome = FHIR.from_contents(load_fixture(:operationoutcome_example))
+
       stub_request(:get, "#{@base_url}/DocumentReference")
         .with(query: @query, headers: @auth_header)
-        .to_return(status: 200, body: wrap_resources_in_bundle(@document_reference_ary.values.flatten).to_json)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@document_reference_ary.values.flatten.append(operation_outcome)).to_json)
 
       @sequence.run_test(@test)
     end
@@ -391,13 +405,15 @@ describe Inferno::Sequence::USCore311DocumentreferenceSequence do
     end
 
     it 'succeeds when a bundle containing a valid resource matching the search parameters is returned' do
+      operation_outcome = FHIR.from_contents(load_fixture(:operationoutcome_example))
+
       stub_request(:get, "#{@base_url}/DocumentReference")
         .with(query: @query, headers: @auth_header)
-        .to_return(status: 200, body: wrap_resources_in_bundle(@document_reference_ary.values.flatten).to_json)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@document_reference_ary.values.flatten.append(operation_outcome)).to_json)
 
       stub_request(:get, "#{@base_url}/DocumentReference")
         .with(query: @query_with_system, headers: @auth_header)
-        .to_return(status: 200, body: wrap_resources_in_bundle(@document_reference_ary.values.flatten).to_json)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@document_reference_ary.values.flatten.append(operation_outcome)).to_json)
 
       @sequence.run_test(@test)
     end
@@ -553,13 +569,15 @@ describe Inferno::Sequence::USCore311DocumentreferenceSequence do
     end
 
     it 'succeeds when a bundle containing a valid resource matching the search parameters is returned' do
+      operation_outcome = FHIR.from_contents(load_fixture(:operationoutcome_example))
+
       stub_request(:get, "#{@base_url}/DocumentReference")
         .with(query: @query, headers: @auth_header)
-        .to_return(status: 200, body: wrap_resources_in_bundle(@document_reference_ary.values.flatten).to_json)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@document_reference_ary.values.flatten.append(operation_outcome)).to_json)
 
       stub_request(:get, "#{@base_url}/DocumentReference")
         .with(query: @query_with_system, headers: @auth_header)
-        .to_return(status: 200, body: wrap_resources_in_bundle(@document_reference_ary.values.flatten).to_json)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@document_reference_ary.values.flatten.append(operation_outcome)).to_json)
 
       @sequence.run_test(@test)
     end
@@ -713,13 +731,15 @@ describe Inferno::Sequence::USCore311DocumentreferenceSequence do
     end
 
     it 'succeeds when a bundle containing a valid resource matching the search parameters is returned' do
+      operation_outcome = FHIR.from_contents(load_fixture(:operationoutcome_example))
+
       stub_request(:get, "#{@base_url}/DocumentReference")
         .with(query: @query, headers: @auth_header)
-        .to_return(status: 200, body: wrap_resources_in_bundle(@document_reference_ary.values.flatten).to_json)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@document_reference_ary.values.flatten.append(operation_outcome)).to_json)
 
       stub_request(:get, "#{@base_url}/DocumentReference")
         .with(query: @query_with_system, headers: @auth_header)
-        .to_return(status: 200, body: wrap_resources_in_bundle(@document_reference_ary.values.flatten).to_json)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@document_reference_ary.values.flatten.append(operation_outcome)).to_json)
 
       @sequence.run_test(@test)
     end
@@ -1003,9 +1023,11 @@ describe Inferno::Sequence::USCore311DocumentreferenceSequence do
     end
 
     it 'succeeds when a bundle containing a valid resource matching the search parameters is returned' do
+      operation_outcome = FHIR.from_contents(load_fixture(:operationoutcome_example))
+
       stub_request(:get, "#{@base_url}/DocumentReference")
         .with(query: @query, headers: @auth_header)
-        .to_return(status: 200, body: wrap_resources_in_bundle(@document_reference_ary.values.flatten).to_json)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@document_reference_ary.values.flatten.append(operation_outcome)).to_json)
 
       @sequence.run_test(@test)
     end

--- a/lib/modules/uscore_v3.1.1/test/us_core_goal_test.rb
+++ b/lib/modules/uscore_v3.1.1/test/us_core_goal_test.rb
@@ -83,15 +83,27 @@ describe Inferno::Sequence::USCore311GoalSequence do
       assert_match(/Invalid \w+:/, exception.message)
     end
 
-    it 'succeeds when a bundle containing a valid resource matching the search parameters is returned' do
+    it 'fails if the bundle contains a resource which is not the searched for resource nor an OperationOutcome' do
       stub_request(:get, "#{@base_url}/Goal")
         .with(query: @query, headers: @auth_header)
-        .to_return(status: 200, body: wrap_resources_in_bundle(@goal_ary.values.flatten).to_json)
+        .to_return(status: 200, body: wrap_resources_in_bundle([FHIR::Goal.new, FHIR::Specimen.new]).to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'All resources returned must be of the type Goal or OperationOutcome', exception.message
+    end
+
+    it 'succeeds when a bundle containing a valid resource matching the search parameters is returned' do
+      operation_outcome = FHIR.from_contents(load_fixture(:operationoutcome_example))
+
+      stub_request(:get, "#{@base_url}/Goal")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@goal_ary.values.flatten.append(operation_outcome)).to_json)
 
       reference_with_type_params = @query.merge('patient': 'Patient/' + @query[:patient])
       stub_request(:get, "#{@base_url}/Goal")
         .with(query: reference_with_type_params, headers: @auth_header)
-        .to_return(status: 200, body: wrap_resources_in_bundle(@goal_ary.values.flatten).to_json)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@goal_ary.values.flatten.append(operation_outcome)).to_json)
 
       @sequence.run_test(@test)
     end
@@ -240,9 +252,11 @@ describe Inferno::Sequence::USCore311GoalSequence do
     end
 
     it 'succeeds when a bundle containing a valid resource matching the search parameters is returned' do
+      operation_outcome = FHIR.from_contents(load_fixture(:operationoutcome_example))
+
       stub_request(:get, "#{@base_url}/Goal")
         .with(query: @query, headers: @auth_header)
-        .to_return(status: 200, body: wrap_resources_in_bundle(@goal_ary.values.flatten).to_json)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@goal_ary.values.flatten.append(operation_outcome)).to_json)
 
       @sequence.run_test(@test)
     end

--- a/lib/modules/uscore_v3.1.1/test/us_core_immunization_test.rb
+++ b/lib/modules/uscore_v3.1.1/test/us_core_immunization_test.rb
@@ -83,15 +83,27 @@ describe Inferno::Sequence::USCore311ImmunizationSequence do
       assert_match(/Invalid \w+:/, exception.message)
     end
 
-    it 'succeeds when a bundle containing a valid resource matching the search parameters is returned' do
+    it 'fails if the bundle contains a resource which is not the searched for resource nor an OperationOutcome' do
       stub_request(:get, "#{@base_url}/Immunization")
         .with(query: @query, headers: @auth_header)
-        .to_return(status: 200, body: wrap_resources_in_bundle(@immunization_ary.values.flatten).to_json)
+        .to_return(status: 200, body: wrap_resources_in_bundle([FHIR::Immunization.new, FHIR::Specimen.new]).to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'All resources returned must be of the type Immunization or OperationOutcome', exception.message
+    end
+
+    it 'succeeds when a bundle containing a valid resource matching the search parameters is returned' do
+      operation_outcome = FHIR.from_contents(load_fixture(:operationoutcome_example))
+
+      stub_request(:get, "#{@base_url}/Immunization")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@immunization_ary.values.flatten.append(operation_outcome)).to_json)
 
       reference_with_type_params = @query.merge('patient': 'Patient/' + @query[:patient])
       stub_request(:get, "#{@base_url}/Immunization")
         .with(query: reference_with_type_params, headers: @auth_header)
-        .to_return(status: 200, body: wrap_resources_in_bundle(@immunization_ary.values.flatten).to_json)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@immunization_ary.values.flatten.append(operation_outcome)).to_json)
 
       @sequence.run_test(@test)
     end
@@ -368,9 +380,11 @@ describe Inferno::Sequence::USCore311ImmunizationSequence do
     end
 
     it 'succeeds when a bundle containing a valid resource matching the search parameters is returned' do
+      operation_outcome = FHIR.from_contents(load_fixture(:operationoutcome_example))
+
       stub_request(:get, "#{@base_url}/Immunization")
         .with(query: @query, headers: @auth_header)
-        .to_return(status: 200, body: wrap_resources_in_bundle(@immunization_ary.values.flatten).to_json)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@immunization_ary.values.flatten.append(operation_outcome)).to_json)
 
       @sequence.run_test(@test)
     end

--- a/lib/modules/uscore_v3.1.1/test/us_core_implantable_device_test.rb
+++ b/lib/modules/uscore_v3.1.1/test/us_core_implantable_device_test.rb
@@ -83,15 +83,27 @@ describe Inferno::Sequence::USCore311ImplantableDeviceSequence do
       assert_match(/Invalid \w+:/, exception.message)
     end
 
-    it 'succeeds when a bundle containing a valid resource matching the search parameters is returned' do
+    it 'fails if the bundle contains a resource which is not the searched for resource nor an OperationOutcome' do
       stub_request(:get, "#{@base_url}/Device")
         .with(query: @query, headers: @auth_header)
-        .to_return(status: 200, body: wrap_resources_in_bundle(@device_ary.values.flatten).to_json)
+        .to_return(status: 200, body: wrap_resources_in_bundle([FHIR::Device.new, FHIR::Specimen.new]).to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'All resources returned must be of the type Device or OperationOutcome', exception.message
+    end
+
+    it 'succeeds when a bundle containing a valid resource matching the search parameters is returned' do
+      operation_outcome = FHIR.from_contents(load_fixture(:operationoutcome_example))
+
+      stub_request(:get, "#{@base_url}/Device")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@device_ary.values.flatten.append(operation_outcome)).to_json)
 
       reference_with_type_params = @query.merge('patient': 'Patient/' + @query[:patient])
       stub_request(:get, "#{@base_url}/Device")
         .with(query: reference_with_type_params, headers: @auth_header)
-        .to_return(status: 200, body: wrap_resources_in_bundle(@device_ary.values.flatten).to_json)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@device_ary.values.flatten.append(operation_outcome)).to_json)
 
       @sequence.run_test(@test)
     end
@@ -178,13 +190,15 @@ describe Inferno::Sequence::USCore311ImplantableDeviceSequence do
     end
 
     it 'succeeds when a bundle containing a valid resource matching the search parameters is returned' do
+      operation_outcome = FHIR.from_contents(load_fixture(:operationoutcome_example))
+
       stub_request(:get, "#{@base_url}/Device")
         .with(query: @query, headers: @auth_header)
-        .to_return(status: 200, body: wrap_resources_in_bundle(@device_ary.values.flatten).to_json)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@device_ary.values.flatten.append(operation_outcome)).to_json)
 
       stub_request(:get, "#{@base_url}/Device")
         .with(query: @query_with_system, headers: @auth_header)
-        .to_return(status: 200, body: wrap_resources_in_bundle(@device_ary.values.flatten).to_json)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@device_ary.values.flatten.append(operation_outcome)).to_json)
 
       @sequence.run_test(@test)
     end

--- a/lib/modules/uscore_v3.1.1/test/us_core_observation_lab_test.rb
+++ b/lib/modules/uscore_v3.1.1/test/us_core_observation_lab_test.rb
@@ -113,7 +113,25 @@ describe Inferno::Sequence::USCore311ObservationLabSequence do
       assert_match(/Invalid \w+:/, exception.message)
     end
 
+    it 'fails if the bundle contains a resource which is not the searched for resource nor an OperationOutcome' do
+      ['laboratory'].each do |value|
+        query_params = {
+          'patient': @sequence.patient_ids.first,
+          'category': value
+        }
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: query_params, headers: @auth_header)
+          .to_return(status: 200, body: wrap_resources_in_bundle([FHIR::Observation.new, FHIR::Specimen.new]).to_json)
+      end
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'All resources returned must be of the type Observation or OperationOutcome', exception.message
+    end
+
     it 'succeeds when a bundle containing a valid resource matching the search parameters is returned' do
+      operation_outcome = FHIR.from_contents(load_fixture(:operationoutcome_example))
+
       ['laboratory'].each do |value|
         query_params = {
           'patient': @sequence.patient_ids.first,
@@ -121,7 +139,7 @@ describe Inferno::Sequence::USCore311ObservationLabSequence do
         }
         body =
           if @sequence.resolve_element_from_path(@observation, 'category.coding.code') == value
-            wrap_resources_in_bundle([@observation]).to_json
+            wrap_resources_in_bundle([@observation, operation_outcome]).to_json
           else
             FHIR::Bundle.new.to_json
           end
@@ -136,7 +154,7 @@ describe Inferno::Sequence::USCore311ObservationLabSequence do
 
       stub_request(:get, "#{@base_url}/Observation")
         .with(query: @query_with_system, headers: @auth_header)
-        .to_return(status: 200, body: wrap_resources_in_bundle(@observation_ary.values.flatten).to_json)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@observation_ary.values.flatten.append(operation_outcome)).to_json)
 
       @sequence.run_test(@test)
     end
@@ -329,13 +347,15 @@ describe Inferno::Sequence::USCore311ObservationLabSequence do
     end
 
     it 'succeeds when a bundle containing a valid resource matching the search parameters is returned' do
+      operation_outcome = FHIR.from_contents(load_fixture(:operationoutcome_example))
+
       stub_request(:get, "#{@base_url}/Observation")
         .with(query: @query, headers: @auth_header)
-        .to_return(status: 200, body: wrap_resources_in_bundle(@observation_ary.values.flatten).to_json)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@observation_ary.values.flatten.append(operation_outcome)).to_json)
 
       stub_request(:get, "#{@base_url}/Observation")
         .with(query: @query_with_system, headers: @auth_header)
-        .to_return(status: 200, body: wrap_resources_in_bundle(@observation_ary.values.flatten).to_json)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@observation_ary.values.flatten.append(operation_outcome)).to_json)
 
       @sequence.run_test(@test)
     end
@@ -626,13 +646,15 @@ describe Inferno::Sequence::USCore311ObservationLabSequence do
     end
 
     it 'succeeds when a bundle containing a valid resource matching the search parameters is returned' do
+      operation_outcome = FHIR.from_contents(load_fixture(:operationoutcome_example))
+
       stub_request(:get, "#{@base_url}/Observation")
         .with(query: @query, headers: @auth_header)
-        .to_return(status: 200, body: wrap_resources_in_bundle(@observation_ary.values.flatten).to_json)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@observation_ary.values.flatten.append(operation_outcome)).to_json)
 
       stub_request(:get, "#{@base_url}/Observation")
         .with(query: @query_with_system, headers: @auth_header)
-        .to_return(status: 200, body: wrap_resources_in_bundle(@observation_ary.values.flatten).to_json)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@observation_ary.values.flatten.append(operation_outcome)).to_json)
 
       @sequence.run_test(@test)
     end

--- a/lib/modules/uscore_v3.1.1/test/us_core_patient_test.rb
+++ b/lib/modules/uscore_v3.1.1/test/us_core_patient_test.rb
@@ -83,10 +83,22 @@ describe Inferno::Sequence::USCore311PatientSequence do
       assert_match(/Invalid \w+:/, exception.message)
     end
 
-    it 'succeeds when a bundle containing a valid resource matching the search parameters is returned' do
+    it 'fails if the bundle contains a resource which is not the searched for resource nor an OperationOutcome' do
       stub_request(:get, "#{@base_url}/Patient")
         .with(query: @query, headers: @auth_header)
-        .to_return(status: 200, body: wrap_resources_in_bundle(@patient_ary.values.flatten).to_json)
+        .to_return(status: 200, body: wrap_resources_in_bundle([FHIR::Patient.new, FHIR::Specimen.new]).to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'All resources returned must be of the type Patient or OperationOutcome', exception.message
+    end
+
+    it 'succeeds when a bundle containing a valid resource matching the search parameters is returned' do
+      operation_outcome = FHIR.from_contents(load_fixture(:operationoutcome_example))
+
+      stub_request(:get, "#{@base_url}/Patient")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@patient_ary.values.flatten.append(operation_outcome)).to_json)
 
       @sequence.run_test(@test)
     end
@@ -171,13 +183,15 @@ describe Inferno::Sequence::USCore311PatientSequence do
     end
 
     it 'succeeds when a bundle containing a valid resource matching the search parameters is returned' do
+      operation_outcome = FHIR.from_contents(load_fixture(:operationoutcome_example))
+
       stub_request(:get, "#{@base_url}/Patient")
         .with(query: @query, headers: @auth_header)
-        .to_return(status: 200, body: wrap_resources_in_bundle(@patient_ary.values.flatten).to_json)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@patient_ary.values.flatten.append(operation_outcome)).to_json)
 
       stub_request(:get, "#{@base_url}/Patient")
         .with(query: @query_with_system, headers: @auth_header)
-        .to_return(status: 200, body: wrap_resources_in_bundle(@patient_ary.values.flatten).to_json)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@patient_ary.values.flatten.append(operation_outcome)).to_json)
 
       @sequence.run_test(@test)
     end
@@ -258,9 +272,11 @@ describe Inferno::Sequence::USCore311PatientSequence do
     end
 
     it 'succeeds when a bundle containing a valid resource matching the search parameters is returned' do
+      operation_outcome = FHIR.from_contents(load_fixture(:operationoutcome_example))
+
       stub_request(:get, "#{@base_url}/Patient")
         .with(query: @query, headers: @auth_header)
-        .to_return(status: 200, body: wrap_resources_in_bundle(@patient_ary.values.flatten).to_json)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@patient_ary.values.flatten.append(operation_outcome)).to_json)
 
       @sequence.run_test(@test)
     end
@@ -342,9 +358,11 @@ describe Inferno::Sequence::USCore311PatientSequence do
     end
 
     it 'succeeds when a bundle containing a valid resource matching the search parameters is returned' do
+      operation_outcome = FHIR.from_contents(load_fixture(:operationoutcome_example))
+
       stub_request(:get, "#{@base_url}/Patient")
         .with(query: @query, headers: @auth_header)
-        .to_return(status: 200, body: wrap_resources_in_bundle(@patient_ary.values.flatten).to_json)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@patient_ary.values.flatten.append(operation_outcome)).to_json)
 
       @sequence.run_test(@test)
     end
@@ -426,9 +444,11 @@ describe Inferno::Sequence::USCore311PatientSequence do
     end
 
     it 'succeeds when a bundle containing a valid resource matching the search parameters is returned' do
+      operation_outcome = FHIR.from_contents(load_fixture(:operationoutcome_example))
+
       stub_request(:get, "#{@base_url}/Patient")
         .with(query: @query, headers: @auth_header)
-        .to_return(status: 200, body: wrap_resources_in_bundle(@patient_ary.values.flatten).to_json)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@patient_ary.values.flatten.append(operation_outcome)).to_json)
 
       @sequence.run_test(@test)
     end
@@ -510,9 +530,11 @@ describe Inferno::Sequence::USCore311PatientSequence do
     end
 
     it 'succeeds when a bundle containing a valid resource matching the search parameters is returned' do
+      operation_outcome = FHIR.from_contents(load_fixture(:operationoutcome_example))
+
       stub_request(:get, "#{@base_url}/Patient")
         .with(query: @query, headers: @auth_header)
-        .to_return(status: 200, body: wrap_resources_in_bundle(@patient_ary.values.flatten).to_json)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@patient_ary.values.flatten.append(operation_outcome)).to_json)
 
       @sequence.run_test(@test)
     end
@@ -594,9 +616,11 @@ describe Inferno::Sequence::USCore311PatientSequence do
     end
 
     it 'succeeds when a bundle containing a valid resource matching the search parameters is returned' do
+      operation_outcome = FHIR.from_contents(load_fixture(:operationoutcome_example))
+
       stub_request(:get, "#{@base_url}/Patient")
         .with(query: @query, headers: @auth_header)
-        .to_return(status: 200, body: wrap_resources_in_bundle(@patient_ary.values.flatten).to_json)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@patient_ary.values.flatten.append(operation_outcome)).to_json)
 
       @sequence.run_test(@test)
     end

--- a/lib/modules/uscore_v3.1.1/test/us_core_procedure_test.rb
+++ b/lib/modules/uscore_v3.1.1/test/us_core_procedure_test.rb
@@ -83,15 +83,27 @@ describe Inferno::Sequence::USCore311ProcedureSequence do
       assert_match(/Invalid \w+:/, exception.message)
     end
 
-    it 'succeeds when a bundle containing a valid resource matching the search parameters is returned' do
+    it 'fails if the bundle contains a resource which is not the searched for resource nor an OperationOutcome' do
       stub_request(:get, "#{@base_url}/Procedure")
         .with(query: @query, headers: @auth_header)
-        .to_return(status: 200, body: wrap_resources_in_bundle(@procedure_ary.values.flatten).to_json)
+        .to_return(status: 200, body: wrap_resources_in_bundle([FHIR::Procedure.new, FHIR::Specimen.new]).to_json)
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'All resources returned must be of the type Procedure or OperationOutcome', exception.message
+    end
+
+    it 'succeeds when a bundle containing a valid resource matching the search parameters is returned' do
+      operation_outcome = FHIR.from_contents(load_fixture(:operationoutcome_example))
+
+      stub_request(:get, "#{@base_url}/Procedure")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@procedure_ary.values.flatten.append(operation_outcome)).to_json)
 
       reference_with_type_params = @query.merge('patient': 'Patient/' + @query[:patient])
       stub_request(:get, "#{@base_url}/Procedure")
         .with(query: reference_with_type_params, headers: @auth_header)
-        .to_return(status: 200, body: wrap_resources_in_bundle(@procedure_ary.values.flatten).to_json)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@procedure_ary.values.flatten.append(operation_outcome)).to_json)
 
       @sequence.run_test(@test)
     end
@@ -368,9 +380,11 @@ describe Inferno::Sequence::USCore311ProcedureSequence do
     end
 
     it 'succeeds when a bundle containing a valid resource matching the search parameters is returned' do
+      operation_outcome = FHIR.from_contents(load_fixture(:operationoutcome_example))
+
       stub_request(:get, "#{@base_url}/Procedure")
         .with(query: @query, headers: @auth_header)
-        .to_return(status: 200, body: wrap_resources_in_bundle(@procedure_ary.values.flatten).to_json)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@procedure_ary.values.flatten.append(operation_outcome)).to_json)
 
       @sequence.run_test(@test)
     end

--- a/lib/modules/uscore_v3.1.1/test/us_core_pulse_oximetry_test.rb
+++ b/lib/modules/uscore_v3.1.1/test/us_core_pulse_oximetry_test.rb
@@ -113,7 +113,25 @@ describe Inferno::Sequence::USCore311PulseOximetrySequence do
       assert_match(/Invalid \w+:/, exception.message)
     end
 
+    it 'fails if the bundle contains a resource which is not the searched for resource nor an OperationOutcome' do
+      ['2708-6', '59408-5'].each do |value|
+        query_params = {
+          'patient': @sequence.patient_ids.first,
+          'code': value
+        }
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: query_params, headers: @auth_header)
+          .to_return(status: 200, body: wrap_resources_in_bundle([FHIR::Observation.new, FHIR::Specimen.new]).to_json)
+      end
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'All resources returned must be of the type Observation or OperationOutcome', exception.message
+    end
+
     it 'succeeds when a bundle containing a valid resource matching the search parameters is returned' do
+      operation_outcome = FHIR.from_contents(load_fixture(:operationoutcome_example))
+
       ['2708-6', '59408-5'].each do |value|
         query_params = {
           'patient': @sequence.patient_ids.first,
@@ -121,7 +139,7 @@ describe Inferno::Sequence::USCore311PulseOximetrySequence do
         }
         body =
           if @sequence.resolve_element_from_path(@observation, 'code.coding.code') == value
-            wrap_resources_in_bundle([@observation]).to_json
+            wrap_resources_in_bundle([@observation, operation_outcome]).to_json
           else
             FHIR::Bundle.new.to_json
           end
@@ -136,7 +154,7 @@ describe Inferno::Sequence::USCore311PulseOximetrySequence do
 
       stub_request(:get, "#{@base_url}/Observation")
         .with(query: @query_with_system, headers: @auth_header)
-        .to_return(status: 200, body: wrap_resources_in_bundle(@observation_ary.values.flatten).to_json)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@observation_ary.values.flatten.append(operation_outcome)).to_json)
 
       @sequence.run_test(@test)
     end
@@ -464,13 +482,15 @@ describe Inferno::Sequence::USCore311PulseOximetrySequence do
     end
 
     it 'succeeds when a bundle containing a valid resource matching the search parameters is returned' do
+      operation_outcome = FHIR.from_contents(load_fixture(:operationoutcome_example))
+
       stub_request(:get, "#{@base_url}/Observation")
         .with(query: @query, headers: @auth_header)
-        .to_return(status: 200, body: wrap_resources_in_bundle(@observation_ary.values.flatten).to_json)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@observation_ary.values.flatten.append(operation_outcome)).to_json)
 
       stub_request(:get, "#{@base_url}/Observation")
         .with(query: @query_with_system, headers: @auth_header)
-        .to_return(status: 200, body: wrap_resources_in_bundle(@observation_ary.values.flatten).to_json)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@observation_ary.values.flatten.append(operation_outcome)).to_json)
 
       @sequence.run_test(@test)
     end
@@ -626,13 +646,15 @@ describe Inferno::Sequence::USCore311PulseOximetrySequence do
     end
 
     it 'succeeds when a bundle containing a valid resource matching the search parameters is returned' do
+      operation_outcome = FHIR.from_contents(load_fixture(:operationoutcome_example))
+
       stub_request(:get, "#{@base_url}/Observation")
         .with(query: @query, headers: @auth_header)
-        .to_return(status: 200, body: wrap_resources_in_bundle(@observation_ary.values.flatten).to_json)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@observation_ary.values.flatten.append(operation_outcome)).to_json)
 
       stub_request(:get, "#{@base_url}/Observation")
         .with(query: @query_with_system, headers: @auth_header)
-        .to_return(status: 200, body: wrap_resources_in_bundle(@observation_ary.values.flatten).to_json)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@observation_ary.values.flatten.append(operation_outcome)).to_json)
 
       @sequence.run_test(@test)
     end

--- a/lib/modules/uscore_v3.1.1/test/us_core_smokingstatus_test.rb
+++ b/lib/modules/uscore_v3.1.1/test/us_core_smokingstatus_test.rb
@@ -113,7 +113,25 @@ describe Inferno::Sequence::USCore311SmokingstatusSequence do
       assert_match(/Invalid \w+:/, exception.message)
     end
 
+    it 'fails if the bundle contains a resource which is not the searched for resource nor an OperationOutcome' do
+      ['72166-2'].each do |value|
+        query_params = {
+          'patient': @sequence.patient_ids.first,
+          'code': value
+        }
+        stub_request(:get, "#{@base_url}/Observation")
+          .with(query: query_params, headers: @auth_header)
+          .to_return(status: 200, body: wrap_resources_in_bundle([FHIR::Observation.new, FHIR::Specimen.new]).to_json)
+      end
+
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_equal 'All resources returned must be of the type Observation or OperationOutcome', exception.message
+    end
+
     it 'succeeds when a bundle containing a valid resource matching the search parameters is returned' do
+      operation_outcome = FHIR.from_contents(load_fixture(:operationoutcome_example))
+
       ['72166-2'].each do |value|
         query_params = {
           'patient': @sequence.patient_ids.first,
@@ -121,7 +139,7 @@ describe Inferno::Sequence::USCore311SmokingstatusSequence do
         }
         body =
           if @sequence.resolve_element_from_path(@observation, 'code.coding.code') == value
-            wrap_resources_in_bundle([@observation]).to_json
+            wrap_resources_in_bundle([@observation, operation_outcome]).to_json
           else
             FHIR::Bundle.new.to_json
           end
@@ -136,7 +154,7 @@ describe Inferno::Sequence::USCore311SmokingstatusSequence do
 
       stub_request(:get, "#{@base_url}/Observation")
         .with(query: @query_with_system, headers: @auth_header)
-        .to_return(status: 200, body: wrap_resources_in_bundle(@observation_ary.values.flatten).to_json)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@observation_ary.values.flatten.append(operation_outcome)).to_json)
 
       @sequence.run_test(@test)
     end

--- a/lib/modules/uscore_v3.1.1/us_core_allergyintolerance_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_allergyintolerance_sequence.rb
@@ -162,7 +162,11 @@ module Inferno
 
           next unless any_resources
 
-          @allergy_intolerance_ary[patient] = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
+          resource_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
+          assert(resource_returned.all? { |resource| ['AllergyIntolerance', 'OperationOutcome'].include? resource.resourceType },
+                 'All resources returned must be of the type AllergyIntolerance or OperationOutcome')
+          resource_returned.reject! { |resource| resource.resourceType == 'OperationOutcome' }
+          @allergy_intolerance_ary[patient] = resource_returned
 
           @allergy_intolerance = @allergy_intolerance_ary[patient]
             .find { |resource| resource.resourceType == 'AllergyIntolerance' }
@@ -177,6 +181,9 @@ module Inferno
           assert_response_ok(reply)
           assert_bundle_response(reply)
           search_with_type = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
+          assert(search_with_type.all? { |resource| ['AllergyIntolerance', 'OperationOutcome'].include? resource.resourceType },
+                 'All resources returned must be of the type AllergyIntolerance or OperationOutcome')
+          search_with_type.reject! { |resource| resource.resourceType == 'OperationOutcome' }
           assert search_with_type.length == @allergy_intolerance_ary[patient].length, 'Expected search by Patient/ID to have the same results as search by ID'
         end
 
@@ -216,6 +223,10 @@ module Inferno
           reply = get_resource_by_params(versioned_resource_class('AllergyIntolerance'), search_params)
 
           validate_search_reply(versioned_resource_class('AllergyIntolerance'), reply, search_params)
+          resource_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
+          assert(resource_returned.all? { |resource| ['AllergyIntolerance', 'OperationOutcome'].include? resource.resourceType },
+                 'All resources returned must be of the type AllergyIntolerance or OperationOutcome')
+          resource_returned.reject! { |resource| resource.resourceType == 'OperationOutcome' }
 
           value_with_system = get_value_for_search_param(resolve_element_from_path(@allergy_intolerance_ary[patient], 'clinicalStatus'), true)
           token_with_system_search_params = search_params.merge('clinical-status': value_with_system)

--- a/lib/modules/uscore_v3.1.1/us_core_allergyintolerance_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_allergyintolerance_sequence.rb
@@ -223,10 +223,6 @@ module Inferno
           reply = get_resource_by_params(versioned_resource_class('AllergyIntolerance'), search_params)
 
           validate_search_reply(versioned_resource_class('AllergyIntolerance'), reply, search_params)
-          resource_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
-          assert(resource_returned.all? { |resource| ['AllergyIntolerance', 'OperationOutcome'].include? resource.resourceType },
-                 'All resources returned must be of the type AllergyIntolerance or OperationOutcome')
-          resource_returned.reject! { |resource| resource.resourceType == 'OperationOutcome' }
 
           value_with_system = get_value_for_search_param(resolve_element_from_path(@allergy_intolerance_ary[patient], 'clinicalStatus'), true)
           token_with_system_search_params = search_params.merge('clinical-status': value_with_system)

--- a/lib/modules/uscore_v3.1.1/us_core_careplan_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_careplan_sequence.rb
@@ -245,10 +245,6 @@ module Inferno
           reply = get_resource_by_params(versioned_resource_class('CarePlan'), search_params)
 
           validate_search_reply(versioned_resource_class('CarePlan'), reply, search_params)
-          resource_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
-          assert(resource_returned.all? { |resource| ['CarePlan', 'OperationOutcome'].include? resource.resourceType },
-                 'All resources returned must be of the type CarePlan or OperationOutcome')
-          resource_returned.reject! { |resource| resource.resourceType == 'OperationOutcome' }
 
           value_with_system = get_value_for_search_param(resolve_element_from_path(@care_plan_ary[patient], 'category'), true)
           token_with_system_search_params = search_params.merge('category': value_with_system)

--- a/lib/modules/uscore_v3.1.1/us_core_careplan_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_careplan_sequence.rb
@@ -175,6 +175,9 @@ module Inferno
 
             @resources_found = true
             resources_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
+            assert(resources_returned.all? { |resource| ['CarePlan', 'OperationOutcome'].include? resource.resourceType },
+                   'All resources returned must be of the type CarePlan or OperationOutcome')
+            resources_returned.reject! { |resource| resource.resourceType == 'OperationOutcome' }
             @care_plan = resources_returned.first
             @care_plan_ary[patient] += resources_returned
 
@@ -197,6 +200,9 @@ module Inferno
             assert_response_ok(reply)
             assert_bundle_response(reply)
             search_with_type = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
+            assert(search_with_type.all? { |resource| ['CarePlan', 'OperationOutcome'].include? resource.resourceType },
+                   'All resources returned must be of the type CarePlan or OperationOutcome.')
+            search_with_type.reject! { |resource| resource.resourceType == 'OperationOutcome' }
             assert search_with_type.length == resources_returned.length, 'Expected search by Patient/ID to have the same results as search by ID'
 
             search_query_variants_tested_once = true
@@ -239,6 +245,10 @@ module Inferno
           reply = get_resource_by_params(versioned_resource_class('CarePlan'), search_params)
 
           validate_search_reply(versioned_resource_class('CarePlan'), reply, search_params)
+          resource_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
+          assert(resource_returned.all? { |resource| ['CarePlan', 'OperationOutcome'].include? resource.resourceType },
+                 'All resources returned must be of the type CarePlan or OperationOutcome')
+          resource_returned.reject! { |resource| resource.resourceType == 'OperationOutcome' }
 
           value_with_system = get_value_for_search_param(resolve_element_from_path(@care_plan_ary[patient], 'category'), true)
           token_with_system_search_params = search_params.merge('category': value_with_system)

--- a/lib/modules/uscore_v3.1.1/us_core_careteam_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_careteam_sequence.rb
@@ -155,6 +155,9 @@ module Inferno
 
             @resources_found = true
             resources_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
+            assert(resources_returned.all? { |resource| ['CareTeam', 'OperationOutcome'].include? resource.resourceType },
+                   'All resources returned must be of the type CareTeam or OperationOutcome')
+            resources_returned.reject! { |resource| resource.resourceType == 'OperationOutcome' }
             @care_team = resources_returned.first
             @care_team_ary[patient] += resources_returned
 
@@ -170,6 +173,9 @@ module Inferno
             assert_response_ok(reply)
             assert_bundle_response(reply)
             search_with_type = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
+            assert(search_with_type.all? { |resource| ['CareTeam', 'OperationOutcome'].include? resource.resourceType },
+                   'All resources returned must be of the type CareTeam or OperationOutcome.')
+            search_with_type.reject! { |resource| resource.resourceType == 'OperationOutcome' }
             assert search_with_type.length == resources_returned.length, 'Expected search by Patient/ID to have the same results as search by ID'
 
             search_query_variants_tested_once = true

--- a/lib/modules/uscore_v3.1.1/us_core_condition_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_condition_sequence.rb
@@ -256,10 +256,6 @@ module Inferno
           reply = perform_search_with_status(reply, search_params) if reply.code == 400
 
           validate_search_reply(versioned_resource_class('Condition'), reply, search_params)
-          resource_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
-          assert(resource_returned.all? { |resource| ['Condition', 'OperationOutcome'].include? resource.resourceType },
-                 'All resources returned must be of the type Condition or OperationOutcome')
-          resource_returned.reject! { |resource| resource.resourceType == 'OperationOutcome' }
 
           value_with_system = get_value_for_search_param(resolve_element_from_path(@condition_ary[patient], 'category'), true)
           token_with_system_search_params = search_params.merge('category': value_with_system)
@@ -303,10 +299,6 @@ module Inferno
           reply = get_resource_by_params(versioned_resource_class('Condition'), search_params)
 
           validate_search_reply(versioned_resource_class('Condition'), reply, search_params)
-          resource_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
-          assert(resource_returned.all? { |resource| ['Condition', 'OperationOutcome'].include? resource.resourceType },
-                 'All resources returned must be of the type Condition or OperationOutcome')
-          resource_returned.reject! { |resource| resource.resourceType == 'OperationOutcome' }
 
           value_with_system = get_value_for_search_param(resolve_element_from_path(@condition_ary[patient], 'clinicalStatus'), true)
           token_with_system_search_params = search_params.merge('clinical-status': value_with_system)
@@ -352,10 +344,6 @@ module Inferno
           reply = perform_search_with_status(reply, search_params) if reply.code == 400
 
           validate_search_reply(versioned_resource_class('Condition'), reply, search_params)
-          resource_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
-          assert(resource_returned.all? { |resource| ['Condition', 'OperationOutcome'].include? resource.resourceType },
-                 'All resources returned must be of the type Condition or OperationOutcome')
-          resource_returned.reject! { |resource| resource.resourceType == 'OperationOutcome' }
 
           value_with_system = get_value_for_search_param(resolve_element_from_path(@condition_ary[patient], 'code'), true)
           token_with_system_search_params = search_params.merge('code': value_with_system)

--- a/lib/modules/uscore_v3.1.1/us_core_condition_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_condition_sequence.rb
@@ -193,7 +193,11 @@ module Inferno
 
           next unless any_resources
 
-          @condition_ary[patient] = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
+          resource_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
+          assert(resource_returned.all? { |resource| ['Condition', 'OperationOutcome'].include? resource.resourceType },
+                 'All resources returned must be of the type Condition or OperationOutcome')
+          resource_returned.reject! { |resource| resource.resourceType == 'OperationOutcome' }
+          @condition_ary[patient] = resource_returned
 
           @condition = @condition_ary[patient]
             .find { |resource| resource.resourceType == 'Condition' }
@@ -208,6 +212,9 @@ module Inferno
           assert_response_ok(reply)
           assert_bundle_response(reply)
           search_with_type = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
+          assert(search_with_type.all? { |resource| ['Condition', 'OperationOutcome'].include? resource.resourceType },
+                 'All resources returned must be of the type Condition or OperationOutcome')
+          search_with_type.reject! { |resource| resource.resourceType == 'OperationOutcome' }
           assert search_with_type.length == @condition_ary[patient].length, 'Expected search by Patient/ID to have the same results as search by ID'
         end
 
@@ -249,6 +256,10 @@ module Inferno
           reply = perform_search_with_status(reply, search_params) if reply.code == 400
 
           validate_search_reply(versioned_resource_class('Condition'), reply, search_params)
+          resource_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
+          assert(resource_returned.all? { |resource| ['Condition', 'OperationOutcome'].include? resource.resourceType },
+                 'All resources returned must be of the type Condition or OperationOutcome')
+          resource_returned.reject! { |resource| resource.resourceType == 'OperationOutcome' }
 
           value_with_system = get_value_for_search_param(resolve_element_from_path(@condition_ary[patient], 'category'), true)
           token_with_system_search_params = search_params.merge('category': value_with_system)
@@ -292,6 +303,10 @@ module Inferno
           reply = get_resource_by_params(versioned_resource_class('Condition'), search_params)
 
           validate_search_reply(versioned_resource_class('Condition'), reply, search_params)
+          resource_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
+          assert(resource_returned.all? { |resource| ['Condition', 'OperationOutcome'].include? resource.resourceType },
+                 'All resources returned must be of the type Condition or OperationOutcome')
+          resource_returned.reject! { |resource| resource.resourceType == 'OperationOutcome' }
 
           value_with_system = get_value_for_search_param(resolve_element_from_path(@condition_ary[patient], 'clinicalStatus'), true)
           token_with_system_search_params = search_params.merge('clinical-status': value_with_system)
@@ -337,6 +352,10 @@ module Inferno
           reply = perform_search_with_status(reply, search_params) if reply.code == 400
 
           validate_search_reply(versioned_resource_class('Condition'), reply, search_params)
+          resource_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
+          assert(resource_returned.all? { |resource| ['Condition', 'OperationOutcome'].include? resource.resourceType },
+                 'All resources returned must be of the type Condition or OperationOutcome')
+          resource_returned.reject! { |resource| resource.resourceType == 'OperationOutcome' }
 
           value_with_system = get_value_for_search_param(resolve_element_from_path(@condition_ary[patient], 'code'), true)
           token_with_system_search_params = search_params.merge('code': value_with_system)

--- a/lib/modules/uscore_v3.1.1/us_core_diagnosticreport_lab_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_diagnosticreport_lab_sequence.rb
@@ -256,10 +256,6 @@ module Inferno
           reply = perform_search_with_status(reply, search_params) if reply.code == 400
 
           validate_search_reply(versioned_resource_class('DiagnosticReport'), reply, search_params)
-          resource_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
-          assert(resource_returned.all? { |resource| ['DiagnosticReport', 'OperationOutcome'].include? resource.resourceType },
-                 'All resources returned must be of the type DiagnosticReport or OperationOutcome')
-          resource_returned.reject! { |resource| resource.resourceType == 'OperationOutcome' }
         end
       end
 
@@ -302,10 +298,6 @@ module Inferno
           reply = perform_search_with_status(reply, search_params) if reply.code == 400
 
           validate_search_reply(versioned_resource_class('DiagnosticReport'), reply, search_params)
-          resource_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
-          assert(resource_returned.all? { |resource| ['DiagnosticReport', 'OperationOutcome'].include? resource.resourceType },
-                 'All resources returned must be of the type DiagnosticReport or OperationOutcome')
-          resource_returned.reject! { |resource| resource.resourceType == 'OperationOutcome' }
 
           ['gt', 'ge', 'lt', 'le'].each do |comparator|
             comparator_val = date_comparator_value(comparator, resolve_element_from_path(@diagnostic_report_ary[patient], 'effective') { |el| get_value_for_search_param(el).present? })
@@ -357,10 +349,6 @@ module Inferno
           reply = perform_search_with_status(reply, search_params) if reply.code == 400
 
           validate_search_reply(versioned_resource_class('DiagnosticReport'), reply, search_params)
-          resource_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
-          assert(resource_returned.all? { |resource| ['DiagnosticReport', 'OperationOutcome'].include? resource.resourceType },
-                 'All resources returned must be of the type DiagnosticReport or OperationOutcome')
-          resource_returned.reject! { |resource| resource.resourceType == 'OperationOutcome' }
 
           value_with_system = get_value_for_search_param(resolve_element_from_path(@diagnostic_report_ary[patient], 'code'), true)
           token_with_system_search_params = search_params.merge('code': value_with_system)
@@ -404,10 +392,6 @@ module Inferno
           reply = get_resource_by_params(versioned_resource_class('DiagnosticReport'), search_params)
 
           validate_search_reply(versioned_resource_class('DiagnosticReport'), reply, search_params)
-          resource_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
-          assert(resource_returned.all? { |resource| ['DiagnosticReport', 'OperationOutcome'].include? resource.resourceType },
-                 'All resources returned must be of the type DiagnosticReport or OperationOutcome')
-          resource_returned.reject! { |resource| resource.resourceType == 'OperationOutcome' }
         end
 
         skip 'Could not resolve all parameters (patient, status) in any resource.' unless resolved_one
@@ -453,10 +437,6 @@ module Inferno
           reply = perform_search_with_status(reply, search_params) if reply.code == 400
 
           validate_search_reply(versioned_resource_class('DiagnosticReport'), reply, search_params)
-          resource_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
-          assert(resource_returned.all? { |resource| ['DiagnosticReport', 'OperationOutcome'].include? resource.resourceType },
-                 'All resources returned must be of the type DiagnosticReport or OperationOutcome')
-          resource_returned.reject! { |resource| resource.resourceType == 'OperationOutcome' }
 
           ['gt', 'ge', 'lt', 'le'].each do |comparator|
             comparator_val = date_comparator_value(comparator, resolve_element_from_path(@diagnostic_report_ary[patient], 'effective') { |el| get_value_for_search_param(el).present? })

--- a/lib/modules/uscore_v3.1.1/us_core_diagnosticreport_lab_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_diagnosticreport_lab_sequence.rb
@@ -193,6 +193,9 @@ module Inferno
 
             @resources_found = true
             resources_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
+            assert(resources_returned.all? { |resource| ['DiagnosticReport', 'OperationOutcome'].include? resource.resourceType },
+                   'All resources returned must be of the type DiagnosticReport or OperationOutcome')
+            resources_returned.reject! { |resource| resource.resourceType == 'OperationOutcome' }
             @diagnostic_report = resources_returned.first
             @diagnostic_report_ary[patient] += resources_returned
 
@@ -215,6 +218,9 @@ module Inferno
             assert_response_ok(reply)
             assert_bundle_response(reply)
             search_with_type = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
+            assert(search_with_type.all? { |resource| ['DiagnosticReport', 'OperationOutcome'].include? resource.resourceType },
+                   'All resources returned must be of the type DiagnosticReport or OperationOutcome.')
+            search_with_type.reject! { |resource| resource.resourceType == 'OperationOutcome' }
             assert search_with_type.length == resources_returned.length, 'Expected search by Patient/ID to have the same results as search by ID'
 
             search_query_variants_tested_once = true
@@ -250,6 +256,10 @@ module Inferno
           reply = perform_search_with_status(reply, search_params) if reply.code == 400
 
           validate_search_reply(versioned_resource_class('DiagnosticReport'), reply, search_params)
+          resource_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
+          assert(resource_returned.all? { |resource| ['DiagnosticReport', 'OperationOutcome'].include? resource.resourceType },
+                 'All resources returned must be of the type DiagnosticReport or OperationOutcome')
+          resource_returned.reject! { |resource| resource.resourceType == 'OperationOutcome' }
         end
       end
 
@@ -292,6 +302,10 @@ module Inferno
           reply = perform_search_with_status(reply, search_params) if reply.code == 400
 
           validate_search_reply(versioned_resource_class('DiagnosticReport'), reply, search_params)
+          resource_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
+          assert(resource_returned.all? { |resource| ['DiagnosticReport', 'OperationOutcome'].include? resource.resourceType },
+                 'All resources returned must be of the type DiagnosticReport or OperationOutcome')
+          resource_returned.reject! { |resource| resource.resourceType == 'OperationOutcome' }
 
           ['gt', 'ge', 'lt', 'le'].each do |comparator|
             comparator_val = date_comparator_value(comparator, resolve_element_from_path(@diagnostic_report_ary[patient], 'effective') { |el| get_value_for_search_param(el).present? })
@@ -343,6 +357,10 @@ module Inferno
           reply = perform_search_with_status(reply, search_params) if reply.code == 400
 
           validate_search_reply(versioned_resource_class('DiagnosticReport'), reply, search_params)
+          resource_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
+          assert(resource_returned.all? { |resource| ['DiagnosticReport', 'OperationOutcome'].include? resource.resourceType },
+                 'All resources returned must be of the type DiagnosticReport or OperationOutcome')
+          resource_returned.reject! { |resource| resource.resourceType == 'OperationOutcome' }
 
           value_with_system = get_value_for_search_param(resolve_element_from_path(@diagnostic_report_ary[patient], 'code'), true)
           token_with_system_search_params = search_params.merge('code': value_with_system)
@@ -386,6 +404,10 @@ module Inferno
           reply = get_resource_by_params(versioned_resource_class('DiagnosticReport'), search_params)
 
           validate_search_reply(versioned_resource_class('DiagnosticReport'), reply, search_params)
+          resource_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
+          assert(resource_returned.all? { |resource| ['DiagnosticReport', 'OperationOutcome'].include? resource.resourceType },
+                 'All resources returned must be of the type DiagnosticReport or OperationOutcome')
+          resource_returned.reject! { |resource| resource.resourceType == 'OperationOutcome' }
         end
 
         skip 'Could not resolve all parameters (patient, status) in any resource.' unless resolved_one
@@ -431,6 +453,10 @@ module Inferno
           reply = perform_search_with_status(reply, search_params) if reply.code == 400
 
           validate_search_reply(versioned_resource_class('DiagnosticReport'), reply, search_params)
+          resource_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
+          assert(resource_returned.all? { |resource| ['DiagnosticReport', 'OperationOutcome'].include? resource.resourceType },
+                 'All resources returned must be of the type DiagnosticReport or OperationOutcome')
+          resource_returned.reject! { |resource| resource.resourceType == 'OperationOutcome' }
 
           ['gt', 'ge', 'lt', 'le'].each do |comparator|
             comparator_val = date_comparator_value(comparator, resolve_element_from_path(@diagnostic_report_ary[patient], 'effective') { |el| get_value_for_search_param(el).present? })

--- a/lib/modules/uscore_v3.1.1/us_core_diagnosticreport_note_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_diagnosticreport_note_sequence.rb
@@ -256,10 +256,6 @@ module Inferno
           reply = perform_search_with_status(reply, search_params) if reply.code == 400
 
           validate_search_reply(versioned_resource_class('DiagnosticReport'), reply, search_params)
-          resource_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
-          assert(resource_returned.all? { |resource| ['DiagnosticReport', 'OperationOutcome'].include? resource.resourceType },
-                 'All resources returned must be of the type DiagnosticReport or OperationOutcome')
-          resource_returned.reject! { |resource| resource.resourceType == 'OperationOutcome' }
         end
       end
 
@@ -302,10 +298,6 @@ module Inferno
           reply = perform_search_with_status(reply, search_params) if reply.code == 400
 
           validate_search_reply(versioned_resource_class('DiagnosticReport'), reply, search_params)
-          resource_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
-          assert(resource_returned.all? { |resource| ['DiagnosticReport', 'OperationOutcome'].include? resource.resourceType },
-                 'All resources returned must be of the type DiagnosticReport or OperationOutcome')
-          resource_returned.reject! { |resource| resource.resourceType == 'OperationOutcome' }
 
           ['gt', 'ge', 'lt', 'le'].each do |comparator|
             comparator_val = date_comparator_value(comparator, resolve_element_from_path(@diagnostic_report_ary[patient], 'effective') { |el| get_value_for_search_param(el).present? })
@@ -357,10 +349,6 @@ module Inferno
           reply = perform_search_with_status(reply, search_params) if reply.code == 400
 
           validate_search_reply(versioned_resource_class('DiagnosticReport'), reply, search_params)
-          resource_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
-          assert(resource_returned.all? { |resource| ['DiagnosticReport', 'OperationOutcome'].include? resource.resourceType },
-                 'All resources returned must be of the type DiagnosticReport or OperationOutcome')
-          resource_returned.reject! { |resource| resource.resourceType == 'OperationOutcome' }
 
           value_with_system = get_value_for_search_param(resolve_element_from_path(@diagnostic_report_ary[patient], 'code'), true)
           token_with_system_search_params = search_params.merge('code': value_with_system)
@@ -404,10 +392,6 @@ module Inferno
           reply = get_resource_by_params(versioned_resource_class('DiagnosticReport'), search_params)
 
           validate_search_reply(versioned_resource_class('DiagnosticReport'), reply, search_params)
-          resource_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
-          assert(resource_returned.all? { |resource| ['DiagnosticReport', 'OperationOutcome'].include? resource.resourceType },
-                 'All resources returned must be of the type DiagnosticReport or OperationOutcome')
-          resource_returned.reject! { |resource| resource.resourceType == 'OperationOutcome' }
         end
 
         skip 'Could not resolve all parameters (patient, status) in any resource.' unless resolved_one
@@ -453,10 +437,6 @@ module Inferno
           reply = perform_search_with_status(reply, search_params) if reply.code == 400
 
           validate_search_reply(versioned_resource_class('DiagnosticReport'), reply, search_params)
-          resource_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
-          assert(resource_returned.all? { |resource| ['DiagnosticReport', 'OperationOutcome'].include? resource.resourceType },
-                 'All resources returned must be of the type DiagnosticReport or OperationOutcome')
-          resource_returned.reject! { |resource| resource.resourceType == 'OperationOutcome' }
 
           ['gt', 'ge', 'lt', 'le'].each do |comparator|
             comparator_val = date_comparator_value(comparator, resolve_element_from_path(@diagnostic_report_ary[patient], 'effective') { |el| get_value_for_search_param(el).present? })

--- a/lib/modules/uscore_v3.1.1/us_core_diagnosticreport_note_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_diagnosticreport_note_sequence.rb
@@ -193,6 +193,9 @@ module Inferno
 
             @resources_found = true
             resources_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
+            assert(resources_returned.all? { |resource| ['DiagnosticReport', 'OperationOutcome'].include? resource.resourceType },
+                   'All resources returned must be of the type DiagnosticReport or OperationOutcome')
+            resources_returned.reject! { |resource| resource.resourceType == 'OperationOutcome' }
             @diagnostic_report = resources_returned.first
             @diagnostic_report_ary[patient] += resources_returned
 
@@ -215,6 +218,9 @@ module Inferno
             assert_response_ok(reply)
             assert_bundle_response(reply)
             search_with_type = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
+            assert(search_with_type.all? { |resource| ['DiagnosticReport', 'OperationOutcome'].include? resource.resourceType },
+                   'All resources returned must be of the type DiagnosticReport or OperationOutcome.')
+            search_with_type.reject! { |resource| resource.resourceType == 'OperationOutcome' }
             assert search_with_type.length == resources_returned.length, 'Expected search by Patient/ID to have the same results as search by ID'
 
             search_query_variants_tested_once = true
@@ -250,6 +256,10 @@ module Inferno
           reply = perform_search_with_status(reply, search_params) if reply.code == 400
 
           validate_search_reply(versioned_resource_class('DiagnosticReport'), reply, search_params)
+          resource_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
+          assert(resource_returned.all? { |resource| ['DiagnosticReport', 'OperationOutcome'].include? resource.resourceType },
+                 'All resources returned must be of the type DiagnosticReport or OperationOutcome')
+          resource_returned.reject! { |resource| resource.resourceType == 'OperationOutcome' }
         end
       end
 
@@ -292,6 +302,10 @@ module Inferno
           reply = perform_search_with_status(reply, search_params) if reply.code == 400
 
           validate_search_reply(versioned_resource_class('DiagnosticReport'), reply, search_params)
+          resource_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
+          assert(resource_returned.all? { |resource| ['DiagnosticReport', 'OperationOutcome'].include? resource.resourceType },
+                 'All resources returned must be of the type DiagnosticReport or OperationOutcome')
+          resource_returned.reject! { |resource| resource.resourceType == 'OperationOutcome' }
 
           ['gt', 'ge', 'lt', 'le'].each do |comparator|
             comparator_val = date_comparator_value(comparator, resolve_element_from_path(@diagnostic_report_ary[patient], 'effective') { |el| get_value_for_search_param(el).present? })
@@ -343,6 +357,10 @@ module Inferno
           reply = perform_search_with_status(reply, search_params) if reply.code == 400
 
           validate_search_reply(versioned_resource_class('DiagnosticReport'), reply, search_params)
+          resource_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
+          assert(resource_returned.all? { |resource| ['DiagnosticReport', 'OperationOutcome'].include? resource.resourceType },
+                 'All resources returned must be of the type DiagnosticReport or OperationOutcome')
+          resource_returned.reject! { |resource| resource.resourceType == 'OperationOutcome' }
 
           value_with_system = get_value_for_search_param(resolve_element_from_path(@diagnostic_report_ary[patient], 'code'), true)
           token_with_system_search_params = search_params.merge('code': value_with_system)
@@ -386,6 +404,10 @@ module Inferno
           reply = get_resource_by_params(versioned_resource_class('DiagnosticReport'), search_params)
 
           validate_search_reply(versioned_resource_class('DiagnosticReport'), reply, search_params)
+          resource_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
+          assert(resource_returned.all? { |resource| ['DiagnosticReport', 'OperationOutcome'].include? resource.resourceType },
+                 'All resources returned must be of the type DiagnosticReport or OperationOutcome')
+          resource_returned.reject! { |resource| resource.resourceType == 'OperationOutcome' }
         end
 
         skip 'Could not resolve all parameters (patient, status) in any resource.' unless resolved_one
@@ -431,6 +453,10 @@ module Inferno
           reply = perform_search_with_status(reply, search_params) if reply.code == 400
 
           validate_search_reply(versioned_resource_class('DiagnosticReport'), reply, search_params)
+          resource_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
+          assert(resource_returned.all? { |resource| ['DiagnosticReport', 'OperationOutcome'].include? resource.resourceType },
+                 'All resources returned must be of the type DiagnosticReport or OperationOutcome')
+          resource_returned.reject! { |resource| resource.resourceType == 'OperationOutcome' }
 
           ['gt', 'ge', 'lt', 'le'].each do |comparator|
             comparator_val = date_comparator_value(comparator, resolve_element_from_path(@diagnostic_report_ary[patient], 'effective') { |el| get_value_for_search_param(el).present? })

--- a/lib/modules/uscore_v3.1.1/us_core_documentreference_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_documentreference_sequence.rb
@@ -202,7 +202,11 @@ module Inferno
 
           next unless any_resources
 
-          @document_reference_ary[patient] = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
+          resource_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
+          assert(resource_returned.all? { |resource| ['DocumentReference', 'OperationOutcome'].include? resource.resourceType },
+                 'All resources returned must be of the type DocumentReference or OperationOutcome')
+          resource_returned.reject! { |resource| resource.resourceType == 'OperationOutcome' }
+          @document_reference_ary[patient] = resource_returned
 
           @document_reference = @document_reference_ary[patient]
             .find { |resource| resource.resourceType == 'DocumentReference' }
@@ -217,6 +221,9 @@ module Inferno
           assert_response_ok(reply)
           assert_bundle_response(reply)
           search_with_type = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
+          assert(search_with_type.all? { |resource| ['DocumentReference', 'OperationOutcome'].include? resource.resourceType },
+                 'All resources returned must be of the type DocumentReference or OperationOutcome')
+          search_with_type.reject! { |resource| resource.resourceType == 'OperationOutcome' }
           assert search_with_type.length == @document_reference_ary[patient].length, 'Expected search by Patient/ID to have the same results as search by ID'
         end
 
@@ -256,6 +263,10 @@ module Inferno
           reply = perform_search_with_status(reply, search_params) if reply.code == 400
 
           validate_search_reply(versioned_resource_class('DocumentReference'), reply, search_params)
+          resource_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
+          assert(resource_returned.all? { |resource| ['DocumentReference', 'OperationOutcome'].include? resource.resourceType },
+                 'All resources returned must be of the type DocumentReference or OperationOutcome')
+          resource_returned.reject! { |resource| resource.resourceType == 'OperationOutcome' }
         end
 
         skip 'Could not resolve all parameters (_id) in any resource.' unless resolved_one
@@ -295,6 +306,10 @@ module Inferno
           reply = perform_search_with_status(reply, search_params) if reply.code == 400
 
           validate_search_reply(versioned_resource_class('DocumentReference'), reply, search_params)
+          resource_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
+          assert(resource_returned.all? { |resource| ['DocumentReference', 'OperationOutcome'].include? resource.resourceType },
+                 'All resources returned must be of the type DocumentReference or OperationOutcome')
+          resource_returned.reject! { |resource| resource.resourceType == 'OperationOutcome' }
 
           value_with_system = get_value_for_search_param(resolve_element_from_path(@document_reference_ary[patient], 'type'), true)
           token_with_system_search_params = search_params.merge('type': value_with_system)
@@ -344,6 +359,10 @@ module Inferno
           reply = perform_search_with_status(reply, search_params) if reply.code == 400
 
           validate_search_reply(versioned_resource_class('DocumentReference'), reply, search_params)
+          resource_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
+          assert(resource_returned.all? { |resource| ['DocumentReference', 'OperationOutcome'].include? resource.resourceType },
+                 'All resources returned must be of the type DocumentReference or OperationOutcome')
+          resource_returned.reject! { |resource| resource.resourceType == 'OperationOutcome' }
 
           value_with_system = get_value_for_search_param(resolve_element_from_path(@document_reference_ary[patient], 'category'), true)
           token_with_system_search_params = search_params.merge('category': value_with_system)
@@ -388,6 +407,10 @@ module Inferno
           reply = perform_search_with_status(reply, search_params) if reply.code == 400
 
           validate_search_reply(versioned_resource_class('DocumentReference'), reply, search_params)
+          resource_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
+          assert(resource_returned.all? { |resource| ['DocumentReference', 'OperationOutcome'].include? resource.resourceType },
+                 'All resources returned must be of the type DocumentReference or OperationOutcome')
+          resource_returned.reject! { |resource| resource.resourceType == 'OperationOutcome' }
 
           value_with_system = get_value_for_search_param(resolve_element_from_path(@document_reference_ary[patient], 'category'), true)
           token_with_system_search_params = search_params.merge('category': value_with_system)
@@ -438,6 +461,10 @@ module Inferno
           reply = perform_search_with_status(reply, search_params) if reply.code == 400
 
           validate_search_reply(versioned_resource_class('DocumentReference'), reply, search_params)
+          resource_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
+          assert(resource_returned.all? { |resource| ['DocumentReference', 'OperationOutcome'].include? resource.resourceType },
+                 'All resources returned must be of the type DocumentReference or OperationOutcome')
+          resource_returned.reject! { |resource| resource.resourceType == 'OperationOutcome' }
 
           ['gt', 'ge', 'lt', 'le'].each do |comparator|
             comparator_val = date_comparator_value(comparator, resolve_element_from_path(@document_reference_ary[patient], 'context.period') { |el| get_value_for_search_param(el).present? })
@@ -488,6 +515,10 @@ module Inferno
           reply = get_resource_by_params(versioned_resource_class('DocumentReference'), search_params)
 
           validate_search_reply(versioned_resource_class('DocumentReference'), reply, search_params)
+          resource_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
+          assert(resource_returned.all? { |resource| ['DocumentReference', 'OperationOutcome'].include? resource.resourceType },
+                 'All resources returned must be of the type DocumentReference or OperationOutcome')
+          resource_returned.reject! { |resource| resource.resourceType == 'OperationOutcome' }
         end
 
         skip 'Could not resolve all parameters (patient, status) in any resource.' unless resolved_one

--- a/lib/modules/uscore_v3.1.1/us_core_documentreference_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_documentreference_sequence.rb
@@ -263,10 +263,6 @@ module Inferno
           reply = perform_search_with_status(reply, search_params) if reply.code == 400
 
           validate_search_reply(versioned_resource_class('DocumentReference'), reply, search_params)
-          resource_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
-          assert(resource_returned.all? { |resource| ['DocumentReference', 'OperationOutcome'].include? resource.resourceType },
-                 'All resources returned must be of the type DocumentReference or OperationOutcome')
-          resource_returned.reject! { |resource| resource.resourceType == 'OperationOutcome' }
         end
 
         skip 'Could not resolve all parameters (_id) in any resource.' unless resolved_one
@@ -306,10 +302,6 @@ module Inferno
           reply = perform_search_with_status(reply, search_params) if reply.code == 400
 
           validate_search_reply(versioned_resource_class('DocumentReference'), reply, search_params)
-          resource_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
-          assert(resource_returned.all? { |resource| ['DocumentReference', 'OperationOutcome'].include? resource.resourceType },
-                 'All resources returned must be of the type DocumentReference or OperationOutcome')
-          resource_returned.reject! { |resource| resource.resourceType == 'OperationOutcome' }
 
           value_with_system = get_value_for_search_param(resolve_element_from_path(@document_reference_ary[patient], 'type'), true)
           token_with_system_search_params = search_params.merge('type': value_with_system)
@@ -359,10 +351,6 @@ module Inferno
           reply = perform_search_with_status(reply, search_params) if reply.code == 400
 
           validate_search_reply(versioned_resource_class('DocumentReference'), reply, search_params)
-          resource_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
-          assert(resource_returned.all? { |resource| ['DocumentReference', 'OperationOutcome'].include? resource.resourceType },
-                 'All resources returned must be of the type DocumentReference or OperationOutcome')
-          resource_returned.reject! { |resource| resource.resourceType == 'OperationOutcome' }
 
           value_with_system = get_value_for_search_param(resolve_element_from_path(@document_reference_ary[patient], 'category'), true)
           token_with_system_search_params = search_params.merge('category': value_with_system)
@@ -407,10 +395,6 @@ module Inferno
           reply = perform_search_with_status(reply, search_params) if reply.code == 400
 
           validate_search_reply(versioned_resource_class('DocumentReference'), reply, search_params)
-          resource_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
-          assert(resource_returned.all? { |resource| ['DocumentReference', 'OperationOutcome'].include? resource.resourceType },
-                 'All resources returned must be of the type DocumentReference or OperationOutcome')
-          resource_returned.reject! { |resource| resource.resourceType == 'OperationOutcome' }
 
           value_with_system = get_value_for_search_param(resolve_element_from_path(@document_reference_ary[patient], 'category'), true)
           token_with_system_search_params = search_params.merge('category': value_with_system)
@@ -461,10 +445,6 @@ module Inferno
           reply = perform_search_with_status(reply, search_params) if reply.code == 400
 
           validate_search_reply(versioned_resource_class('DocumentReference'), reply, search_params)
-          resource_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
-          assert(resource_returned.all? { |resource| ['DocumentReference', 'OperationOutcome'].include? resource.resourceType },
-                 'All resources returned must be of the type DocumentReference or OperationOutcome')
-          resource_returned.reject! { |resource| resource.resourceType == 'OperationOutcome' }
 
           ['gt', 'ge', 'lt', 'le'].each do |comparator|
             comparator_val = date_comparator_value(comparator, resolve_element_from_path(@document_reference_ary[patient], 'context.period') { |el| get_value_for_search_param(el).present? })
@@ -515,10 +495,6 @@ module Inferno
           reply = get_resource_by_params(versioned_resource_class('DocumentReference'), search_params)
 
           validate_search_reply(versioned_resource_class('DocumentReference'), reply, search_params)
-          resource_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
-          assert(resource_returned.all? { |resource| ['DocumentReference', 'OperationOutcome'].include? resource.resourceType },
-                 'All resources returned must be of the type DocumentReference or OperationOutcome')
-          resource_returned.reject! { |resource| resource.resourceType == 'OperationOutcome' }
         end
 
         skip 'Could not resolve all parameters (patient, status) in any resource.' unless resolved_one

--- a/lib/modules/uscore_v3.1.1/us_core_goal_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_goal_sequence.rb
@@ -221,10 +221,6 @@ module Inferno
           reply = get_resource_by_params(versioned_resource_class('Goal'), search_params)
 
           validate_search_reply(versioned_resource_class('Goal'), reply, search_params)
-          resource_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
-          assert(resource_returned.all? { |resource| ['Goal', 'OperationOutcome'].include? resource.resourceType },
-                 'All resources returned must be of the type Goal or OperationOutcome')
-          resource_returned.reject! { |resource| resource.resourceType == 'OperationOutcome' }
         end
 
         skip 'Could not resolve all parameters (patient, lifecycle-status) in any resource.' unless resolved_one

--- a/lib/modules/uscore_v3.1.1/us_core_goal_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_goal_sequence.rb
@@ -160,7 +160,11 @@ module Inferno
 
           next unless any_resources
 
-          @goal_ary[patient] = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
+          resource_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
+          assert(resource_returned.all? { |resource| ['Goal', 'OperationOutcome'].include? resource.resourceType },
+                 'All resources returned must be of the type Goal or OperationOutcome')
+          resource_returned.reject! { |resource| resource.resourceType == 'OperationOutcome' }
+          @goal_ary[patient] = resource_returned
 
           @goal = @goal_ary[patient]
             .find { |resource| resource.resourceType == 'Goal' }
@@ -175,6 +179,9 @@ module Inferno
           assert_response_ok(reply)
           assert_bundle_response(reply)
           search_with_type = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
+          assert(search_with_type.all? { |resource| ['Goal', 'OperationOutcome'].include? resource.resourceType },
+                 'All resources returned must be of the type Goal or OperationOutcome')
+          search_with_type.reject! { |resource| resource.resourceType == 'OperationOutcome' }
           assert search_with_type.length == @goal_ary[patient].length, 'Expected search by Patient/ID to have the same results as search by ID'
         end
 
@@ -214,6 +221,10 @@ module Inferno
           reply = get_resource_by_params(versioned_resource_class('Goal'), search_params)
 
           validate_search_reply(versioned_resource_class('Goal'), reply, search_params)
+          resource_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
+          assert(resource_returned.all? { |resource| ['Goal', 'OperationOutcome'].include? resource.resourceType },
+                 'All resources returned must be of the type Goal or OperationOutcome')
+          resource_returned.reject! { |resource| resource.resourceType == 'OperationOutcome' }
         end
 
         skip 'Could not resolve all parameters (patient, lifecycle-status) in any resource.' unless resolved_one

--- a/lib/modules/uscore_v3.1.1/us_core_immunization_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_immunization_sequence.rb
@@ -160,7 +160,11 @@ module Inferno
 
           next unless any_resources
 
-          @immunization_ary[patient] = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
+          resource_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
+          assert(resource_returned.all? { |resource| ['Immunization', 'OperationOutcome'].include? resource.resourceType },
+                 'All resources returned must be of the type Immunization or OperationOutcome')
+          resource_returned.reject! { |resource| resource.resourceType == 'OperationOutcome' }
+          @immunization_ary[patient] = resource_returned
 
           @immunization = @immunization_ary[patient]
             .find { |resource| resource.resourceType == 'Immunization' }
@@ -175,6 +179,9 @@ module Inferno
           assert_response_ok(reply)
           assert_bundle_response(reply)
           search_with_type = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
+          assert(search_with_type.all? { |resource| ['Immunization', 'OperationOutcome'].include? resource.resourceType },
+                 'All resources returned must be of the type Immunization or OperationOutcome')
+          search_with_type.reject! { |resource| resource.resourceType == 'OperationOutcome' }
           assert search_with_type.length == @immunization_ary[patient].length, 'Expected search by Patient/ID to have the same results as search by ID'
         end
 
@@ -220,6 +227,10 @@ module Inferno
           reply = perform_search_with_status(reply, search_params) if reply.code == 400
 
           validate_search_reply(versioned_resource_class('Immunization'), reply, search_params)
+          resource_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
+          assert(resource_returned.all? { |resource| ['Immunization', 'OperationOutcome'].include? resource.resourceType },
+                 'All resources returned must be of the type Immunization or OperationOutcome')
+          resource_returned.reject! { |resource| resource.resourceType == 'OperationOutcome' }
 
           ['gt', 'ge', 'lt', 'le'].each do |comparator|
             comparator_val = date_comparator_value(comparator, resolve_element_from_path(@immunization_ary[patient], 'occurrence') { |el| get_value_for_search_param(el).present? })
@@ -265,6 +276,10 @@ module Inferno
           reply = get_resource_by_params(versioned_resource_class('Immunization'), search_params)
 
           validate_search_reply(versioned_resource_class('Immunization'), reply, search_params)
+          resource_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
+          assert(resource_returned.all? { |resource| ['Immunization', 'OperationOutcome'].include? resource.resourceType },
+                 'All resources returned must be of the type Immunization or OperationOutcome')
+          resource_returned.reject! { |resource| resource.resourceType == 'OperationOutcome' }
         end
 
         skip 'Could not resolve all parameters (patient, status) in any resource.' unless resolved_one

--- a/lib/modules/uscore_v3.1.1/us_core_immunization_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_immunization_sequence.rb
@@ -227,10 +227,6 @@ module Inferno
           reply = perform_search_with_status(reply, search_params) if reply.code == 400
 
           validate_search_reply(versioned_resource_class('Immunization'), reply, search_params)
-          resource_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
-          assert(resource_returned.all? { |resource| ['Immunization', 'OperationOutcome'].include? resource.resourceType },
-                 'All resources returned must be of the type Immunization or OperationOutcome')
-          resource_returned.reject! { |resource| resource.resourceType == 'OperationOutcome' }
 
           ['gt', 'ge', 'lt', 'le'].each do |comparator|
             comparator_val = date_comparator_value(comparator, resolve_element_from_path(@immunization_ary[patient], 'occurrence') { |el| get_value_for_search_param(el).present? })
@@ -276,10 +272,6 @@ module Inferno
           reply = get_resource_by_params(versioned_resource_class('Immunization'), search_params)
 
           validate_search_reply(versioned_resource_class('Immunization'), reply, search_params)
-          resource_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
-          assert(resource_returned.all? { |resource| ['Immunization', 'OperationOutcome'].include? resource.resourceType },
-                 'All resources returned must be of the type Immunization or OperationOutcome')
-          resource_returned.reject! { |resource| resource.resourceType == 'OperationOutcome' }
         end
 
         skip 'Could not resolve all parameters (patient, status) in any resource.' unless resolved_one

--- a/lib/modules/uscore_v3.1.1/us_core_implantable_device_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_implantable_device_sequence.rb
@@ -202,10 +202,6 @@ module Inferno
           reply = get_resource_by_params(versioned_resource_class('Device'), search_params)
 
           validate_search_reply(versioned_resource_class('Device'), reply, search_params)
-          resource_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
-          assert(resource_returned.all? { |resource| ['Device', 'OperationOutcome'].include? resource.resourceType },
-                 'All resources returned must be of the type Device or OperationOutcome')
-          resource_returned.reject! { |resource| resource.resourceType == 'OperationOutcome' }
 
           value_with_system = get_value_for_search_param(resolve_element_from_path(@device_ary[patient], 'type'), true)
           token_with_system_search_params = search_params.merge('type': value_with_system)

--- a/lib/modules/uscore_v3.1.1/us_core_medicationrequest_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_medicationrequest_sequence.rb
@@ -210,6 +210,9 @@ module Inferno
 
             @resources_found = true
             resources_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
+            assert(resources_returned.all? { |resource| ['MedicationRequest', 'OperationOutcome'].include? resource.resourceType },
+                   'All resources returned must be of the type MedicationRequest or OperationOutcome')
+            resources_returned.reject! { |resource| resource.resourceType == 'OperationOutcome' }
             @medication_request = resources_returned.first
             @medication_request_ary[patient] += resources_returned
 
@@ -227,6 +230,9 @@ module Inferno
             assert_response_ok(reply)
             assert_bundle_response(reply)
             search_with_type = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
+            assert(search_with_type.all? { |resource| ['MedicationRequest', 'OperationOutcome'].include? resource.resourceType },
+                   'All resources returned must be of the type MedicationRequest or OperationOutcome.')
+            search_with_type.reject! { |resource| resource.resourceType == 'OperationOutcome' }
             assert search_with_type.length == resources_returned.length, 'Expected search by Patient/ID to have the same results as search by ID'
 
             test_medication_inclusion(@medication_request_ary[patient], search_params)
@@ -274,7 +280,11 @@ module Inferno
           reply = get_resource_by_params(versioned_resource_class('MedicationRequest'), search_params)
 
           validate_search_reply(versioned_resource_class('MedicationRequest'), reply, search_params)
-          test_medication_inclusion(reply.resource.entry.map(&:resource), search_params)
+          resource_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
+          assert(resource_returned.all? { |resource| ['MedicationRequest', 'OperationOutcome'].include? resource.resourceType },
+                 'All resources returned must be of the type MedicationRequest or OperationOutcome')
+          resource_returned.reject! { |resource| resource.resourceType == 'OperationOutcome' }
+          test_medication_inclusion(resource_returned, search_params)
         end
 
         skip 'Could not resolve all parameters (patient, intent, status) in any resource.' unless resolved_one
@@ -320,7 +330,11 @@ module Inferno
           reply = perform_search_with_status(reply, search_params) if reply.code == 400
 
           validate_search_reply(versioned_resource_class('MedicationRequest'), reply, search_params)
-          test_medication_inclusion(reply.resource.entry.map(&:resource), search_params)
+          resource_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
+          assert(resource_returned.all? { |resource| ['MedicationRequest', 'OperationOutcome'].include? resource.resourceType },
+                 'All resources returned must be of the type MedicationRequest or OperationOutcome')
+          resource_returned.reject! { |resource| resource.resourceType == 'OperationOutcome' }
+          test_medication_inclusion(resource_returned, search_params)
         end
 
         skip 'Could not resolve all parameters (patient, intent, encounter) in any resource.' unless resolved_one
@@ -370,7 +384,11 @@ module Inferno
           reply = perform_search_with_status(reply, search_params) if reply.code == 400
 
           validate_search_reply(versioned_resource_class('MedicationRequest'), reply, search_params)
-          test_medication_inclusion(reply.resource.entry.map(&:resource), search_params)
+          resource_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
+          assert(resource_returned.all? { |resource| ['MedicationRequest', 'OperationOutcome'].include? resource.resourceType },
+                 'All resources returned must be of the type MedicationRequest or OperationOutcome')
+          resource_returned.reject! { |resource| resource.resourceType == 'OperationOutcome' }
+          test_medication_inclusion(resource_returned, search_params)
         end
 
         skip 'Could not resolve all parameters (patient, intent, authoredon) in any resource.' unless resolved_one

--- a/lib/modules/uscore_v3.1.1/us_core_medicationrequest_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_medicationrequest_sequence.rb
@@ -280,11 +280,12 @@ module Inferno
           reply = get_resource_by_params(versioned_resource_class('MedicationRequest'), search_params)
 
           validate_search_reply(versioned_resource_class('MedicationRequest'), reply, search_params)
-          resource_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
-          assert(resource_returned.all? { |resource| ['MedicationRequest', 'OperationOutcome'].include? resource.resourceType },
+
+          resources_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
+          assert(resources_returned.all? { |resource| ['MedicationRequest', 'OperationOutcome'].include? resource.resourceType },
                  'All resources returned must be of the type MedicationRequest or OperationOutcome')
-          resource_returned.reject! { |resource| resource.resourceType == 'OperationOutcome' }
-          test_medication_inclusion(resource_returned, search_params)
+          resources_returned.reject! { |resource| resource.resourceType == 'OperationOutcome' }
+          test_medication_inclusion(resources_returned, search_params)
         end
 
         skip 'Could not resolve all parameters (patient, intent, status) in any resource.' unless resolved_one
@@ -330,11 +331,12 @@ module Inferno
           reply = perform_search_with_status(reply, search_params) if reply.code == 400
 
           validate_search_reply(versioned_resource_class('MedicationRequest'), reply, search_params)
-          resource_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
-          assert(resource_returned.all? { |resource| ['MedicationRequest', 'OperationOutcome'].include? resource.resourceType },
+
+          resources_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
+          assert(resources_returned.all? { |resource| ['MedicationRequest', 'OperationOutcome'].include? resource.resourceType },
                  'All resources returned must be of the type MedicationRequest or OperationOutcome')
-          resource_returned.reject! { |resource| resource.resourceType == 'OperationOutcome' }
-          test_medication_inclusion(resource_returned, search_params)
+          resources_returned.reject! { |resource| resource.resourceType == 'OperationOutcome' }
+          test_medication_inclusion(resources_returned, search_params)
         end
 
         skip 'Could not resolve all parameters (patient, intent, encounter) in any resource.' unless resolved_one
@@ -384,11 +386,12 @@ module Inferno
           reply = perform_search_with_status(reply, search_params) if reply.code == 400
 
           validate_search_reply(versioned_resource_class('MedicationRequest'), reply, search_params)
-          resource_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
-          assert(resource_returned.all? { |resource| ['MedicationRequest', 'OperationOutcome'].include? resource.resourceType },
+
+          resources_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
+          assert(resources_returned.all? { |resource| ['MedicationRequest', 'OperationOutcome'].include? resource.resourceType },
                  'All resources returned must be of the type MedicationRequest or OperationOutcome')
-          resource_returned.reject! { |resource| resource.resourceType == 'OperationOutcome' }
-          test_medication_inclusion(resource_returned, search_params)
+          resources_returned.reject! { |resource| resource.resourceType == 'OperationOutcome' }
+          test_medication_inclusion(resources_returned, search_params)
         end
 
         skip 'Could not resolve all parameters (patient, intent, authoredon) in any resource.' unless resolved_one

--- a/lib/modules/uscore_v3.1.1/us_core_observation_lab_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_observation_lab_sequence.rb
@@ -190,6 +190,9 @@ module Inferno
 
             @resources_found = true
             resources_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
+            assert(resources_returned.all? { |resource| ['Observation', 'OperationOutcome'].include? resource.resourceType },
+                   'All resources returned must be of the type Observation or OperationOutcome')
+            resources_returned.reject! { |resource| resource.resourceType == 'OperationOutcome' }
             @observation = resources_returned.first
             @observation_ary[patient] += resources_returned
 
@@ -212,6 +215,9 @@ module Inferno
             assert_response_ok(reply)
             assert_bundle_response(reply)
             search_with_type = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
+            assert(search_with_type.all? { |resource| ['Observation', 'OperationOutcome'].include? resource.resourceType },
+                   'All resources returned must be of the type Observation or OperationOutcome.')
+            search_with_type.reject! { |resource| resource.resourceType == 'OperationOutcome' }
             assert search_with_type.length == resources_returned.length, 'Expected search by Patient/ID to have the same results as search by ID'
 
             search_query_variants_tested_once = true
@@ -254,6 +260,10 @@ module Inferno
           reply = perform_search_with_status(reply, search_params) if reply.code == 400
 
           validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
+          resource_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
+          assert(resource_returned.all? { |resource| ['Observation', 'OperationOutcome'].include? resource.resourceType },
+                 'All resources returned must be of the type Observation or OperationOutcome')
+          resource_returned.reject! { |resource| resource.resourceType == 'OperationOutcome' }
 
           value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'code'), true)
           token_with_system_search_params = search_params.merge('code': value_with_system)
@@ -303,6 +313,10 @@ module Inferno
           reply = perform_search_with_status(reply, search_params) if reply.code == 400
 
           validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
+          resource_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
+          assert(resource_returned.all? { |resource| ['Observation', 'OperationOutcome'].include? resource.resourceType },
+                 'All resources returned must be of the type Observation or OperationOutcome')
+          resource_returned.reject! { |resource| resource.resourceType == 'OperationOutcome' }
 
           ['gt', 'ge', 'lt', 'le'].each do |comparator|
             comparator_val = date_comparator_value(comparator, resolve_element_from_path(@observation_ary[patient], 'effective') { |el| get_value_for_search_param(el).present? })
@@ -354,6 +368,10 @@ module Inferno
           reply = get_resource_by_params(versioned_resource_class('Observation'), search_params)
 
           validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
+          resource_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
+          assert(resource_returned.all? { |resource| ['Observation', 'OperationOutcome'].include? resource.resourceType },
+                 'All resources returned must be of the type Observation or OperationOutcome')
+          resource_returned.reject! { |resource| resource.resourceType == 'OperationOutcome' }
 
           value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category'), true)
           token_with_system_search_params = search_params.merge('category': value_with_system)
@@ -404,6 +422,10 @@ module Inferno
           reply = perform_search_with_status(reply, search_params) if reply.code == 400
 
           validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
+          resource_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
+          assert(resource_returned.all? { |resource| ['Observation', 'OperationOutcome'].include? resource.resourceType },
+                 'All resources returned must be of the type Observation or OperationOutcome')
+          resource_returned.reject! { |resource| resource.resourceType == 'OperationOutcome' }
 
           ['gt', 'ge', 'lt', 'le'].each do |comparator|
             comparator_val = date_comparator_value(comparator, resolve_element_from_path(@observation_ary[patient], 'effective') { |el| get_value_for_search_param(el).present? })

--- a/lib/modules/uscore_v3.1.1/us_core_observation_lab_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_observation_lab_sequence.rb
@@ -260,10 +260,6 @@ module Inferno
           reply = perform_search_with_status(reply, search_params) if reply.code == 400
 
           validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
-          resource_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
-          assert(resource_returned.all? { |resource| ['Observation', 'OperationOutcome'].include? resource.resourceType },
-                 'All resources returned must be of the type Observation or OperationOutcome')
-          resource_returned.reject! { |resource| resource.resourceType == 'OperationOutcome' }
 
           value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'code'), true)
           token_with_system_search_params = search_params.merge('code': value_with_system)
@@ -313,10 +309,6 @@ module Inferno
           reply = perform_search_with_status(reply, search_params) if reply.code == 400
 
           validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
-          resource_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
-          assert(resource_returned.all? { |resource| ['Observation', 'OperationOutcome'].include? resource.resourceType },
-                 'All resources returned must be of the type Observation or OperationOutcome')
-          resource_returned.reject! { |resource| resource.resourceType == 'OperationOutcome' }
 
           ['gt', 'ge', 'lt', 'le'].each do |comparator|
             comparator_val = date_comparator_value(comparator, resolve_element_from_path(@observation_ary[patient], 'effective') { |el| get_value_for_search_param(el).present? })
@@ -368,10 +360,6 @@ module Inferno
           reply = get_resource_by_params(versioned_resource_class('Observation'), search_params)
 
           validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
-          resource_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
-          assert(resource_returned.all? { |resource| ['Observation', 'OperationOutcome'].include? resource.resourceType },
-                 'All resources returned must be of the type Observation or OperationOutcome')
-          resource_returned.reject! { |resource| resource.resourceType == 'OperationOutcome' }
 
           value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category'), true)
           token_with_system_search_params = search_params.merge('category': value_with_system)
@@ -422,10 +410,6 @@ module Inferno
           reply = perform_search_with_status(reply, search_params) if reply.code == 400
 
           validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
-          resource_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
-          assert(resource_returned.all? { |resource| ['Observation', 'OperationOutcome'].include? resource.resourceType },
-                 'All resources returned must be of the type Observation or OperationOutcome')
-          resource_returned.reject! { |resource| resource.resourceType == 'OperationOutcome' }
 
           ['gt', 'ge', 'lt', 'le'].each do |comparator|
             comparator_val = date_comparator_value(comparator, resolve_element_from_path(@observation_ary[patient], 'effective') { |el| get_value_for_search_param(el).present? })

--- a/lib/modules/uscore_v3.1.1/us_core_patient_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_patient_sequence.rb
@@ -211,10 +211,6 @@ module Inferno
           reply = get_resource_by_params(versioned_resource_class('Patient'), search_params)
 
           validate_search_reply(versioned_resource_class('Patient'), reply, search_params)
-          resource_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
-          assert(resource_returned.all? { |resource| ['Patient', 'OperationOutcome'].include? resource.resourceType },
-                 'All resources returned must be of the type Patient or OperationOutcome')
-          resource_returned.reject! { |resource| resource.resourceType == 'OperationOutcome' }
 
           value_with_system = get_value_for_search_param(resolve_element_from_path(@patient_ary[patient], 'identifier'), true)
           token_with_system_search_params = search_params.merge('identifier': value_with_system)
@@ -256,10 +252,6 @@ module Inferno
           reply = get_resource_by_params(versioned_resource_class('Patient'), search_params)
 
           validate_search_reply(versioned_resource_class('Patient'), reply, search_params)
-          resource_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
-          assert(resource_returned.all? { |resource| ['Patient', 'OperationOutcome'].include? resource.resourceType },
-                 'All resources returned must be of the type Patient or OperationOutcome')
-          resource_returned.reject! { |resource| resource.resourceType == 'OperationOutcome' }
         end
 
         skip 'Could not resolve all parameters (name) in any resource.' unless resolved_one
@@ -297,10 +289,6 @@ module Inferno
           reply = get_resource_by_params(versioned_resource_class('Patient'), search_params)
 
           validate_search_reply(versioned_resource_class('Patient'), reply, search_params)
-          resource_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
-          assert(resource_returned.all? { |resource| ['Patient', 'OperationOutcome'].include? resource.resourceType },
-                 'All resources returned must be of the type Patient or OperationOutcome')
-          resource_returned.reject! { |resource| resource.resourceType == 'OperationOutcome' }
         end
 
         skip 'Could not resolve all parameters (birthdate, name) in any resource.' unless resolved_one
@@ -338,10 +326,6 @@ module Inferno
           reply = get_resource_by_params(versioned_resource_class('Patient'), search_params)
 
           validate_search_reply(versioned_resource_class('Patient'), reply, search_params)
-          resource_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
-          assert(resource_returned.all? { |resource| ['Patient', 'OperationOutcome'].include? resource.resourceType },
-                 'All resources returned must be of the type Patient or OperationOutcome')
-          resource_returned.reject! { |resource| resource.resourceType == 'OperationOutcome' }
         end
 
         skip 'Could not resolve all parameters (gender, name) in any resource.' unless resolved_one
@@ -380,10 +364,6 @@ module Inferno
           reply = get_resource_by_params(versioned_resource_class('Patient'), search_params)
 
           validate_search_reply(versioned_resource_class('Patient'), reply, search_params)
-          resource_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
-          assert(resource_returned.all? { |resource| ['Patient', 'OperationOutcome'].include? resource.resourceType },
-                 'All resources returned must be of the type Patient or OperationOutcome')
-          resource_returned.reject! { |resource| resource.resourceType == 'OperationOutcome' }
         end
 
         skip 'Could not resolve all parameters (birthdate, family) in any resource.' unless resolved_one
@@ -422,10 +402,6 @@ module Inferno
           reply = get_resource_by_params(versioned_resource_class('Patient'), search_params)
 
           validate_search_reply(versioned_resource_class('Patient'), reply, search_params)
-          resource_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
-          assert(resource_returned.all? { |resource| ['Patient', 'OperationOutcome'].include? resource.resourceType },
-                 'All resources returned must be of the type Patient or OperationOutcome')
-          resource_returned.reject! { |resource| resource.resourceType == 'OperationOutcome' }
         end
 
         skip 'Could not resolve all parameters (family, gender) in any resource.' unless resolved_one

--- a/lib/modules/uscore_v3.1.1/us_core_patient_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_patient_sequence.rb
@@ -162,7 +162,11 @@ module Inferno
 
           next unless any_resources
 
-          @patient_ary[patient] = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
+          resource_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
+          assert(resource_returned.all? { |resource| ['Patient', 'OperationOutcome'].include? resource.resourceType },
+                 'All resources returned must be of the type Patient or OperationOutcome')
+          resource_returned.reject! { |resource| resource.resourceType == 'OperationOutcome' }
+          @patient_ary[patient] = resource_returned
 
           @patient = @patient_ary[patient]
             .find { |resource| resource.resourceType == 'Patient' }
@@ -207,6 +211,10 @@ module Inferno
           reply = get_resource_by_params(versioned_resource_class('Patient'), search_params)
 
           validate_search_reply(versioned_resource_class('Patient'), reply, search_params)
+          resource_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
+          assert(resource_returned.all? { |resource| ['Patient', 'OperationOutcome'].include? resource.resourceType },
+                 'All resources returned must be of the type Patient or OperationOutcome')
+          resource_returned.reject! { |resource| resource.resourceType == 'OperationOutcome' }
 
           value_with_system = get_value_for_search_param(resolve_element_from_path(@patient_ary[patient], 'identifier'), true)
           token_with_system_search_params = search_params.merge('identifier': value_with_system)
@@ -248,6 +256,10 @@ module Inferno
           reply = get_resource_by_params(versioned_resource_class('Patient'), search_params)
 
           validate_search_reply(versioned_resource_class('Patient'), reply, search_params)
+          resource_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
+          assert(resource_returned.all? { |resource| ['Patient', 'OperationOutcome'].include? resource.resourceType },
+                 'All resources returned must be of the type Patient or OperationOutcome')
+          resource_returned.reject! { |resource| resource.resourceType == 'OperationOutcome' }
         end
 
         skip 'Could not resolve all parameters (name) in any resource.' unless resolved_one
@@ -285,6 +297,10 @@ module Inferno
           reply = get_resource_by_params(versioned_resource_class('Patient'), search_params)
 
           validate_search_reply(versioned_resource_class('Patient'), reply, search_params)
+          resource_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
+          assert(resource_returned.all? { |resource| ['Patient', 'OperationOutcome'].include? resource.resourceType },
+                 'All resources returned must be of the type Patient or OperationOutcome')
+          resource_returned.reject! { |resource| resource.resourceType == 'OperationOutcome' }
         end
 
         skip 'Could not resolve all parameters (birthdate, name) in any resource.' unless resolved_one
@@ -322,6 +338,10 @@ module Inferno
           reply = get_resource_by_params(versioned_resource_class('Patient'), search_params)
 
           validate_search_reply(versioned_resource_class('Patient'), reply, search_params)
+          resource_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
+          assert(resource_returned.all? { |resource| ['Patient', 'OperationOutcome'].include? resource.resourceType },
+                 'All resources returned must be of the type Patient or OperationOutcome')
+          resource_returned.reject! { |resource| resource.resourceType == 'OperationOutcome' }
         end
 
         skip 'Could not resolve all parameters (gender, name) in any resource.' unless resolved_one
@@ -360,6 +380,10 @@ module Inferno
           reply = get_resource_by_params(versioned_resource_class('Patient'), search_params)
 
           validate_search_reply(versioned_resource_class('Patient'), reply, search_params)
+          resource_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
+          assert(resource_returned.all? { |resource| ['Patient', 'OperationOutcome'].include? resource.resourceType },
+                 'All resources returned must be of the type Patient or OperationOutcome')
+          resource_returned.reject! { |resource| resource.resourceType == 'OperationOutcome' }
         end
 
         skip 'Could not resolve all parameters (birthdate, family) in any resource.' unless resolved_one
@@ -398,6 +422,10 @@ module Inferno
           reply = get_resource_by_params(versioned_resource_class('Patient'), search_params)
 
           validate_search_reply(versioned_resource_class('Patient'), reply, search_params)
+          resource_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
+          assert(resource_returned.all? { |resource| ['Patient', 'OperationOutcome'].include? resource.resourceType },
+                 'All resources returned must be of the type Patient or OperationOutcome')
+          resource_returned.reject! { |resource| resource.resourceType == 'OperationOutcome' }
         end
 
         skip 'Could not resolve all parameters (family, gender) in any resource.' unless resolved_one

--- a/lib/modules/uscore_v3.1.1/us_core_procedure_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_procedure_sequence.rb
@@ -174,7 +174,11 @@ module Inferno
 
           next unless any_resources
 
-          @procedure_ary[patient] = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
+          resource_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
+          assert(resource_returned.all? { |resource| ['Procedure', 'OperationOutcome'].include? resource.resourceType },
+                 'All resources returned must be of the type Procedure or OperationOutcome')
+          resource_returned.reject! { |resource| resource.resourceType == 'OperationOutcome' }
+          @procedure_ary[patient] = resource_returned
 
           @procedure = @procedure_ary[patient]
             .find { |resource| resource.resourceType == 'Procedure' }
@@ -189,6 +193,9 @@ module Inferno
           assert_response_ok(reply)
           assert_bundle_response(reply)
           search_with_type = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
+          assert(search_with_type.all? { |resource| ['Procedure', 'OperationOutcome'].include? resource.resourceType },
+                 'All resources returned must be of the type Procedure or OperationOutcome')
+          search_with_type.reject! { |resource| resource.resourceType == 'OperationOutcome' }
           assert search_with_type.length == @procedure_ary[patient].length, 'Expected search by Patient/ID to have the same results as search by ID'
         end
 
@@ -233,6 +240,10 @@ module Inferno
           reply = perform_search_with_status(reply, search_params) if reply.code == 400
 
           validate_search_reply(versioned_resource_class('Procedure'), reply, search_params)
+          resource_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
+          assert(resource_returned.all? { |resource| ['Procedure', 'OperationOutcome'].include? resource.resourceType },
+                 'All resources returned must be of the type Procedure or OperationOutcome')
+          resource_returned.reject! { |resource| resource.resourceType == 'OperationOutcome' }
 
           ['gt', 'ge', 'lt', 'le'].each do |comparator|
             comparator_val = date_comparator_value(comparator, resolve_element_from_path(@procedure_ary[patient], 'performed') { |el| get_value_for_search_param(el).present? })
@@ -278,6 +289,10 @@ module Inferno
           reply = get_resource_by_params(versioned_resource_class('Procedure'), search_params)
 
           validate_search_reply(versioned_resource_class('Procedure'), reply, search_params)
+          resource_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
+          assert(resource_returned.all? { |resource| ['Procedure', 'OperationOutcome'].include? resource.resourceType },
+                 'All resources returned must be of the type Procedure or OperationOutcome')
+          resource_returned.reject! { |resource| resource.resourceType == 'OperationOutcome' }
         end
 
         skip 'Could not resolve all parameters (patient, status) in any resource.' unless resolved_one
@@ -323,6 +338,10 @@ module Inferno
           reply = perform_search_with_status(reply, search_params) if reply.code == 400
 
           validate_search_reply(versioned_resource_class('Procedure'), reply, search_params)
+          resource_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
+          assert(resource_returned.all? { |resource| ['Procedure', 'OperationOutcome'].include? resource.resourceType },
+                 'All resources returned must be of the type Procedure or OperationOutcome')
+          resource_returned.reject! { |resource| resource.resourceType == 'OperationOutcome' }
 
           ['gt', 'ge', 'lt', 'le'].each do |comparator|
             comparator_val = date_comparator_value(comparator, resolve_element_from_path(@procedure_ary[patient], 'performed') { |el| get_value_for_search_param(el).present? })

--- a/lib/modules/uscore_v3.1.1/us_core_procedure_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_procedure_sequence.rb
@@ -240,10 +240,6 @@ module Inferno
           reply = perform_search_with_status(reply, search_params) if reply.code == 400
 
           validate_search_reply(versioned_resource_class('Procedure'), reply, search_params)
-          resource_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
-          assert(resource_returned.all? { |resource| ['Procedure', 'OperationOutcome'].include? resource.resourceType },
-                 'All resources returned must be of the type Procedure or OperationOutcome')
-          resource_returned.reject! { |resource| resource.resourceType == 'OperationOutcome' }
 
           ['gt', 'ge', 'lt', 'le'].each do |comparator|
             comparator_val = date_comparator_value(comparator, resolve_element_from_path(@procedure_ary[patient], 'performed') { |el| get_value_for_search_param(el).present? })
@@ -289,10 +285,6 @@ module Inferno
           reply = get_resource_by_params(versioned_resource_class('Procedure'), search_params)
 
           validate_search_reply(versioned_resource_class('Procedure'), reply, search_params)
-          resource_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
-          assert(resource_returned.all? { |resource| ['Procedure', 'OperationOutcome'].include? resource.resourceType },
-                 'All resources returned must be of the type Procedure or OperationOutcome')
-          resource_returned.reject! { |resource| resource.resourceType == 'OperationOutcome' }
         end
 
         skip 'Could not resolve all parameters (patient, status) in any resource.' unless resolved_one
@@ -338,10 +330,6 @@ module Inferno
           reply = perform_search_with_status(reply, search_params) if reply.code == 400
 
           validate_search_reply(versioned_resource_class('Procedure'), reply, search_params)
-          resource_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
-          assert(resource_returned.all? { |resource| ['Procedure', 'OperationOutcome'].include? resource.resourceType },
-                 'All resources returned must be of the type Procedure or OperationOutcome')
-          resource_returned.reject! { |resource| resource.resourceType == 'OperationOutcome' }
 
           ['gt', 'ge', 'lt', 'le'].each do |comparator|
             comparator_val = date_comparator_value(comparator, resolve_element_from_path(@procedure_ary[patient], 'performed') { |el| get_value_for_search_param(el).present? })

--- a/lib/modules/uscore_v3.1.1/us_core_pulse_oximetry_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_pulse_oximetry_sequence.rb
@@ -265,10 +265,6 @@ module Inferno
           reply = perform_search_with_status(reply, search_params) if reply.code == 400
 
           validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
-          resource_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
-          assert(resource_returned.all? { |resource| ['Observation', 'OperationOutcome'].include? resource.resourceType },
-                 'All resources returned must be of the type Observation or OperationOutcome')
-          resource_returned.reject! { |resource| resource.resourceType == 'OperationOutcome' }
 
           ['gt', 'ge', 'lt', 'le'].each do |comparator|
             comparator_val = date_comparator_value(comparator, resolve_element_from_path(@observation_ary[patient], 'effective') { |el| get_value_for_search_param(el).present? })
@@ -320,10 +316,6 @@ module Inferno
           reply = perform_search_with_status(reply, search_params) if reply.code == 400
 
           validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
-          resource_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
-          assert(resource_returned.all? { |resource| ['Observation', 'OperationOutcome'].include? resource.resourceType },
-                 'All resources returned must be of the type Observation or OperationOutcome')
-          resource_returned.reject! { |resource| resource.resourceType == 'OperationOutcome' }
 
           value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category'), true)
           token_with_system_search_params = search_params.merge('category': value_with_system)
@@ -368,10 +360,6 @@ module Inferno
           reply = get_resource_by_params(versioned_resource_class('Observation'), search_params)
 
           validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
-          resource_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
-          assert(resource_returned.all? { |resource| ['Observation', 'OperationOutcome'].include? resource.resourceType },
-                 'All resources returned must be of the type Observation or OperationOutcome')
-          resource_returned.reject! { |resource| resource.resourceType == 'OperationOutcome' }
 
           value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category'), true)
           token_with_system_search_params = search_params.merge('category': value_with_system)
@@ -422,10 +410,6 @@ module Inferno
           reply = perform_search_with_status(reply, search_params) if reply.code == 400
 
           validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
-          resource_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
-          assert(resource_returned.all? { |resource| ['Observation', 'OperationOutcome'].include? resource.resourceType },
-                 'All resources returned must be of the type Observation or OperationOutcome')
-          resource_returned.reject! { |resource| resource.resourceType == 'OperationOutcome' }
 
           ['gt', 'ge', 'lt', 'le'].each do |comparator|
             comparator_val = date_comparator_value(comparator, resolve_element_from_path(@observation_ary[patient], 'effective') { |el| get_value_for_search_param(el).present? })

--- a/lib/modules/uscore_v3.1.1/us_core_pulse_oximetry_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_pulse_oximetry_sequence.rb
@@ -190,6 +190,9 @@ module Inferno
 
             @resources_found = true
             resources_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
+            assert(resources_returned.all? { |resource| ['Observation', 'OperationOutcome'].include? resource.resourceType },
+                   'All resources returned must be of the type Observation or OperationOutcome')
+            resources_returned.reject! { |resource| resource.resourceType == 'OperationOutcome' }
             @observation = resources_returned.first
             @observation_ary[patient] += resources_returned
 
@@ -212,6 +215,9 @@ module Inferno
             assert_response_ok(reply)
             assert_bundle_response(reply)
             search_with_type = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
+            assert(search_with_type.all? { |resource| ['Observation', 'OperationOutcome'].include? resource.resourceType },
+                   'All resources returned must be of the type Observation or OperationOutcome.')
+            search_with_type.reject! { |resource| resource.resourceType == 'OperationOutcome' }
             assert search_with_type.length == resources_returned.length, 'Expected search by Patient/ID to have the same results as search by ID'
 
             search_query_variants_tested_once = true
@@ -259,6 +265,10 @@ module Inferno
           reply = perform_search_with_status(reply, search_params) if reply.code == 400
 
           validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
+          resource_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
+          assert(resource_returned.all? { |resource| ['Observation', 'OperationOutcome'].include? resource.resourceType },
+                 'All resources returned must be of the type Observation or OperationOutcome')
+          resource_returned.reject! { |resource| resource.resourceType == 'OperationOutcome' }
 
           ['gt', 'ge', 'lt', 'le'].each do |comparator|
             comparator_val = date_comparator_value(comparator, resolve_element_from_path(@observation_ary[patient], 'effective') { |el| get_value_for_search_param(el).present? })
@@ -310,6 +320,10 @@ module Inferno
           reply = perform_search_with_status(reply, search_params) if reply.code == 400
 
           validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
+          resource_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
+          assert(resource_returned.all? { |resource| ['Observation', 'OperationOutcome'].include? resource.resourceType },
+                 'All resources returned must be of the type Observation or OperationOutcome')
+          resource_returned.reject! { |resource| resource.resourceType == 'OperationOutcome' }
 
           value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category'), true)
           token_with_system_search_params = search_params.merge('category': value_with_system)
@@ -354,6 +368,10 @@ module Inferno
           reply = get_resource_by_params(versioned_resource_class('Observation'), search_params)
 
           validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
+          resource_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
+          assert(resource_returned.all? { |resource| ['Observation', 'OperationOutcome'].include? resource.resourceType },
+                 'All resources returned must be of the type Observation or OperationOutcome')
+          resource_returned.reject! { |resource| resource.resourceType == 'OperationOutcome' }
 
           value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category'), true)
           token_with_system_search_params = search_params.merge('category': value_with_system)
@@ -404,6 +422,10 @@ module Inferno
           reply = perform_search_with_status(reply, search_params) if reply.code == 400
 
           validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
+          resource_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
+          assert(resource_returned.all? { |resource| ['Observation', 'OperationOutcome'].include? resource.resourceType },
+                 'All resources returned must be of the type Observation or OperationOutcome')
+          resource_returned.reject! { |resource| resource.resourceType == 'OperationOutcome' }
 
           ['gt', 'ge', 'lt', 'le'].each do |comparator|
             comparator_val = date_comparator_value(comparator, resolve_element_from_path(@observation_ary[patient], 'effective') { |el| get_value_for_search_param(el).present? })

--- a/lib/modules/uscore_v3.1.1/us_core_smokingstatus_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_smokingstatus_sequence.rb
@@ -194,6 +194,9 @@ module Inferno
 
             @resources_found = true
             resources_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
+            assert(resources_returned.all? { |resource| ['Observation', 'OperationOutcome'].include? resource.resourceType },
+                   'All resources returned must be of the type Observation or OperationOutcome')
+            resources_returned.reject! { |resource| resource.resourceType == 'OperationOutcome' }
             @observation = resources_returned.first
             @observation_ary[patient] += resources_returned
 
@@ -216,6 +219,9 @@ module Inferno
             assert_response_ok(reply)
             assert_bundle_response(reply)
             search_with_type = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
+            assert(search_with_type.all? { |resource| ['Observation', 'OperationOutcome'].include? resource.resourceType },
+                   'All resources returned must be of the type Observation or OperationOutcome.')
+            search_with_type.reject! { |resource| resource.resourceType == 'OperationOutcome' }
             assert search_with_type.length == resources_returned.length, 'Expected search by Patient/ID to have the same results as search by ID'
 
             search_query_variants_tested_once = true

--- a/test/fixtures/bundle_1.json
+++ b/test/fixtures/bundle_1.json
@@ -7,6 +7,12 @@
         "resourceType": "Patient",
         "id": "1"
       }
+    },
+    {
+      "resource": {
+        "resourceType": "OperationOutcome",
+        "id": "3"
+      }
     }
   ],
   "link": [

--- a/test/fixtures/bundle_1.json
+++ b/test/fixtures/bundle_1.json
@@ -7,12 +7,6 @@
         "resourceType": "Patient",
         "id": "1"
       }
-    },
-    {
-      "resource": {
-        "resourceType": "OperationOutcome",
-        "id": "3"
-      }
     }
   ],
   "link": [

--- a/test/unit/sequence_base_test.rb
+++ b/test/unit/sequence_base_test.rb
@@ -254,7 +254,7 @@ class SequenceBaseTest < MiniTest::Test
       @sequence = Inferno::Sequence::SequenceBase.new(instance, client, true)
     end
 
-    it 'returns non-OperationOutcome resources from all bundles' do
+    it 'returns resources from all bundles' do
       stub_request(:get, @bundle1.link.first.url)
         .to_return(body: @bundle2)
 

--- a/test/unit/sequence_base_test.rb
+++ b/test/unit/sequence_base_test.rb
@@ -254,7 +254,7 @@ class SequenceBaseTest < MiniTest::Test
       @sequence = Inferno::Sequence::SequenceBase.new(instance, client, true)
     end
 
-    it 'returns resources from all bundles' do
+    it 'returns non-OperationOutcome resources from all bundles' do
       stub_request(:get, @bundle1.link.first.url)
         .to_return(body: @bundle2)
 


### PR DESCRIPTION
This PR makes it so that sequences don't save OperationOutcome results after performing a search. If the search was successful, and an operationoutcome was returned the bundle, the sequence will continue as if it didn't see an OperationOutcome. 

This change won't affect the situation where a search fails and they return an operation outcome. 

**Submitter:**
- [X] This pull request describes why these changes were made
- [X] Internal ticket for this PR: https://oncprojectracking.healthit.gov/support/browse/FI-1149
- [X] Internal ticket links to this PR
- [X] Internal ticket is properly labeled (Community/Program)
- [X] Internal ticket has a justification for its Community/Program label
- [X] Code diff has been reviewed for extraneous/missing code
- [X] Tests are included and test edge cases
- [X] Tests/code quality metrics have been run locally and pass


**Reviewer 1:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code

**Reviewer 2:**

Name:
- [ ] Code is maintainable and reusable, reuses existing code and infrastructure
      where appropriate, and accomplishes the task's purpose
- [ ] The tests appropriately test the new code, including edge cases
- [ ] You have tried to break the code
