### PR TITLE
unescape the \\, in search value

### DIFF
--- a/lib/app/sequence_base.rb
+++ b/lib/app/sequence_base.rb
@@ -537,7 +537,8 @@ module Inferno
           assert resource_validation_errors[:errors].empty?, "Invalid #{resource.resourceType}: #{resource_validation_errors[:errors].join("\n* ")}"
 
           search_params.each do |key, value|
-            validate_resource_item(resource, key.to_s, value)
+            unescaped_value = value&.gsub('\\,', ',')
+            validate_resource_item(resource, key.to_s, unescaped_value)
           end
         end
       end

--- a/lib/modules/uscore_v3.1.1/test/fixtures/us_core_patient.json
+++ b/lib/modules/uscore_v3.1.1/test/fixtures/us_core_patient.json
@@ -122,7 +122,8 @@
       "given": [
         "Amy",
         "V."
-      ]
+      ],
+      "text": "Shaw, Amy"
     }
   ],
   "telecom": [

--- a/lib/modules/uscore_v3.1.1/test/us_core_patient_test.rb
+++ b/lib/modules/uscore_v3.1.1/test/us_core_patient_test.rb
@@ -264,6 +264,23 @@ describe Inferno::Sequence::USCore311PatientSequence do
 
       @sequence.run_test(@test)
     end
+
+    it 'succeeds when name has comma in text' do
+      # remove patient's family name and give name so that
+      # inferno has to use the name.text for search
+      @patient.name.first.family = nil
+      @patient.name.first.given = nil
+
+      @query = {
+        'name': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@patient_ary[@sequence.patient_ids.first], 'name'))
+      }
+
+      stub_request(:get, "#{@base_url}/Patient")
+        .with(query: @query, headers: @auth_header)
+        .to_return(status: 200, body: wrap_resources_in_bundle(@patient_ary.values.flatten).to_json)
+
+      @sequence.run_test(@test)
+    end
   end
 
   describe 'Patient search by birthdate+name test' do


### PR DESCRIPTION
# Summary
when creating search_parameter, comma(,) character is replaced with "\\," to avoid conflict with FHIR multiple OR search. For example: "Dole,John" is reformed search parameter: name=Dole\\,John in order to distinguish from name=Dole,John which is searching name starts with "Dole" or "John"

While compare the result with search parameter, the "\\," in search parameter need to changed back to "," only.

## New behavior
Unescape "\\," in search value to ","

## Code changes
validate_reply_entries in sequence_base.rb
new unit test
updated testing artifact with name text

## Testing guidance
