### PR TITLE
Delay failure to enable more tests to run.

### DIFF
--- a/generator/uscore/templates/unit_tests/search_unit_test.rb.erb
+++ b/generator/uscore/templates/unit_tests/search_unit_test.rb.erb
@@ -152,17 +152,17 @@ describe '<%= resource_type %> search by <%= search_params.keys.join('+') %> tes
       }
       stub_request(:get, "#{@base_url}/<%= resource_type %>")
         .with(query: query_params, headers: @auth_header)
-        .to_return(status: 200, body: wrap_resources_in_bundle([FHIR::<%= resource_type %>.new, FHIR::Specimen.new]).to_json)
+        .to_return(status: 200, body: wrap_resources_in_bundle([FHIR::<%= resource_type %>.new, FHIR::Specimen.new, FHIR::PaymentNotice.new]).to_json)
     end
   <% else %>
     stub_request(:get, "#{@base_url}/<%= resource_type %>")
       .with(query: @query, headers: @auth_header)
-      .to_return(status: 200, body: wrap_resources_in_bundle([FHIR::<%= resource_type %>.new, FHIR::Specimen.new]).to_json)
+      .to_return(status: 200, body: wrap_resources_in_bundle([FHIR::<%= resource_type %>.new, FHIR::Specimen.new, FHIR::PaymentNotice.new]).to_json)
   <% end %>
 
     exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
 
-    assert_equal 'All resources returned must be of the type <%= resource_type %> or OperationOutcome', exception.message
+    assert_equal 'All resources returned must be of the type <%= resource_type %> or OperationOutcome, but includes Specimen, PaymentNotice', exception.message
   end
 <% end %>
 

--- a/lib/modules/uscore_v3.1.1/bodyheight_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/bodyheight_sequence.rb
@@ -190,14 +190,17 @@ module Inferno
 
             @resources_found = true
             resources_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
-            assert(resources_returned.all? { |resource| ['Observation', 'OperationOutcome'].include? resource.resourceType },
-                   'All resources returned must be of the type Observation or OperationOutcome')
-            resources_returned.reject! { |resource| resource.resourceType == 'OperationOutcome' }
+            types_in_response = Set.new(resources_returned.map { |resource| resource&.resourceType })
+            resources_returned.select! { |resource| resource.resourceType == 'Observation' }
             @observation = resources_returned.first
             @observation_ary[patient] += resources_returned
 
             save_resource_references(versioned_resource_class('Observation'), @observation_ary[patient], Inferno::ValidationUtil::US_CORE_R4_URIS[:body_height])
             save_delayed_sequence_references(resources_returned, USCore311BodyheightSequenceDefinitions::DELAYED_REFERENCES)
+
+            invalid_types_in_response = types_in_response - Set.new(['Observation', 'OperationOutcome'])
+            assert(invalid_types_in_response.empty?,
+                   'All resources returned must be of the type Observation or OperationOutcome, but includes ' + invalid_types_in_response.to_a.join(', '))
             validate_reply_entries(resources_returned, search_params)
 
             next if search_query_variants_tested_once
@@ -215,14 +218,13 @@ module Inferno
             assert_response_ok(reply)
             assert_bundle_response(reply)
             search_with_type = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
-            assert(search_with_type.all? { |resource| ['Observation', 'OperationOutcome'].include? resource.resourceType },
-                   'All resources returned must be of the type Observation or OperationOutcome.')
-            search_with_type.reject! { |resource| resource.resourceType == 'OperationOutcome' }
+            search_with_type.select! { |resource| resource.resourceType == 'Observation' }
             assert search_with_type.length == resources_returned.length, 'Expected search by Patient/ID to have the same results as search by ID'
 
             search_query_variants_tested_once = true
           end
         end
+
         skip_if_not_found(resource_type: 'Observation', delayed: false)
       end
 

--- a/lib/modules/uscore_v3.1.1/bodytemp_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/bodytemp_sequence.rb
@@ -190,14 +190,17 @@ module Inferno
 
             @resources_found = true
             resources_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
-            assert(resources_returned.all? { |resource| ['Observation', 'OperationOutcome'].include? resource.resourceType },
-                   'All resources returned must be of the type Observation or OperationOutcome')
-            resources_returned.reject! { |resource| resource.resourceType == 'OperationOutcome' }
+            types_in_response = Set.new(resources_returned.map { |resource| resource&.resourceType })
+            resources_returned.select! { |resource| resource.resourceType == 'Observation' }
             @observation = resources_returned.first
             @observation_ary[patient] += resources_returned
 
             save_resource_references(versioned_resource_class('Observation'), @observation_ary[patient], Inferno::ValidationUtil::US_CORE_R4_URIS[:body_temperature])
             save_delayed_sequence_references(resources_returned, USCore311BodytempSequenceDefinitions::DELAYED_REFERENCES)
+
+            invalid_types_in_response = types_in_response - Set.new(['Observation', 'OperationOutcome'])
+            assert(invalid_types_in_response.empty?,
+                   'All resources returned must be of the type Observation or OperationOutcome, but includes ' + invalid_types_in_response.to_a.join(', '))
             validate_reply_entries(resources_returned, search_params)
 
             next if search_query_variants_tested_once
@@ -215,14 +218,13 @@ module Inferno
             assert_response_ok(reply)
             assert_bundle_response(reply)
             search_with_type = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
-            assert(search_with_type.all? { |resource| ['Observation', 'OperationOutcome'].include? resource.resourceType },
-                   'All resources returned must be of the type Observation or OperationOutcome.')
-            search_with_type.reject! { |resource| resource.resourceType == 'OperationOutcome' }
+            search_with_type.select! { |resource| resource.resourceType == 'Observation' }
             assert search_with_type.length == resources_returned.length, 'Expected search by Patient/ID to have the same results as search by ID'
 
             search_query_variants_tested_once = true
           end
         end
+
         skip_if_not_found(resource_type: 'Observation', delayed: false)
       end
 

--- a/lib/modules/uscore_v3.1.1/bodyweight_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/bodyweight_sequence.rb
@@ -190,14 +190,17 @@ module Inferno
 
             @resources_found = true
             resources_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
-            assert(resources_returned.all? { |resource| ['Observation', 'OperationOutcome'].include? resource.resourceType },
-                   'All resources returned must be of the type Observation or OperationOutcome')
-            resources_returned.reject! { |resource| resource.resourceType == 'OperationOutcome' }
+            types_in_response = Set.new(resources_returned.map { |resource| resource&.resourceType })
+            resources_returned.select! { |resource| resource.resourceType == 'Observation' }
             @observation = resources_returned.first
             @observation_ary[patient] += resources_returned
 
             save_resource_references(versioned_resource_class('Observation'), @observation_ary[patient], Inferno::ValidationUtil::US_CORE_R4_URIS[:body_weight])
             save_delayed_sequence_references(resources_returned, USCore311BodyweightSequenceDefinitions::DELAYED_REFERENCES)
+
+            invalid_types_in_response = types_in_response - Set.new(['Observation', 'OperationOutcome'])
+            assert(invalid_types_in_response.empty?,
+                   'All resources returned must be of the type Observation or OperationOutcome, but includes ' + invalid_types_in_response.to_a.join(', '))
             validate_reply_entries(resources_returned, search_params)
 
             next if search_query_variants_tested_once
@@ -215,14 +218,13 @@ module Inferno
             assert_response_ok(reply)
             assert_bundle_response(reply)
             search_with_type = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
-            assert(search_with_type.all? { |resource| ['Observation', 'OperationOutcome'].include? resource.resourceType },
-                   'All resources returned must be of the type Observation or OperationOutcome.')
-            search_with_type.reject! { |resource| resource.resourceType == 'OperationOutcome' }
+            search_with_type.select! { |resource| resource.resourceType == 'Observation' }
             assert search_with_type.length == resources_returned.length, 'Expected search by Patient/ID to have the same results as search by ID'
 
             search_query_variants_tested_once = true
           end
         end
+
         skip_if_not_found(resource_type: 'Observation', delayed: false)
       end
 

--- a/lib/modules/uscore_v3.1.1/bp_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/bp_sequence.rb
@@ -190,14 +190,17 @@ module Inferno
 
             @resources_found = true
             resources_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
-            assert(resources_returned.all? { |resource| ['Observation', 'OperationOutcome'].include? resource.resourceType },
-                   'All resources returned must be of the type Observation or OperationOutcome')
-            resources_returned.reject! { |resource| resource.resourceType == 'OperationOutcome' }
+            types_in_response = Set.new(resources_returned.map { |resource| resource&.resourceType })
+            resources_returned.select! { |resource| resource.resourceType == 'Observation' }
             @observation = resources_returned.first
             @observation_ary[patient] += resources_returned
 
             save_resource_references(versioned_resource_class('Observation'), @observation_ary[patient], Inferno::ValidationUtil::US_CORE_R4_URIS[:blood_pressure])
             save_delayed_sequence_references(resources_returned, USCore311BpSequenceDefinitions::DELAYED_REFERENCES)
