### PR TITLE
FI-1150 skip contained reference from save_delayed_reference

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -39,7 +39,7 @@ resource_validator: external
 
 # The url where the external validator can be reached. Ignored when using the
 # internal validator.
-external_resource_validator_url: http://validator_service:4567
+external_resource_validator_url: http://localhost:8887
 
 # The list of testing modules which will be made available. These entries must
 # match the "name" field in the .yml files in lib/modules.

--- a/config.yml
+++ b/config.yml
@@ -39,7 +39,7 @@ resource_validator: external
 
 # The url where the external validator can be reached. Ignored when using the
 # internal validator.
-external_resource_validator_url: http://localhost:8887
+external_resource_validator_url: http://validator_service:4567
 
 # The list of testing modules which will be made available. These entries must
 # match the "name" field in the .yml files in lib/modules.

--- a/lib/app/sequence_base.rb
+++ b/lib/app/sequence_base.rb
@@ -745,7 +745,7 @@ module Inferno
           delayed_sequence_references.each do |delayed_sequence_reference|
             reference_elements = resolve_path(resource, delayed_sequence_reference[:path])
             reference_elements.each do |reference|
-              next unless reference.is_a? FHIR::Reference
+              next if !(reference.is_a? FHIR::Reference) || reference.contained?
 
               resource_class = reference.resource_class.name.demodulize
               is_delayed = delayed_sequence_reference[:resources].include?(resource_class)

--- a/lib/modules/uscore_v3.1.1/test/fixtures/us_core_careteam.json
+++ b/lib/modules/uscore_v3.1.1/test/fixtures/us_core_careteam.json
@@ -54,6 +54,16 @@
     {
       "role": [
         {
+          "text": "Healthcare Proxy"
+        }
+      ],
+      "member": {
+        "reference": "#199951"
+      }
+    },
+    {
+      "role": [
+        {
           "coding": [
             {
               "system": "http://snomed.info/sct",
@@ -67,6 +77,54 @@
         "reference": "Patient/example",
         "display": "Amy V. Shaw"
       }
+    }
+  ],
+  "contained": [
+    {
+      "resourceType": "RelatedPerson",
+      "id": "199951",
+      "patient": {
+        "reference": "Patient/75C0BB942A5F475D8F931C2B1A3A04A4",
+        "display": "Elson,Carmine-CareTeam Theresia"
+      },
+      "relationship": [
+        {
+          "text": "Oth"
+        }
+      ],
+      "name": [
+        {
+          "use": "official",
+          "text": "Stalone,Rick",
+          "family": "Stalone",
+          "given": [
+            "Rick"
+          ]
+        }
+      ]
+    },
+    {
+      "resourceType": "RelatedPerson",
+      "id": "199952",
+      "patient": {
+        "reference": "Patient/75C0BB942A5F475D8F931C2B1A3A04A4",
+        "display": "Elson,Carmine-CareTeam Theresia"
+      },
+      "relationship": [
+        {
+          "text": "Oth"
+        }
+      ],
+      "name": [
+        {
+          "use": "official",
+          "text": "Stalone,Bobbie",
+          "family": "Stalone",
+          "given": [
+            "Bobbie"
+          ]
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
# Summary
Add logic skipping contained reference from treating as delayed references

## New behavior
reference to contained resource are skipped

## Code changes
save_delayed_sequence_references() in sequence_base.rb

## Testing guidance
Add a MustSpported reference to a contained resource. Example provided at lib/module/uscore_v3.1.1/test/fixutres/us_core_careteam.json