### PR TITLE
FI-1157 Allow more flexibility in which endpoints expose which smart capabiliites

### DIFF
--- a/lib/modules/onc_program/onc_smart_discovery_sequence.rb
+++ b/lib/modules/onc_program/onc_smart_discovery_sequence.rb
@@ -47,7 +47,27 @@ module Inferno
         # run after the oauth endpoints are saved
       end
 
-      REQUIRED_SMART_CAPABILITIES = [
+      # Only require EHR launch related capabilities
+      # A separate sequence handles standalone launch
+
+      def self.required_smart_capabilities
+        [
+          'launch-ehr',
+          'client-confidential-symmetric',
+          'sso-openid-connect',
+          'context-banner',
+          'context-style',
+          'context-ehr-patient',
+          'permission-offline',
+          'permission-user'
+        ]
+      end
+
+      def required_smart_capabilities
+        self.class.required_smart_capabilities
+      end
+
+      SMART_CAPABILITIES = [
         'launch-ehr',
         'launch-standalone',
         'client-public',
@@ -267,7 +287,7 @@ module Inferno
           description %(
             A SMART on FHIR server SHALL convey its capabilities to app
             developers by listing a set of the capabilities. The following
-            capabilities are required: #{REQUIRED_SMART_CAPABILITIES.join(', ')}
+            capabilities are required: #{OncSMARTDiscoverySequence.required_smart_capabilities.join(', ')}
           )
         end
 
@@ -276,7 +296,7 @@ module Inferno
         capabilities = @well_known_configuration['capabilities']
         assert capabilities.is_a?(Array), 'The well-known capabilities are not an array'
 
-        missing_capabilities = REQUIRED_SMART_CAPABILITIES - capabilities
+        missing_capabilities = required_smart_capabilities - capabilities
         assert missing_capabilities.empty?, "The following required capabilities are missing: #{missing_capabilities.join(', ')}"
       end
     end

--- a/lib/modules/onc_program/onc_smart_discovery_sequence.rb
+++ b/lib/modules/onc_program/onc_smart_discovery_sequence.rb
@@ -286,8 +286,10 @@ module Inferno
           link 'http://hl7.org/fhir/smart-app-launch/conformance/index.html#core-capabilities'
           description %(
             A SMART on FHIR server SHALL convey its capabilities to app
-            developers by listing a set of the capabilities. The following
-            capabilities are required: #{OncSMARTDiscoverySequence.required_smart_capabilities.join(', ')}
+            developers by listing the SMART core capabilities supported by
+            their implementation within the Well-known configuration file.
+            This test ensures that the capabilities required by this scenario
+            are properly documented in the Well-known file.
           )
         end
 
@@ -297,7 +299,7 @@ module Inferno
         assert capabilities.is_a?(Array), 'The well-known capabilities are not an array'
 
         missing_capabilities = required_smart_capabilities - capabilities
-        assert missing_capabilities.empty?, "The following required capabilities are missing: #{missing_capabilities.join(', ')}"
+        assert missing_capabilities.empty?, "The following capabilities required for this scenario are missing: #{missing_capabilities.join(', ')}"
       end
     end
   end

--- a/lib/modules/onc_program/onc_standalone_smart_discovery_sequence.rb
+++ b/lib/modules/onc_program/onc_standalone_smart_discovery_sequence.rb
@@ -48,6 +48,18 @@ module Inferno
         @instance.onc_sl_oauth_authorize_endpoint = oauth_authorize_endpoint
         @instance.save!
       end
+
+      def self.required_smart_capabilities
+        [
+          'launch-standalone',
+          'client-public',
+          'client-confidential-symmetric',
+          'sso-openid-connect',
+          'context-standalone-patient',
+          'permission-offline',
+          'permission-patient'
+        ]
+      end
     end
   end
 end

--- a/lib/modules/onc_program/test/onc_smart_discovery_sequence_test.rb
+++ b/lib/modules/onc_program/test/onc_smart_discovery_sequence_test.rb
@@ -9,6 +9,18 @@ describe Inferno::Sequence::OncSMARTDiscoverySequence do
     @instance = Inferno::Models::TestingInstance.new
   end
 
+  it 'must require a a subset of all capabilities' do
+    # Our ONC program tests allow for multiple endpoints, so we cannot require
+    # all capabilities to be supported by all endpoints.  This test ensures our
+    # test only requires a subset.
+
+    all_capabilities = @sequence_class::SMART_CAPABILITIES.to_set
+    required_capabilities = @sequence_class.required_smart_capabilities.to_set
+
+    assert required_capabilities.include? 'launch-ehr'
+    assert required_capabilities.proper_subset?(all_capabilities)
+  end
+
   describe 'required capabilities test' do
     before do
       @test = @sequence_class[:required_capabilities]
@@ -32,8 +44,8 @@ describe Inferno::Sequence::OncSMARTDiscoverySequence do
     end
 
     it 'fails if a required capability is missing' do
-      @sequence_class::REQUIRED_SMART_CAPABILITIES.each do |capability|
-        capabilities = @sequence_class::REQUIRED_SMART_CAPABILITIES.dup
+      @sequence_class.required_smart_capabilities.each do |capability|
+        capabilities = @sequence_class.required_smart_capabilities.dup
         capabilities.delete(capability)
 
         @sequence.instance_variable_set(:@well_known_configuration, 'capabilities' => capabilities)
@@ -45,7 +57,14 @@ describe Inferno::Sequence::OncSMARTDiscoverySequence do
     end
 
     it 'succeeds if all required capabilities are present' do
-      capabilities = @sequence_class::REQUIRED_SMART_CAPABILITIES
+      capabilities = @sequence_class.required_smart_capabilities
+      @sequence.instance_variable_set(:@well_known_configuration, 'capabilities' => capabilities)
+
+      @sequence.run_test(@test)
+    end
+
+    it 'succeeds if all capabilities are present' do
+      capabilities = @sequence_class::SMART_CAPABILITIES
       @sequence.instance_variable_set(:@well_known_configuration, 'capabilities' => capabilities)
 
       @sequence.run_test(@test)

--- a/lib/modules/onc_program/test/onc_smart_discovery_sequence_test.rb
+++ b/lib/modules/onc_program/test/onc_smart_discovery_sequence_test.rb
@@ -52,7 +52,7 @@ describe Inferno::Sequence::OncSMARTDiscoverySequence do
 
         exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
 
-        assert_equal "The following required capabilities are missing: #{capability}", exception.message
+        assert_equal "The following capabilities required for this scenario are missing: #{capability}", exception.message
       end
     end
 

--- a/lib/modules/onc_program/test/onc_standalone_smart_discovery_sequence_test.rb
+++ b/lib/modules/onc_program/test/onc_standalone_smart_discovery_sequence_test.rb
@@ -9,6 +9,18 @@ describe Inferno::Sequence::OncStandaloneSMARTDiscoverySequence do
     @instance = Inferno::Models::TestingInstance.new
   end
 
+  it 'must require a a subset of all capabilities' do
+    # Our ONC program tests allow for multiple endpoints, so we cannot require
+    # all capabilities to be supported by all endpoints.  This test ensures our
+    # test only requires a subset.
+
+    all_capabilities = @sequence_class::SMART_CAPABILITIES.to_set
+    required_capabilities = @sequence_class.required_smart_capabilities.to_set
+
+    assert required_capabilities.include? 'launch-standalone'
+    assert required_capabilities.proper_subset?(all_capabilities)
+  end
+
   describe 'required capabilities test' do
     before do
       @test = @sequence_class[:required_capabilities]
@@ -32,8 +44,8 @@ describe Inferno::Sequence::OncStandaloneSMARTDiscoverySequence do
     end
 
     it 'fails if a required capability is missing' do
-      @sequence_class::REQUIRED_SMART_CAPABILITIES.each do |capability|
-        capabilities = @sequence_class::REQUIRED_SMART_CAPABILITIES.dup
+      @sequence_class.required_smart_capabilities.each do |capability|
+        capabilities = @sequence_class.required_smart_capabilities.dup
         capabilities.delete(capability)
 
         @sequence.instance_variable_set(:@well_known_configuration, 'capabilities' => capabilities)
@@ -45,7 +57,14 @@ describe Inferno::Sequence::OncStandaloneSMARTDiscoverySequence do
     end
 
     it 'succeeds if all required capabilities are present' do
-      capabilities = @sequence_class::REQUIRED_SMART_CAPABILITIES
+      capabilities = @sequence_class.required_smart_capabilities
+      @sequence.instance_variable_set(:@well_known_configuration, 'capabilities' => capabilities)
+
+      @sequence.run_test(@test)
+    end
+
+    it 'succeeds if all capabilities are present' do
+      capabilities = @sequence_class::SMART_CAPABILITIES
       @sequence.instance_variable_set(:@well_known_configuration, 'capabilities' => capabilities)
 
       @sequence.run_test(@test)

--- a/lib/modules/onc_program/test/onc_standalone_smart_discovery_sequence_test.rb
+++ b/lib/modules/onc_program/test/onc_standalone_smart_discovery_sequence_test.rb
@@ -52,7 +52,7 @@ describe Inferno::Sequence::OncStandaloneSMARTDiscoverySequence do
 
         exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
 
-        assert_equal "The following required capabilities are missing: #{capability}", exception.message
+        assert_equal "The following capabilities required for this scenario are missing: #{capability}", exception.message
       end
     end
 


### PR DESCRIPTION
# Summary

If a system implements patient-centric and practitioner-centric APIs using different FHIR endpoints, then they should not need to state support for all smart capabilities at every endpoint.

## New behavior

This now only ensures that the capabilities relevant to the current target use case (patient standalone vs practitioner ehr) is tested.

## Code changes

The only tricky part here is how to override what used to be a CONSTANT.  Please verify that this approach makes sense.

## Testing guidance

Review updated tests.  They should cover all necessary cases.