+
+            invalid_types_in_response = types_in_response - Set.new(['Observation', 'OperationOutcome'])
+            assert(invalid_types_in_response.empty?,
+                   'All resources returned must be of the type Observation or OperationOutcome, but includes ' + invalid_types_in_response.to_a.join(', '))
             validate_reply_entries(resources_returned, search_params)
 
             next if search_query_variants_tested_once
@@ -215,14 +218,13 @@ module Inferno
             assert_response_ok(reply)
             assert_bundle_response(reply)
             search_with_type = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
-            assert(search_with_type.all? { |resource| ['Observation', 'OperationOutcome'].include? resource.resourceType },
-                   'All resources returned must be of the type Observation or OperationOutcome.')
-            search_with_type.reject! { |resource| resource.resourceType == 'OperationOutcome' }
+            search_with_type.select! { |resource| resource.resourceType == 'Observation' }
             assert search_with_type.length == resources_returned.length, 'Expected search by Patient/ID to have the same results as search by ID'
 
             search_query_variants_tested_once = true
           end
         end
+
         skip_if_not_found(resource_type: 'Observation', delayed: false)
       end
 

--- a/lib/modules/uscore_v3.1.1/head_occipital_frontal_circumference_percentile_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/head_occipital_frontal_circumference_percentile_sequence.rb
@@ -190,14 +190,17 @@ module Inferno
 
             @resources_found = true
             resources_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
-            assert(resources_returned.all? { |resource| ['Observation', 'OperationOutcome'].include? resource.resourceType },
-                   'All resources returned must be of the type Observation or OperationOutcome')
-            resources_returned.reject! { |resource| resource.resourceType == 'OperationOutcome' }
+            types_in_response = Set.new(resources_returned.map { |resource| resource&.resourceType })
+            resources_returned.select! { |resource| resource.resourceType == 'Observation' }
             @observation = resources_returned.first
             @observation_ary[patient] += resources_returned
 
             save_resource_references(versioned_resource_class('Observation'), @observation_ary[patient], Inferno::ValidationUtil::US_CORE_R4_URIS[:head_circumference_percentile])
             save_delayed_sequence_references(resources_returned, USCore311HeadOccipitalFrontalCircumferencePercentileSequenceDefinitions::DELAYED_REFERENCES)
+
+            invalid_types_in_response = types_in_response - Set.new(['Observation', 'OperationOutcome'])
+            assert(invalid_types_in_response.empty?,
+                   'All resources returned must be of the type Observation or OperationOutcome, but includes ' + invalid_types_in_response.to_a.join(', '))
             validate_reply_entries(resources_returned, search_params)
 
             next if search_query_variants_tested_once
@@ -215,14 +218,13 @@ module Inferno
             assert_response_ok(reply)
             assert_bundle_response(reply)
             search_with_type = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
-            assert(search_with_type.all? { |resource| ['Observation', 'OperationOutcome'].include? resource.resourceType },
-                   'All resources returned must be of the type Observation or OperationOutcome.')
-            search_with_type.reject! { |resource| resource.resourceType == 'OperationOutcome' }
+            search_with_type.select! { |resource| resource.resourceType == 'Observation' }
             assert search_with_type.length == resources_returned.length, 'Expected search by Patient/ID to have the same results as search by ID'
 
             search_query_variants_tested_once = true
           end
         end
+
         skip_if_not_found(resource_type: 'Observation', delayed: false)
       end
 

--- a/lib/modules/uscore_v3.1.1/heartrate_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/heartrate_sequence.rb
@@ -190,14 +190,17 @@ module Inferno
 
             @resources_found = true
             resources_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
-            assert(resources_returned.all? { |resource| ['Observation', 'OperationOutcome'].include? resource.resourceType },
-                   'All resources returned must be of the type Observation or OperationOutcome')
-            resources_returned.reject! { |resource| resource.resourceType == 'OperationOutcome' }
+            types_in_response = Set.new(resources_returned.map { |resource| resource&.resourceType })
+            resources_returned.select! { |resource| resource.resourceType == 'Observation' }
             @observation = resources_returned.first
             @observation_ary[patient] += resources_returned
 
             save_resource_references(versioned_resource_class('Observation'), @observation_ary[patient], Inferno::ValidationUtil::US_CORE_R4_URIS[:heart_rate])
             save_delayed_sequence_references(resources_returned, USCore311HeartrateSequenceDefinitions::DELAYED_REFERENCES)
+
+            invalid_types_in_response = types_in_response - Set.new(['Observation', 'OperationOutcome'])
+            assert(invalid_types_in_response.empty?,
+                   'All resources returned must be of the type Observation or OperationOutcome, but includes ' + invalid_types_in_response.to_a.join(', '))
             validate_reply_entries(resources_returned, search_params)
 
             next if search_query_variants_tested_once
@@ -215,14 +218,13 @@ module Inferno
             assert_response_ok(reply)
             assert_bundle_response(reply)
             search_with_type = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
-            assert(search_with_type.all? { |resource| ['Observation', 'OperationOutcome'].include? resource.resourceType },
-                   'All resources returned must be of the type Observation or OperationOutcome.')
-            search_with_type.reject! { |resource| resource.resourceType == 'OperationOutcome' }
+            search_with_type.select! { |resource| resource.resourceType == 'Observation' }
             assert search_with_type.length == resources_returned.length, 'Expected search by Patient/ID to have the same results as search by ID'
 
             search_query_variants_tested_once = true
           end
         end
+
         skip_if_not_found(resource_type: 'Observation', delayed: false)
       end
 

--- a/lib/modules/uscore_v3.1.1/pediatric_bmi_for_age_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/pediatric_bmi_for_age_sequence.rb
@@ -190,14 +190,17 @@ module Inferno
 
             @resources_found = true
             resources_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
-            assert(resources_returned.all? { |resource| ['Observation', 'OperationOutcome'].include? resource.resourceType },
-                   'All resources returned must be of the type Observation or OperationOutcome')
-            resources_returned.reject! { |resource| resource.resourceType == 'OperationOutcome' }
+            types_in_response = Set.new(resources_returned.map { |resource| resource&.resourceType })
+            resources_returned.select! { |resource| resource.resourceType == 'Observation' }
             @observation = resources_returned.first
             @observation_ary[patient] += resources_returned
 
             save_resource_references(versioned_resource_class('Observation'), @observation_ary[patient], Inferno::ValidationUtil::US_CORE_R4_URIS[:pediatric_bmi_age])
             save_delayed_sequence_references(resources_returned, USCore311PediatricBmiForAgeSequenceDefinitions::DELAYED_REFERENCES)
+
+            invalid_types_in_response = types_in_response - Set.new(['Observation', 'OperationOutcome'])
+            assert(invalid_types_in_response.empty?,
+                   'All resources returned must be of the type Observation or OperationOutcome, but includes ' + invalid_types_in_response.to_a.join(', '))
             validate_reply_entries(resources_returned, search_params)
 
             next if search_query_variants_tested_once
@@ -215,14 +218,13 @@ module Inferno
             assert_response_ok(reply)
             assert_bundle_response(reply)
             search_with_type = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
-            assert(search_with_type.all? { |resource| ['Observation', 'OperationOutcome'].include? resource.resourceType },
-                   'All resources returned must be of the type Observation or OperationOutcome.')
-            search_with_type.reject! { |resource| resource.resourceType == 'OperationOutcome' }
+            search_with_type.select! { |resource| resource.resourceType == 'Observation' }
             assert search_with_type.length == resources_returned.length, 'Expected search by Patient/ID to have the same results as search by ID'
 
             search_query_variants_tested_once = true
           end
         end
+
         skip_if_not_found(resource_type: 'Observation', delayed: false)
       end
 

--- a/lib/modules/uscore_v3.1.1/pediatric_weight_for_height_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/pediatric_weight_for_height_sequence.rb
@@ -190,14 +190,17 @@ module Inferno
 
             @resources_found = true
             resources_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
-            assert(resources_returned.all? { |resource| ['Observation', 'OperationOutcome'].include? resource.resourceType },
-                   'All resources returned must be of the type Observation or OperationOutcome')
-            resources_returned.reject! { |resource| resource.resourceType == 'OperationOutcome' }
+            types_in_response = Set.new(resources_returned.map { |resource| resource&.resourceType })
+            resources_returned.select! { |resource| resource.resourceType == 'Observation' }
             @observation = resources_returned.first
             @observation_ary[patient] += resources_returned
 
             save_resource_references(versioned_resource_class('Observation'), @observation_ary[patient], Inferno::ValidationUtil::US_CORE_R4_URIS[:pediatric_weight_height])
             save_delayed_sequence_references(resources_returned, USCore311PediatricWeightForHeightSequenceDefinitions::DELAYED_REFERENCES)
