### PR TITLE
FI-1166: Remove frame embedding protection at app level.

### DIFF
--- a/lib/app/endpoint.rb
+++ b/lib/app/endpoint.rb
@@ -59,6 +59,7 @@ module Inferno
       set :static, true
       set :views, File.expand_path('views', __dir__)
       set(:prefix) { '/' << name[/[^:]+$/].underscore }
+      set :protection, except: :frame_options # necessary for SMART EHR Launches
 
       def render_index
         unless defined?(settings.presets).nil? || settings.presets.nil?

--- a/test/integration/home_page_test.rb
+++ b/test/integration/home_page_test.rb
@@ -14,6 +14,11 @@ class HomePageTest < MiniTest::Test
     assert last_response.body.downcase.include? 'html'
   end
 
+  def test_no_x_frame_options_header
+    get '/'
+    refute_includes last_response.headers.keys.map(&:downcase), 'x-frame-options'
+  end
+
   def test_404_page
     get '/asdfasdf'
     assert last_response.not_found?


### PR DESCRIPTION
# Summary

Some Inferno tests require the application to be embedded within an EHR interface in order to demonstrate certain functionality.  Web browsers inspect the "X-Frame-Options" header to ensure that the website being included allows this behavior. By default, Sinatra includes this header for security reasons.  We need to disable it for users that want to run Inferno outside of Docker.  For Docker users, we already strip these headers out when routing the request through NGINX.

See https://github.com/onc-healthit/inferno-program/issues/235#issuecomment-786914929

## New behavior

This configures Sinatra to not include that header for any response.  We may consider being more discerning in the new version to only disable it for response that may be embedded in an EHR, but that would be difficult in this legacy architecture.

## Code changes

Update to the Sinatra config and an integration test verifying it is not sent.

## Testing guidance

Launch using `bundle exec rackup` and ensure there is no `X-Frame-Options` header returned.  In other words, you should not see this when inspecting the request/responses:

![Screen Shot 2021-03-01 at 10 46 01 AM](https://user-images.githubusercontent.com/412901/109530921-43b35f80-7a85-11eb-8878-cb00d5bf925a.png)