+
+            invalid_types_in_response = types_in_response - Set.new(['Observation', 'OperationOutcome'])
+            assert(invalid_types_in_response.empty?,
+                   'All resources returned must be of the type Observation or OperationOutcome, but includes ' + invalid_types_in_response.to_a.join(', '))
             validate_reply_entries(resources_returned, search_params)
 
             next if search_query_variants_tested_once
@@ -215,14 +218,13 @@ module Inferno
             assert_response_ok(reply)
             assert_bundle_response(reply)
             search_with_type = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
-            assert(search_with_type.all? { |resource| ['Observation', 'OperationOutcome'].include? resource.resourceType },
-                   'All resources returned must be of the type Observation or OperationOutcome.')
-            search_with_type.reject! { |resource| resource.resourceType == 'OperationOutcome' }
+            search_with_type.select! { |resource| resource.resourceType == 'Observation' }
             assert search_with_type.length == resources_returned.length, 'Expected search by Patient/ID to have the same results as search by ID'
 
             search_query_variants_tested_once = true
           end
         end
+
         skip_if_not_found(resource_type: 'Observation', delayed: false)
       end
 

--- a/lib/modules/uscore_v3.1.1/resprate_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/resprate_sequence.rb
@@ -190,14 +190,17 @@ module Inferno
 
             @resources_found = true
             resources_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
-            assert(resources_returned.all? { |resource| ['Observation', 'OperationOutcome'].include? resource.resourceType },
-                   'All resources returned must be of the type Observation or OperationOutcome')
-            resources_returned.reject! { |resource| resource.resourceType == 'OperationOutcome' }
+            types_in_response = Set.new(resources_returned.map { |resource| resource&.resourceType })
+            resources_returned.select! { |resource| resource.resourceType == 'Observation' }
             @observation = resources_returned.first
             @observation_ary[patient] += resources_returned
 
             save_resource_references(versioned_resource_class('Observation'), @observation_ary[patient], Inferno::ValidationUtil::US_CORE_R4_URIS[:resp_rate])
             save_delayed_sequence_references(resources_returned, USCore311ResprateSequenceDefinitions::DELAYED_REFERENCES)
+
+            invalid_types_in_response = types_in_response - Set.new(['Observation', 'OperationOutcome'])
+            assert(invalid_types_in_response.empty?,
+                   'All resources returned must be of the type Observation or OperationOutcome, but includes ' + invalid_types_in_response.to_a.join(', '))
             validate_reply_entries(resources_returned, search_params)
 
             next if search_query_variants_tested_once
@@ -215,14 +218,13 @@ module Inferno
             assert_response_ok(reply)
             assert_bundle_response(reply)
             search_with_type = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
-            assert(search_with_type.all? { |resource| ['Observation', 'OperationOutcome'].include? resource.resourceType },
-                   'All resources returned must be of the type Observation or OperationOutcome.')
-            search_with_type.reject! { |resource| resource.resourceType == 'OperationOutcome' }
+            search_with_type.select! { |resource| resource.resourceType == 'Observation' }
             assert search_with_type.length == resources_returned.length, 'Expected search by Patient/ID to have the same results as search by ID'
 
             search_query_variants_tested_once = true
           end
         end
+
         skip_if_not_found(resource_type: 'Observation', delayed: false)
       end
 

--- a/lib/modules/uscore_v3.1.1/test/bodyheight_test.rb
+++ b/lib/modules/uscore_v3.1.1/test/bodyheight_test.rb
@@ -121,12 +121,12 @@ describe Inferno::Sequence::USCore311BodyheightSequence do
         }
         stub_request(:get, "#{@base_url}/Observation")
           .with(query: query_params, headers: @auth_header)
-          .to_return(status: 200, body: wrap_resources_in_bundle([FHIR::Observation.new, FHIR::Specimen.new]).to_json)
+          .to_return(status: 200, body: wrap_resources_in_bundle([FHIR::Observation.new, FHIR::Specimen.new, FHIR::PaymentNotice.new]).to_json)
       end
 
       exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
 
-      assert_equal 'All resources returned must be of the type Observation or OperationOutcome', exception.message
+      assert_equal 'All resources returned must be of the type Observation or OperationOutcome, but includes Specimen, PaymentNotice', exception.message
     end
 
     it 'succeeds when a bundle containing a valid resource matching the search parameters is returned' do

--- a/lib/modules/uscore_v3.1.1/test/bodytemp_test.rb
+++ b/lib/modules/uscore_v3.1.1/test/bodytemp_test.rb
@@ -121,12 +121,12 @@ describe Inferno::Sequence::USCore311BodytempSequence do
         }
         stub_request(:get, "#{@base_url}/Observation")
           .with(query: query_params, headers: @auth_header)
-          .to_return(status: 200, body: wrap_resources_in_bundle([FHIR::Observation.new, FHIR::Specimen.new]).to_json)
+          .to_return(status: 200, body: wrap_resources_in_bundle([FHIR::Observation.new, FHIR::Specimen.new, FHIR::PaymentNotice.new]).to_json)
       end
 
       exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
 
-      assert_equal 'All resources returned must be of the type Observation or OperationOutcome', exception.message
+      assert_equal 'All resources returned must be of the type Observation or OperationOutcome, but includes Specimen, PaymentNotice', exception.message
     end
 
     it 'succeeds when a bundle containing a valid resource matching the search parameters is returned' do

--- a/lib/modules/uscore_v3.1.1/test/bodyweight_test.rb
+++ b/lib/modules/uscore_v3.1.1/test/bodyweight_test.rb
@@ -121,12 +121,12 @@ describe Inferno::Sequence::USCore311BodyweightSequence do
         }
         stub_request(:get, "#{@base_url}/Observation")
           .with(query: query_params, headers: @auth_header)
-          .to_return(status: 200, body: wrap_resources_in_bundle([FHIR::Observation.new, FHIR::Specimen.new]).to_json)
+          .to_return(status: 200, body: wrap_resources_in_bundle([FHIR::Observation.new, FHIR::Specimen.new, FHIR::PaymentNotice.new]).to_json)
       end
 
       exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
 
-      assert_equal 'All resources returned must be of the type Observation or OperationOutcome', exception.message
+      assert_equal 'All resources returned must be of the type Observation or OperationOutcome, but includes Specimen, PaymentNotice', exception.message
     end
 
     it 'succeeds when a bundle containing a valid resource matching the search parameters is returned' do

--- a/lib/modules/uscore_v3.1.1/test/bp_test.rb
+++ b/lib/modules/uscore_v3.1.1/test/bp_test.rb
@@ -121,12 +121,12 @@ describe Inferno::Sequence::USCore311BpSequence do
         }
         stub_request(:get, "#{@base_url}/Observation")
           .with(query: query_params, headers: @auth_header)
-          .to_return(status: 200, body: wrap_resources_in_bundle([FHIR::Observation.new, FHIR::Specimen.new]).to_json)
+          .to_return(status: 200, body: wrap_resources_in_bundle([FHIR::Observation.new, FHIR::Specimen.new, FHIR::PaymentNotice.new]).to_json)
       end
 
       exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
 
-      assert_equal 'All resources returned must be of the type Observation or OperationOutcome', exception.message
+      assert_equal 'All resources returned must be of the type Observation or OperationOutcome, but includes Specimen, PaymentNotice', exception.message
     end
 
     it 'succeeds when a bundle containing a valid resource matching the search parameters is returned' do

--- a/lib/modules/uscore_v3.1.1/test/head_occipital_frontal_circumference_percentile_test.rb
+++ b/lib/modules/uscore_v3.1.1/test/head_occipital_frontal_circumference_percentile_test.rb
@@ -121,12 +121,12 @@ describe Inferno::Sequence::USCore311HeadOccipitalFrontalCircumferencePercentile
         }
         stub_request(:get, "#{@base_url}/Observation")
           .with(query: query_params, headers: @auth_header)
-          .to_return(status: 200, body: wrap_resources_in_bundle([FHIR::Observation.new, FHIR::Specimen.new]).to_json)
+          .to_return(status: 200, body: wrap_resources_in_bundle([FHIR::Observation.new, FHIR::Specimen.new, FHIR::PaymentNotice.new]).to_json)
       end
 
       exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
 
-      assert_equal 'All resources returned must be of the type Observation or OperationOutcome', exception.message
+      assert_equal 'All resources returned must be of the type Observation or OperationOutcome, but includes Specimen, PaymentNotice', exception.message
     end
 
     it 'succeeds when a bundle containing a valid resource matching the search parameters is returned' do

--- a/lib/modules/uscore_v3.1.1/test/heartrate_test.rb
+++ b/lib/modules/uscore_v3.1.1/test/heartrate_test.rb
@@ -121,12 +121,12 @@ describe Inferno::Sequence::USCore311HeartrateSequence do
         }
         stub_request(:get, "#{@base_url}/Observation")
           .with(query: query_params, headers: @auth_header)
-          .to_return(status: 200, body: wrap_resources_in_bundle([FHIR::Observation.new, FHIR::Specimen.new]).to_json)
+          .to_return(status: 200, body: wrap_resources_in_bundle([FHIR::Observation.new, FHIR::Specimen.new, FHIR::PaymentNotice.new]).to_json)
       end
 
       exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
 
-      assert_equal 'All resources returned must be of the type Observation or OperationOutcome', exception.message
+      assert_equal 'All resources returned must be of the type Observation or OperationOutcome, but includes Specimen, PaymentNotice', exception.message
     end
 
     it 'succeeds when a bundle containing a valid resource matching the search parameters is returned' do

--- a/lib/modules/uscore_v3.1.1/test/pediatric_bmi_for_age_test.rb
+++ b/lib/modules/uscore_v3.1.1/test/pediatric_bmi_for_age_test.rb
@@ -121,12 +121,12 @@ describe Inferno::Sequence::USCore311PediatricBmiForAgeSequence do
         }
         stub_request(:get, "#{@base_url}/Observation")
           .with(query: query_params, headers: @auth_header)
-          .to_return(status: 200, body: wrap_resources_in_bundle([FHIR::Observation.new, FHIR::Specimen.new]).to_json)
+          .to_return(status: 200, body: wrap_resources_in_bundle([FHIR::Observation.new, FHIR::Specimen.new, FHIR::PaymentNotice.new]).to_json)
       end
 
       exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
 
-      assert_equal 'All resources returned must be of the type Observation or OperationOutcome', exception.message
+      assert_equal 'All resources returned must be of the type Observation or OperationOutcome, but includes Specimen, PaymentNotice', exception.message
     end
 
     it 'succeeds when a bundle containing a valid resource matching the search parameters is returned' do

--- a/lib/modules/uscore_v3.1.1/test/pediatric_weight_for_height_test.rb
+++ b/lib/modules/uscore_v3.1.1/test/pediatric_weight_for_height_test.rb
@@ -121,12 +121,12 @@ describe Inferno::Sequence::USCore311PediatricWeightForHeightSequence do
         }
         stub_request(:get, "#{@base_url}/Observation")
           .with(query: query_params, headers: @auth_header)
-          .to_return(status: 200, body: wrap_resources_in_bundle([FHIR::Observation.new, FHIR::Specimen.new]).to_json)
+          .to_return(status: 200, body: wrap_resources_in_bundle([FHIR::Observation.new, FHIR::Specimen.new, FHIR::PaymentNotice.new]).to_json)
       end
 
       exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
 
-      assert_equal 'All resources returned must be of the type Observation or OperationOutcome', exception.message
+      assert_equal 'All resources returned must be of the type Observation or OperationOutcome, but includes Specimen, PaymentNotice', exception.message
     end
 
     it 'succeeds when a bundle containing a valid resource matching the search parameters is returned' do

--- a/lib/modules/uscore_v3.1.1/test/resprate_test.rb
+++ b/lib/modules/uscore_v3.1.1/test/resprate_test.rb
@@ -121,12 +121,12 @@ describe Inferno::Sequence::USCore311ResprateSequence do
         }
         stub_request(:get, "#{@base_url}/Observation")
           .with(query: query_params, headers: @auth_header)
-          .to_return(status: 200, body: wrap_resources_in_bundle([FHIR::Observation.new, FHIR::Specimen.new]).to_json)
+          .to_return(status: 200, body: wrap_resources_in_bundle([FHIR::Observation.new, FHIR::Specimen.new, FHIR::PaymentNotice.new]).to_json)
       end
 
       exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
 
-      assert_equal 'All resources returned must be of the type Observation or OperationOutcome', exception.message
+      assert_equal 'All resources returned must be of the type Observation or OperationOutcome, but includes Specimen, PaymentNotice', exception.message
     end
 
     it 'succeeds when a bundle containing a valid resource matching the search parameters is returned' do

--- a/lib/modules/uscore_v3.1.1/test/us_core_allergyintolerance_test.rb
+++ b/lib/modules/uscore_v3.1.1/test/us_core_allergyintolerance_test.rb
@@ -86,11 +86,11 @@ describe Inferno::Sequence::USCore311AllergyintoleranceSequence do
     it 'fails if the bundle contains a resource which is not the searched for resource nor an OperationOutcome' do
       stub_request(:get, "#{@base_url}/AllergyIntolerance")
         .with(query: @query, headers: @auth_header)
-        .to_return(status: 200, body: wrap_resources_in_bundle([FHIR::AllergyIntolerance.new, FHIR::Specimen.new]).to_json)
+        .to_return(status: 200, body: wrap_resources_in_bundle([FHIR::AllergyIntolerance.new, FHIR::Specimen.new, FHIR::PaymentNotice.new]).to_json)
 
       exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
 
-      assert_equal 'All resources returned must be of the type AllergyIntolerance or OperationOutcome', exception.message
+      assert_equal 'All resources returned must be of the type AllergyIntolerance or OperationOutcome, but includes Specimen, PaymentNotice', exception.message
     end
 
     it 'succeeds when a bundle containing a valid resource matching the search parameters is returned' do

--- a/lib/modules/uscore_v3.1.1/test/us_core_careplan_test.rb
+++ b/lib/modules/uscore_v3.1.1/test/us_core_careplan_test.rb
@@ -121,12 +121,12 @@ describe Inferno::Sequence::USCore311CareplanSequence do
         }
         stub_request(:get, "#{@base_url}/CarePlan")
           .with(query: query_params, headers: @auth_header)
-          .to_return(status: 200, body: wrap_resources_in_bundle([FHIR::CarePlan.new, FHIR::Specimen.new]).to_json)
+          .to_return(status: 200, body: wrap_resources_in_bundle([FHIR::CarePlan.new, FHIR::Specimen.new, FHIR::PaymentNotice.new]).to_json)
       end
 
       exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
 
-      assert_equal 'All resources returned must be of the type CarePlan or OperationOutcome', exception.message
+      assert_equal 'All resources returned must be of the type CarePlan or OperationOutcome, but includes Specimen, PaymentNotice', exception.message
     end
 
     it 'succeeds when a bundle containing a valid resource matching the search parameters is returned' do

--- a/lib/modules/uscore_v3.1.1/test/us_core_careteam_test.rb
+++ b/lib/modules/uscore_v3.1.1/test/us_core_careteam_test.rb
@@ -116,12 +116,12 @@ describe Inferno::Sequence::USCore311CareteamSequence do
         }
         stub_request(:get, "#{@base_url}/CareTeam")
           .with(query: query_params, headers: @auth_header)
-          .to_return(status: 200, body: wrap_resources_in_bundle([FHIR::CareTeam.new, FHIR::Specimen.new]).to_json)
+          .to_return(status: 200, body: wrap_resources_in_bundle([FHIR::CareTeam.new, FHIR::Specimen.new, FHIR::PaymentNotice.new]).to_json)
       end
 
       exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
 
-      assert_equal 'All resources returned must be of the type CareTeam or OperationOutcome', exception.message
+      assert_equal 'All resources returned must be of the type CareTeam or OperationOutcome, but includes Specimen, PaymentNotice', exception.message
     end
 
     it 'succeeds when a bundle containing a valid resource matching the search parameters is returned' do

--- a/lib/modules/uscore_v3.1.1/test/us_core_condition_test.rb
+++ b/lib/modules/uscore_v3.1.1/test/us_core_condition_test.rb
@@ -86,11 +86,11 @@ describe Inferno::Sequence::USCore311ConditionSequence do
     it 'fails if the bundle contains a resource which is not the searched for resource nor an OperationOutcome' do
       stub_request(:get, "#{@base_url}/Condition")
         .with(query: @query, headers: @auth_header)
-        .to_return(status: 200, body: wrap_resources_in_bundle([FHIR::Condition.new, FHIR::Specimen.new]).to_json)
+        .to_return(status: 200, body: wrap_resources_in_bundle([FHIR::Condition.new, FHIR::Specimen.new, FHIR::PaymentNotice.new]).to_json)
 
       exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
 
-      assert_equal 'All resources returned must be of the type Condition or OperationOutcome', exception.message
+      assert_equal 'All resources returned must be of the type Condition or OperationOutcome, but includes Specimen, PaymentNotice', exception.message
     end
 
     it 'succeeds when a bundle containing a valid resource matching the search parameters is returned' do

--- a/lib/modules/uscore_v3.1.1/test/us_core_diagnosticreport_lab_test.rb
+++ b/lib/modules/uscore_v3.1.1/test/us_core_diagnosticreport_lab_test.rb
@@ -121,12 +121,12 @@ describe Inferno::Sequence::USCore311DiagnosticreportLabSequence do
         }
         stub_request(:get, "#{@base_url}/DiagnosticReport")
           .with(query: query_params, headers: @auth_header)
-          .to_return(status: 200, body: wrap_resources_in_bundle([FHIR::DiagnosticReport.new, FHIR::Specimen.new]).to_json)
+          .to_return(status: 200, body: wrap_resources_in_bundle([FHIR::DiagnosticReport.new, FHIR::Specimen.new, FHIR::PaymentNotice.new]).to_json)
       end
 
       exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
 
-      assert_equal 'All resources returned must be of the type DiagnosticReport or OperationOutcome', exception.message
+      assert_equal 'All resources returned must be of the type DiagnosticReport or OperationOutcome, but includes Specimen, PaymentNotice', exception.message
     end
 
     it 'succeeds when a bundle containing a valid resource matching the search parameters is returned' do

--- a/lib/modules/uscore_v3.1.1/test/us_core_diagnosticreport_note_test.rb
+++ b/lib/modules/uscore_v3.1.1/test/us_core_diagnosticreport_note_test.rb
@@ -121,12 +121,12 @@ describe Inferno::Sequence::USCore311DiagnosticreportNoteSequence do
         }
         stub_request(:get, "#{@base_url}/DiagnosticReport")
           .with(query: query_params, headers: @auth_header)
-          .to_return(status: 200, body: wrap_resources_in_bundle([FHIR::DiagnosticReport.new, FHIR::Specimen.new]).to_json)
+          .to_return(status: 200, body: wrap_resources_in_bundle([FHIR::DiagnosticReport.new, FHIR::Specimen.new, FHIR::PaymentNotice.new]).to_json)
       end
 
       exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
 
-      assert_equal 'All resources returned must be of the type DiagnosticReport or OperationOutcome', exception.message
+      assert_equal 'All resources returned must be of the type DiagnosticReport or OperationOutcome, but includes Specimen, PaymentNotice', exception.message
     end
 
     it 'succeeds when a bundle containing a valid resource matching the search parameters is returned' do

--- a/lib/modules/uscore_v3.1.1/test/us_core_documentreference_test.rb
+++ b/lib/modules/uscore_v3.1.1/test/us_core_documentreference_test.rb
@@ -86,11 +86,11 @@ describe Inferno::Sequence::USCore311DocumentreferenceSequence do
     it 'fails if the bundle contains a resource which is not the searched for resource nor an OperationOutcome' do
       stub_request(:get, "#{@base_url}/DocumentReference")
         .with(query: @query, headers: @auth_header)
-        .to_return(status: 200, body: wrap_resources_in_bundle([FHIR::DocumentReference.new, FHIR::Specimen.new]).to_json)
+        .to_return(status: 200, body: wrap_resources_in_bundle([FHIR::DocumentReference.new, FHIR::Specimen.new, FHIR::PaymentNotice.new]).to_json)
 
       exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
 
-      assert_equal 'All resources returned must be of the type DocumentReference or OperationOutcome', exception.message
+      assert_equal 'All resources returned must be of the type DocumentReference or OperationOutcome, but includes Specimen, PaymentNotice', exception.message
     end
 
     it 'succeeds when a bundle containing a valid resource matching the search parameters is returned' do

--- a/lib/modules/uscore_v3.1.1/test/us_core_goal_test.rb
+++ b/lib/modules/uscore_v3.1.1/test/us_core_goal_test.rb
@@ -86,11 +86,11 @@ describe Inferno::Sequence::USCore311GoalSequence do
     it 'fails if the bundle contains a resource which is not the searched for resource nor an OperationOutcome' do
       stub_request(:get, "#{@base_url}/Goal")
         .with(query: @query, headers: @auth_header)
-        .to_return(status: 200, body: wrap_resources_in_bundle([FHIR::Goal.new, FHIR::Specimen.new]).to_json)
+        .to_return(status: 200, body: wrap_resources_in_bundle([FHIR::Goal.new, FHIR::Specimen.new, FHIR::PaymentNotice.new]).to_json)
 
       exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
 
-      assert_equal 'All resources returned must be of the type Goal or OperationOutcome', exception.message
+      assert_equal 'All resources returned must be of the type Goal or OperationOutcome, but includes Specimen, PaymentNotice', exception.message
     end
 
     it 'succeeds when a bundle containing a valid resource matching the search parameters is returned' do

--- a/lib/modules/uscore_v3.1.1/test/us_core_immunization_test.rb
+++ b/lib/modules/uscore_v3.1.1/test/us_core_immunization_test.rb
@@ -86,11 +86,11 @@ describe Inferno::Sequence::USCore311ImmunizationSequence do
     it 'fails if the bundle contains a resource which is not the searched for resource nor an OperationOutcome' do
       stub_request(:get, "#{@base_url}/Immunization")
         .with(query: @query, headers: @auth_header)
-        .to_return(status: 200, body: wrap_resources_in_bundle([FHIR::Immunization.new, FHIR::Specimen.new]).to_json)
+        .to_return(status: 200, body: wrap_resources_in_bundle([FHIR::Immunization.new, FHIR::Specimen.new, FHIR::PaymentNotice.new]).to_json)
 
       exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
 
-      assert_equal 'All resources returned must be of the type Immunization or OperationOutcome', exception.message
+      assert_equal 'All resources returned must be of the type Immunization or OperationOutcome, but includes Specimen, PaymentNotice', exception.message
     end
 
     it 'succeeds when a bundle containing a valid resource matching the search parameters is returned' do

--- a/lib/modules/uscore_v3.1.1/test/us_core_implantable_device_test.rb
+++ b/lib/modules/uscore_v3.1.1/test/us_core_implantable_device_test.rb
@@ -86,11 +86,11 @@ describe Inferno::Sequence::USCore311ImplantableDeviceSequence do
     it 'fails if the bundle contains a resource which is not the searched for resource nor an OperationOutcome' do
       stub_request(:get, "#{@base_url}/Device")
         .with(query: @query, headers: @auth_header)
-        .to_return(status: 200, body: wrap_resources_in_bundle([FHIR::Device.new, FHIR::Specimen.new]).to_json)
+        .to_return(status: 200, body: wrap_resources_in_bundle([FHIR::Device.new, FHIR::Specimen.new, FHIR::PaymentNotice.new]).to_json)
 
       exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
 
-      assert_equal 'All resources returned must be of the type Device or OperationOutcome', exception.message
+      assert_equal 'All resources returned must be of the type Device or OperationOutcome, but includes Specimen, PaymentNotice', exception.message
     end
 
     it 'succeeds when a bundle containing a valid resource matching the search parameters is returned' do

--- a/lib/modules/uscore_v3.1.1/test/us_core_medicationrequest_test.rb
+++ b/lib/modules/uscore_v3.1.1/test/us_core_medicationrequest_test.rb
@@ -116,12 +116,12 @@ describe Inferno::Sequence::USCore311MedicationrequestSequence do
         }
         stub_request(:get, "#{@base_url}/MedicationRequest")
           .with(query: query_params, headers: @auth_header)
-          .to_return(status: 200, body: wrap_resources_in_bundle([FHIR::MedicationRequest.new, FHIR::Specimen.new]).to_json)
+          .to_return(status: 200, body: wrap_resources_in_bundle([FHIR::MedicationRequest.new, FHIR::Specimen.new, FHIR::PaymentNotice.new]).to_json)
       end
 
       exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
 
-      assert_equal 'All resources returned must be of the type MedicationRequest or OperationOutcome', exception.message
+      assert_equal 'All resources returned must be of the type MedicationRequest or OperationOutcome, but includes Specimen, PaymentNotice', exception.message
     end
 
     it 'succeeds when a bundle containing a valid resource matching the search parameters is returned' do

--- a/lib/modules/uscore_v3.1.1/test/us_core_observation_lab_test.rb
+++ b/lib/modules/uscore_v3.1.1/test/us_core_observation_lab_test.rb
@@ -121,12 +121,12 @@ describe Inferno::Sequence::USCore311ObservationLabSequence do
         }
         stub_request(:get, "#{@base_url}/Observation")
           .with(query: query_params, headers: @auth_header)
-          .to_return(status: 200, body: wrap_resources_in_bundle([FHIR::Observation.new, FHIR::Specimen.new]).to_json)
+          .to_return(status: 200, body: wrap_resources_in_bundle([FHIR::Observation.new, FHIR::Specimen.new, FHIR::PaymentNotice.new]).to_json)
       end
 
       exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
 
-      assert_equal 'All resources returned must be of the type Observation or OperationOutcome', exception.message
+      assert_equal 'All resources returned must be of the type Observation or OperationOutcome, but includes Specimen, PaymentNotice', exception.message
     end
 
     it 'succeeds when a bundle containing a valid resource matching the search parameters is returned' do

--- a/lib/modules/uscore_v3.1.1/test/us_core_patient_test.rb
+++ b/lib/modules/uscore_v3.1.1/test/us_core_patient_test.rb
@@ -86,11 +86,11 @@ describe Inferno::Sequence::USCore311PatientSequence do
     it 'fails if the bundle contains a resource which is not the searched for resource nor an OperationOutcome' do
       stub_request(:get, "#{@base_url}/Patient")
         .with(query: @query, headers: @auth_header)
-        .to_return(status: 200, body: wrap_resources_in_bundle([FHIR::Patient.new, FHIR::Specimen.new]).to_json)
+        .to_return(status: 200, body: wrap_resources_in_bundle([FHIR::Patient.new, FHIR::Specimen.new, FHIR::PaymentNotice.new]).to_json)
 
       exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
 
-      assert_equal 'All resources returned must be of the type Patient or OperationOutcome', exception.message
+      assert_equal 'All resources returned must be of the type Patient or OperationOutcome, but includes Specimen, PaymentNotice', exception.message
     end
 
     it 'succeeds when a bundle containing a valid resource matching the search parameters is returned' do

--- a/lib/modules/uscore_v3.1.1/test/us_core_procedure_test.rb
+++ b/lib/modules/uscore_v3.1.1/test/us_core_procedure_test.rb
@@ -86,11 +86,11 @@ describe Inferno::Sequence::USCore311ProcedureSequence do
     it 'fails if the bundle contains a resource which is not the searched for resource nor an OperationOutcome' do
       stub_request(:get, "#{@base_url}/Procedure")
         .with(query: @query, headers: @auth_header)
-        .to_return(status: 200, body: wrap_resources_in_bundle([FHIR::Procedure.new, FHIR::Specimen.new]).to_json)
+        .to_return(status: 200, body: wrap_resources_in_bundle([FHIR::Procedure.new, FHIR::Specimen.new, FHIR::PaymentNotice.new]).to_json)
 
       exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
 
-      assert_equal 'All resources returned must be of the type Procedure or OperationOutcome', exception.message
+      assert_equal 'All resources returned must be of the type Procedure or OperationOutcome, but includes Specimen, PaymentNotice', exception.message
     end
 
     it 'succeeds when a bundle containing a valid resource matching the search parameters is returned' do

--- a/lib/modules/uscore_v3.1.1/test/us_core_pulse_oximetry_test.rb
+++ b/lib/modules/uscore_v3.1.1/test/us_core_pulse_oximetry_test.rb
@@ -121,12 +121,12 @@ describe Inferno::Sequence::USCore311PulseOximetrySequence do
         }
         stub_request(:get, "#{@base_url}/Observation")
           .with(query: query_params, headers: @auth_header)
-          .to_return(status: 200, body: wrap_resources_in_bundle([FHIR::Observation.new, FHIR::Specimen.new]).to_json)
+          .to_return(status: 200, body: wrap_resources_in_bundle([FHIR::Observation.new, FHIR::Specimen.new, FHIR::PaymentNotice.new]).to_json)
       end
 
       exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
 
-      assert_equal 'All resources returned must be of the type Observation or OperationOutcome', exception.message
+      assert_equal 'All resources returned must be of the type Observation or OperationOutcome, but includes Specimen, PaymentNotice', exception.message
     end
 
     it 'succeeds when a bundle containing a valid resource matching the search parameters is returned' do

--- a/lib/modules/uscore_v3.1.1/test/us_core_smokingstatus_test.rb
+++ b/lib/modules/uscore_v3.1.1/test/us_core_smokingstatus_test.rb
@@ -121,12 +121,12 @@ describe Inferno::Sequence::USCore311SmokingstatusSequence do
         }
         stub_request(:get, "#{@base_url}/Observation")
           .with(query: query_params, headers: @auth_header)
-          .to_return(status: 200, body: wrap_resources_in_bundle([FHIR::Observation.new, FHIR::Specimen.new]).to_json)
+          .to_return(status: 200, body: wrap_resources_in_bundle([FHIR::Observation.new, FHIR::Specimen.new, FHIR::PaymentNotice.new]).to_json)
       end
 
       exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
 
-      assert_equal 'All resources returned must be of the type Observation or OperationOutcome', exception.message
+      assert_equal 'All resources returned must be of the type Observation or OperationOutcome, but includes Specimen, PaymentNotice', exception.message
     end
 
     it 'succeeds when a bundle containing a valid resource matching the search parameters is returned' do

--- a/lib/modules/uscore_v3.1.1/us_core_careplan_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_careplan_sequence.rb
@@ -175,14 +175,17 @@ module Inferno
 
             @resources_found = true
             resources_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
-            assert(resources_returned.all? { |resource| ['CarePlan', 'OperationOutcome'].include? resource.resourceType },
-                   'All resources returned must be of the type CarePlan or OperationOutcome')
-            resources_returned.reject! { |resource| resource.resourceType == 'OperationOutcome' }
+            types_in_response = Set.new(resources_returned.map { |resource| resource&.resourceType })
+            resources_returned.select! { |resource| resource.resourceType == 'CarePlan' }
             @care_plan = resources_returned.first
             @care_plan_ary[patient] += resources_returned
 
             save_resource_references(versioned_resource_class('CarePlan'), @care_plan_ary[patient])
             save_delayed_sequence_references(resources_returned, USCore311CareplanSequenceDefinitions::DELAYED_REFERENCES)
+
+            invalid_types_in_response = types_in_response - Set.new(['CarePlan', 'OperationOutcome'])
+            assert(invalid_types_in_response.empty?,
+                   'All resources returned must be of the type CarePlan or OperationOutcome, but includes ' + invalid_types_in_response.to_a.join(', '))
             validate_reply_entries(resources_returned, search_params)
 
             next if search_query_variants_tested_once
@@ -200,14 +203,13 @@ module Inferno
             assert_response_ok(reply)
             assert_bundle_response(reply)
             search_with_type = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
-            assert(search_with_type.all? { |resource| ['CarePlan', 'OperationOutcome'].include? resource.resourceType },
-                   'All resources returned must be of the type CarePlan or OperationOutcome.')
-            search_with_type.reject! { |resource| resource.resourceType == 'OperationOutcome' }
+            search_with_type.select! { |resource| resource.resourceType == 'CarePlan' }
             assert search_with_type.length == resources_returned.length, 'Expected search by Patient/ID to have the same results as search by ID'
 
             search_query_variants_tested_once = true
           end
         end
+
         skip_if_not_found(resource_type: 'CarePlan', delayed: false)
       end
 

--- a/lib/modules/uscore_v3.1.1/us_core_condition_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_condition_sequence.rb
@@ -193,11 +193,10 @@ module Inferno
 
           next unless any_resources
 
-          resource_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
-          assert(resource_returned.all? { |resource| ['Condition', 'OperationOutcome'].include? resource.resourceType },
-                 'All resources returned must be of the type Condition or OperationOutcome')
-          resource_returned.reject! { |resource| resource.resourceType == 'OperationOutcome' }
-          @condition_ary[patient] = resource_returned
+          resources_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
+          types_in_response = Set.new(resources_returned.map { |resource| resource&.resourceType })
+          resources_returned.select! { |resource| resource.resourceType == 'Condition' }
+          @condition_ary[patient] = resources_returned
 
           @condition = @condition_ary[patient]
             .find { |resource| resource.resourceType == 'Condition' }
@@ -205,6 +204,11 @@ module Inferno
 
           save_resource_references(versioned_resource_class('Condition'), @condition_ary[patient])
           save_delayed_sequence_references(@condition_ary[patient], USCore311ConditionSequenceDefinitions::DELAYED_REFERENCES)
+
+          invalid_types_in_response = types_in_response - Set.new(['Condition', 'OperationOutcome'])
+          assert(invalid_types_in_response.empty?,
+                 'All resources returned must be of the type Condition or OperationOutcome, but includes ' + invalid_types_in_response.to_a.join(', '))
+
           validate_reply_entries(@condition_ary[patient], search_params)
 
           search_params = search_params.merge('patient': "Patient/#{patient}")
@@ -212,9 +216,7 @@ module Inferno
           assert_response_ok(reply)
           assert_bundle_response(reply)
           search_with_type = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
-          assert(search_with_type.all? { |resource| ['Condition', 'OperationOutcome'].include? resource.resourceType },
-                 'All resources returned must be of the type Condition or OperationOutcome')
-          search_with_type.reject! { |resource| resource.resourceType == 'OperationOutcome' }
+          search_with_type.select! { |resource| resource.resourceType == 'Condition' }
           assert search_with_type.length == @condition_ary[patient].length, 'Expected search by Patient/ID to have the same results as search by ID'
         end
 

--- a/lib/modules/uscore_v3.1.1/us_core_diagnosticreport_note_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_diagnosticreport_note_sequence.rb
@@ -193,14 +193,17 @@ module Inferno
 
             @resources_found = true
             resources_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
-            assert(resources_returned.all? { |resource| ['DiagnosticReport', 'OperationOutcome'].include? resource.resourceType },
-                   'All resources returned must be of the type DiagnosticReport or OperationOutcome')
-            resources_returned.reject! { |resource| resource.resourceType == 'OperationOutcome' }
+            types_in_response = Set.new(resources_returned.map { |resource| resource&.resourceType })
+            resources_returned.select! { |resource| resource.resourceType == 'DiagnosticReport' }
             @diagnostic_report = resources_returned.first
             @diagnostic_report_ary[patient] += resources_returned
 
             save_resource_references(versioned_resource_class('DiagnosticReport'), @diagnostic_report_ary[patient], Inferno::ValidationUtil::US_CORE_R4_URIS[:diagnostic_report_note])
             save_delayed_sequence_references(resources_returned, USCore311DiagnosticreportNoteSequenceDefinitions::DELAYED_REFERENCES)
+
+            invalid_types_in_response = types_in_response - Set.new(['DiagnosticReport', 'OperationOutcome'])
+            assert(invalid_types_in_response.empty?,
+                   'All resources returned must be of the type DiagnosticReport or OperationOutcome, but includes ' + invalid_types_in_response.to_a.join(', '))
             validate_reply_entries(resources_returned, search_params)
 
             next if search_query_variants_tested_once
@@ -218,14 +221,13 @@ module Inferno
             assert_response_ok(reply)
             assert_bundle_response(reply)
             search_with_type = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
-            assert(search_with_type.all? { |resource| ['DiagnosticReport', 'OperationOutcome'].include? resource.resourceType },
-                   'All resources returned must be of the type DiagnosticReport or OperationOutcome.')
-            search_with_type.reject! { |resource| resource.resourceType == 'OperationOutcome' }
+            search_with_type.select! { |resource| resource.resourceType == 'DiagnosticReport' }
             assert search_with_type.length == resources_returned.length, 'Expected search by Patient/ID to have the same results as search by ID'
 
             search_query_variants_tested_once = true
           end
         end
+
         skip_if_not_found(resource_type: 'DiagnosticReport', delayed: false)
       end
 

--- a/lib/modules/uscore_v3.1.1/us_core_goal_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_goal_sequence.rb
@@ -160,11 +160,10 @@ module Inferno
 
           next unless any_resources
 
-          resource_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
-          assert(resource_returned.all? { |resource| ['Goal', 'OperationOutcome'].include? resource.resourceType },
-                 'All resources returned must be of the type Goal or OperationOutcome')
-          resource_returned.reject! { |resource| resource.resourceType == 'OperationOutcome' }
-          @goal_ary[patient] = resource_returned
+          resources_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
+          types_in_response = Set.new(resources_returned.map { |resource| resource&.resourceType })
+          resources_returned.select! { |resource| resource.resourceType == 'Goal' }
+          @goal_ary[patient] = resources_returned
 
           @goal = @goal_ary[patient]
             .find { |resource| resource.resourceType == 'Goal' }
@@ -172,6 +171,11 @@ module Inferno
 
           save_resource_references(versioned_resource_class('Goal'), @goal_ary[patient])
           save_delayed_sequence_references(@goal_ary[patient], USCore311GoalSequenceDefinitions::DELAYED_REFERENCES)
+
+          invalid_types_in_response = types_in_response - Set.new(['Goal', 'OperationOutcome'])
+          assert(invalid_types_in_response.empty?,
+                 'All resources returned must be of the type Goal or OperationOutcome, but includes ' + invalid_types_in_response.to_a.join(', '))
+
           validate_reply_entries(@goal_ary[patient], search_params)
 
           search_params = search_params.merge('patient': "Patient/#{patient}")
@@ -179,9 +183,7 @@ module Inferno
           assert_response_ok(reply)
           assert_bundle_response(reply)
           search_with_type = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
-          assert(search_with_type.all? { |resource| ['Goal', 'OperationOutcome'].include? resource.resourceType },
-                 'All resources returned must be of the type Goal or OperationOutcome')
-          search_with_type.reject! { |resource| resource.resourceType == 'OperationOutcome' }
+          search_with_type.select! { |resource| resource.resourceType == 'Goal' }
           assert search_with_type.length == @goal_ary[patient].length, 'Expected search by Patient/ID to have the same results as search by ID'
         end
 

--- a/lib/modules/uscore_v3.1.1/us_core_immunization_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_immunization_sequence.rb
@@ -160,11 +160,10 @@ module Inferno
 
           next unless any_resources
 
-          resource_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
-          assert(resource_returned.all? { |resource| ['Immunization', 'OperationOutcome'].include? resource.resourceType },
-                 'All resources returned must be of the type Immunization or OperationOutcome')
-          resource_returned.reject! { |resource| resource.resourceType == 'OperationOutcome' }
-          @immunization_ary[patient] = resource_returned
+          resources_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
+          types_in_response = Set.new(resources_returned.map { |resource| resource&.resourceType })
+          resources_returned.select! { |resource| resource.resourceType == 'Immunization' }
+          @immunization_ary[patient] = resources_returned
 
           @immunization = @immunization_ary[patient]
             .find { |resource| resource.resourceType == 'Immunization' }
@@ -172,6 +171,11 @@ module Inferno
 
           save_resource_references(versioned_resource_class('Immunization'), @immunization_ary[patient])
           save_delayed_sequence_references(@immunization_ary[patient], USCore311ImmunizationSequenceDefinitions::DELAYED_REFERENCES)
+
+          invalid_types_in_response = types_in_response - Set.new(['Immunization', 'OperationOutcome'])
+          assert(invalid_types_in_response.empty?,
+                 'All resources returned must be of the type Immunization or OperationOutcome, but includes ' + invalid_types_in_response.to_a.join(', '))
+
           validate_reply_entries(@immunization_ary[patient], search_params)
 
           search_params = search_params.merge('patient': "Patient/#{patient}")
@@ -179,9 +183,7 @@ module Inferno
           assert_response_ok(reply)
           assert_bundle_response(reply)
           search_with_type = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
-          assert(search_with_type.all? { |resource| ['Immunization', 'OperationOutcome'].include? resource.resourceType },
-                 'All resources returned must be of the type Immunization or OperationOutcome')
-          search_with_type.reject! { |resource| resource.resourceType == 'OperationOutcome' }
+          search_with_type.select! { |resource| resource.resourceType == 'Immunization' }
           assert search_with_type.length == @immunization_ary[patient].length, 'Expected search by Patient/ID to have the same results as search by ID'
         end
 

--- a/lib/modules/uscore_v3.1.1/us_core_medicationrequest_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_medicationrequest_sequence.rb
@@ -210,14 +210,17 @@ module Inferno
 
             @resources_found = true
             resources_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
-            assert(resources_returned.all? { |resource| ['MedicationRequest', 'OperationOutcome'].include? resource.resourceType },
-                   'All resources returned must be of the type MedicationRequest or OperationOutcome')
-            resources_returned.reject! { |resource| resource.resourceType == 'OperationOutcome' }
+            types_in_response = Set.new(resources_returned.map { |resource| resource&.resourceType })
+            resources_returned.select! { |resource| resource.resourceType == 'MedicationRequest' }
             @medication_request = resources_returned.first
             @medication_request_ary[patient] += resources_returned
 
             save_resource_references(versioned_resource_class('MedicationRequest'), @medication_request_ary[patient])
             save_delayed_sequence_references(resources_returned, USCore311MedicationrequestSequenceDefinitions::DELAYED_REFERENCES)
+
+            invalid_types_in_response = types_in_response - Set.new(['MedicationRequest', 'OperationOutcome'])
+            assert(invalid_types_in_response.empty?,
+                   'All resources returned must be of the type MedicationRequest or OperationOutcome, but includes ' + invalid_types_in_response.to_a.join(', '))
             validate_reply_entries(resources_returned, search_params)
 
             next if search_query_variants_tested_once
@@ -230,9 +233,7 @@ module Inferno
             assert_response_ok(reply)
             assert_bundle_response(reply)
             search_with_type = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
-            assert(search_with_type.all? { |resource| ['MedicationRequest', 'OperationOutcome'].include? resource.resourceType },
-                   'All resources returned must be of the type MedicationRequest or OperationOutcome.')
-            search_with_type.reject! { |resource| resource.resourceType == 'OperationOutcome' }
+            search_with_type.select! { |resource| resource.resourceType == 'MedicationRequest' }
             assert search_with_type.length == resources_returned.length, 'Expected search by Patient/ID to have the same results as search by ID'
 
             test_medication_inclusion(@medication_request_ary[patient], search_params)
@@ -240,6 +241,7 @@ module Inferno
             search_query_variants_tested_once = true
           end
         end
+
         skip_if_not_found(resource_type: 'MedicationRequest', delayed: false)
       end
 

--- a/lib/modules/uscore_v3.1.1/us_core_observation_lab_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_observation_lab_sequence.rb
@@ -190,14 +190,17 @@ module Inferno
 
             @resources_found = true
             resources_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
-            assert(resources_returned.all? { |resource| ['Observation', 'OperationOutcome'].include? resource.resourceType },
-                   'All resources returned must be of the type Observation or OperationOutcome')
-            resources_returned.reject! { |resource| resource.resourceType == 'OperationOutcome' }
+            types_in_response = Set.new(resources_returned.map { |resource| resource&.resourceType })
+            resources_returned.select! { |resource| resource.resourceType == 'Observation' }
             @observation = resources_returned.first
             @observation_ary[patient] += resources_returned
 
             save_resource_references(versioned_resource_class('Observation'), @observation_ary[patient], Inferno::ValidationUtil::US_CORE_R4_URIS[:lab_results])
             save_delayed_sequence_references(resources_returned, USCore311ObservationLabSequenceDefinitions::DELAYED_REFERENCES)
+
+            invalid_types_in_response = types_in_response - Set.new(['Observation', 'OperationOutcome'])
+            assert(invalid_types_in_response.empty?,
+                   'All resources returned must be of the type Observation or OperationOutcome, but includes ' + invalid_types_in_response.to_a.join(', '))
             validate_reply_entries(resources_returned, search_params)
 
             next if search_query_variants_tested_once
@@ -215,14 +218,13 @@ module Inferno
             assert_response_ok(reply)
             assert_bundle_response(reply)
             search_with_type = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
-            assert(search_with_type.all? { |resource| ['Observation', 'OperationOutcome'].include? resource.resourceType },
-                   'All resources returned must be of the type Observation or OperationOutcome.')
-            search_with_type.reject! { |resource| resource.resourceType == 'OperationOutcome' }
+            search_with_type.select! { |resource| resource.resourceType == 'Observation' }
             assert search_with_type.length == resources_returned.length, 'Expected search by Patient/ID to have the same results as search by ID'
 
             search_query_variants_tested_once = true
           end
         end
+
         skip_if_not_found(resource_type: 'Observation', delayed: false)
       end
 

--- a/lib/modules/uscore_v3.1.1/us_core_procedure_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_procedure_sequence.rb
@@ -174,11 +174,10 @@ module Inferno
 
           next unless any_resources
 
-          resource_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
-          assert(resource_returned.all? { |resource| ['Procedure', 'OperationOutcome'].include? resource.resourceType },
-                 'All resources returned must be of the type Procedure or OperationOutcome')
-          resource_returned.reject! { |resource| resource.resourceType == 'OperationOutcome' }
-          @procedure_ary[patient] = resource_returned
+          resources_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
+          types_in_response = Set.new(resources_returned.map { |resource| resource&.resourceType })
+          resources_returned.select! { |resource| resource.resourceType == 'Procedure' }
+          @procedure_ary[patient] = resources_returned
 
           @procedure = @procedure_ary[patient]
             .find { |resource| resource.resourceType == 'Procedure' }
@@ -186,6 +185,11 @@ module Inferno
 
           save_resource_references(versioned_resource_class('Procedure'), @procedure_ary[patient])
           save_delayed_sequence_references(@procedure_ary[patient], USCore311ProcedureSequenceDefinitions::DELAYED_REFERENCES)
+
+          invalid_types_in_response = types_in_response - Set.new(['Procedure', 'OperationOutcome'])
+          assert(invalid_types_in_response.empty?,
+                 'All resources returned must be of the type Procedure or OperationOutcome, but includes ' + invalid_types_in_response.to_a.join(', '))
+
           validate_reply_entries(@procedure_ary[patient], search_params)
 
           search_params = search_params.merge('patient': "Patient/#{patient}")
@@ -193,9 +197,7 @@ module Inferno
           assert_response_ok(reply)
           assert_bundle_response(reply)
           search_with_type = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
-          assert(search_with_type.all? { |resource| ['Procedure', 'OperationOutcome'].include? resource.resourceType },
-                 'All resources returned must be of the type Procedure or OperationOutcome')
-          search_with_type.reject! { |resource| resource.resourceType == 'OperationOutcome' }
+          search_with_type.select! { |resource| resource.resourceType == 'Procedure' }
           assert search_with_type.length == @procedure_ary[patient].length, 'Expected search by Patient/ID to have the same results as search by ID'
         end
 

--- a/lib/modules/uscore_v3.1.1/us_core_pulse_oximetry_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_pulse_oximetry_sequence.rb
@@ -190,14 +190,17 @@ module Inferno
 
             @resources_found = true
             resources_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
-            assert(resources_returned.all? { |resource| ['Observation', 'OperationOutcome'].include? resource.resourceType },
-                   'All resources returned must be of the type Observation or OperationOutcome')
-            resources_returned.reject! { |resource| resource.resourceType == 'OperationOutcome' }
+            types_in_response = Set.new(resources_returned.map { |resource| resource&.resourceType })
+            resources_returned.select! { |resource| resource.resourceType == 'Observation' }
             @observation = resources_returned.first
             @observation_ary[patient] += resources_returned
 
             save_resource_references(versioned_resource_class('Observation'), @observation_ary[patient], Inferno::ValidationUtil::US_CORE_R4_URIS[:pulse_oximetry])
             save_delayed_sequence_references(resources_returned, USCore311PulseOximetrySequenceDefinitions::DELAYED_REFERENCES)
+
+            invalid_types_in_response = types_in_response - Set.new(['Observation', 'OperationOutcome'])
+            assert(invalid_types_in_response.empty?,
+                   'All resources returned must be of the type Observation or OperationOutcome, but includes ' + invalid_types_in_response.to_a.join(', '))
             validate_reply_entries(resources_returned, search_params)
 
             next if search_query_variants_tested_once
@@ -215,14 +218,13 @@ module Inferno
             assert_response_ok(reply)
             assert_bundle_response(reply)
             search_with_type = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
-            assert(search_with_type.all? { |resource| ['Observation', 'OperationOutcome'].include? resource.resourceType },
-                   'All resources returned must be of the type Observation or OperationOutcome.')
-            search_with_type.reject! { |resource| resource.resourceType == 'OperationOutcome' }
+            search_with_type.select! { |resource| resource.resourceType == 'Observation' }
             assert search_with_type.length == resources_returned.length, 'Expected search by Patient/ID to have the same results as search by ID'
 
             search_query_variants_tested_once = true
           end
         end
+
         skip_if_not_found(resource_type: 'Observation', delayed: false)
       end
 

--- a/lib/modules/uscore_v3.1.1/us_core_smokingstatus_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_smokingstatus_sequence.rb
@@ -194,14 +194,17 @@ module Inferno
 
             @resources_found = true
             resources_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
-            assert(resources_returned.all? { |resource| ['Observation', 'OperationOutcome'].include? resource.resourceType },
-                   'All resources returned must be of the type Observation or OperationOutcome')
-            resources_returned.reject! { |resource| resource.resourceType == 'OperationOutcome' }
+            types_in_response = Set.new(resources_returned.map { |resource| resource&.resourceType })
+            resources_returned.select! { |resource| resource.resourceType == 'Observation' }
             @observation = resources_returned.first
             @observation_ary[patient] += resources_returned
 
             save_resource_references(versioned_resource_class('Observation'), @observation_ary[patient], Inferno::ValidationUtil::US_CORE_R4_URIS[:smoking_status])
             save_delayed_sequence_references(resources_returned, USCore311SmokingstatusSequenceDefinitions::DELAYED_REFERENCES)
+
+            invalid_types_in_response = types_in_response - Set.new(['Observation', 'OperationOutcome'])
+            assert(invalid_types_in_response.empty?,
+                   'All resources returned must be of the type Observation or OperationOutcome, but includes ' + invalid_types_in_response.to_a.join(', '))
             validate_reply_entries(resources_returned, search_params)
 
             next if search_query_variants_tested_once
@@ -219,14 +222,13 @@ module Inferno
             assert_response_ok(reply)
             assert_bundle_response(reply)
             search_with_type = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
-            assert(search_with_type.all? { |resource| ['Observation', 'OperationOutcome'].include? resource.resourceType },
-                   'All resources returned must be of the type Observation or OperationOutcome.')
-            search_with_type.reject! { |resource| resource.resourceType == 'OperationOutcome' }
+            search_with_type.select! { |resource| resource.resourceType == 'Observation' }
             assert search_with_type.length == resources_returned.length, 'Expected search by Patient/ID to have the same results as search by ID'
 
             search_query_variants_tested_once = true
           end
         end
+
         skip_if_not_found(resource_type: 'Observation', delayed: false)
       end
 


### PR DESCRIPTION
An issue that I came across is that in this implementation, sending an incorrect resource type causes the test to fail prior to saving any of the resources.  This is not a great experience for the user, since none of the later tests in the sequence will be able to run.  We try to avoid that.

Does this fix that problem @czh-orz?
