### PR TITLE
FI 1175 validator updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,21 @@ all of which are hereby incorporated by reference.
       Nucleic Acids Res. 2004 Jan 1;32(Database issue):D267-70. doi: 10.1093/nar/gkh061.
       PubMed PMID: 14681409; PubMed Central PMCID: PMC308795.
 
-### Reference Implementation
+## Validator Service
+
+Inferno uses an external validator service, found [here](https://github.com/inferno-community/fhir-validator-wrapper/), to validate resources provided to Inferno. When running Inferno in Docker using the `docker-compose.yml` file from this repository, the validator service is run as a separate Docker container that Inferno makes HTTP requests to.
+
+### Updating the Validator Service in Docker
+
+When Inferno is updated to a new version, it will occasionally require a new version of the validator service. If Inferno is being run using the `docker-compose.yml` file in this repository, the new validator version will be specified as part of the `validator_service` image declaration following an update through Git.
+
+To download the Docker files associated with the new version, run `docker-compose pull` in the Inferno directory. Once the new files are downloaded, you can update the version by running `docker-compose down`, followed by `docker-compose up --force-recreate`. This will restart Inferno and the validator service with the new service version.
+
+### Updating the Validator Service outside of Docker
+
+If Inferno isn't running in Docker, the valdiator service will have to be updated manually. See the [FHIR Validator Wrapper repository](https://github.com/inferno-community/fhir-validator-wrapper) for more information on how to run the validator service outside of docker.
+
+## Reference Implementation
 
 While it is recommended that users install Inferno locally, a reference
 implementation of Inferno is hosted at https://inferno.healthit.gov/inferno
@@ -206,7 +220,7 @@ available in perpetuity.
 ## Supported Browsers
 
 Inferno has been tested on the latest versions of Chrome, Firefox, Safari, and
-Edge.  Internet Explorer is not supported at this time.
+Edge. Internet Explorer is not supported at this time.
 
 ## Unit Tests
 

--- a/config.yml
+++ b/config.yml
@@ -41,6 +41,10 @@ resource_validator: external
 # internal validator.
 external_resource_validator_url: http://validator_service:4567
 
+# The expected version of the external validator. The app will display a warning if
+# the found version doesn't match the expected version exactly.
+external_resource_validator_version: '1.2.0'
+
 # The list of testing modules which will be made available. These entries must
 # match the "name" field in the .yml files in lib/modules.
 modules:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
     depends_on:
       - validator_service
   validator_service:
-    image: infernocommunity/fhir-validator-service:v0.1.1
+    image: infernocommunity/fhir-validator-service:v1.2.0
     environment:
       DISABLE_TX: 'true'
   nginx:

--- a/lib/app/endpoint.rb
+++ b/lib/app/endpoint.rb
@@ -19,7 +19,7 @@ module Inferno
       Inferno::DEFAULT_SCOPES = settings.default_scopes
       Inferno::ENVIRONMENT = settings.environment
       Inferno::PURGE_ON_RELOAD = settings.purge_database_on_reload
-      Inferno::RESOURCE_VALIDATOR = Inferno::App::ResourceValidatorFactory.new_validator(settings.resource_validator, settings.external_resource_validator_url)
+      Inferno::RESOURCE_VALIDATOR = Inferno::App::ResourceValidatorFactory.new_validator(settings.resource_validator, settings.external_resource_validator_url, settings.external_resource_validator_version)
 
       if settings.logging_enabled
         $stdout.sync = true # output in Docker is heavily delayed without this

--- a/lib/app/utils/fhir_models_validator.rb
+++ b/lib/app/utils/fhir_models_validator.rb
@@ -21,5 +21,10 @@ module Inferno
         information: []
       }
     end
+
+    # @return true (FHIR Models Validator always matches the expected version)
+    def version_match?
+      true
+    end
   end
 end

--- a/lib/app/utils/hl7_validator.rb
+++ b/lib/app/utils/hl7_validator.rb
@@ -6,7 +6,6 @@ module Inferno
     ISSUE_DETAILS_FILTER = [
       %r{^Sub-extension url 'introspect' is not defined by the Extension http://fhir-registry\.smarthealthit\.org/StructureDefinition/oauth-uris$},
       %r{^Sub-extension url 'revoke' is not defined by the Extension http://fhir-registry\.smarthealthit\.org/StructureDefinition/oauth-uris$},
-      /^URL value .* does not resolve$/,
       /^vs-1: if Observation\.effective\[x\] is dateTime and has a value then that value shall be precise to the day/, # Invalid invariant in FHIR v4.0.1
       /^us-core-1: Datetime must be at least to day/ # Invalid invariant in US Core v3.1.1
     ].freeze

--- a/lib/app/utils/hl7_validator.rb
+++ b/lib/app/utils/hl7_validator.rb
@@ -10,11 +10,13 @@ module Inferno
       /^us-core-1: Datetime must be at least to day/ # Invalid invariant in US Core v3.1.1
     ].freeze
     @validator_url = nil
+    attr_accessor :expected_version
 
-    def initialize(validator_url)
+    def initialize(validator_url, expected_version = nil)
       raise ArgumentError, 'Validator URL is unset' if validator_url.blank?
 
       @validator_url = validator_url
+      @expected_version = expected_version
     end
 
     def validate(resource, fhir_models_klass, profile_url = nil)
@@ -40,6 +42,12 @@ module Inferno
     rescue StandardError
       Inferno.logger.error('Unable to reach the /version validator endpoint. Please ensure that the validator is up to date.')
       nil
+    end
+
+    # @return [Boolean] true if the 'requested' version from the config file matches the version
+    # returned by the external service, false otherwise.
+    def version_match?
+      @expected_version == version
     end
 
     private

--- a/lib/app/utils/resource_validator_factory.rb
+++ b/lib/app/utils/resource_validator_factory.rb
@@ -6,14 +6,14 @@ require_relative 'hl7_validator'
 module Inferno
   class App
     module ResourceValidatorFactory
-      def self.new_validator(selected_validator, external_validator_url)
+      def self.new_validator(selected_validator, external_validator_url, validator_version)
         return Inferno::FHIRModelsValidator.new if ENV['RACK_ENV'] == 'test'
 
         case selected_validator
         when 'internal'
           Inferno::FHIRModelsValidator.new
         when 'external'
-          Inferno::HL7Validator.new(external_validator_url)
+          Inferno::HL7Validator.new(external_validator_url, validator_version)
         end
       end
     end

--- a/lib/app/views/index_onc_program.erb
+++ b/lib/app/views/index_onc_program.erb
@@ -3,6 +3,8 @@
   
   <%= erb(:missing_valuesets, {}, {}) %>
 
+  <%= erb(:resource_validator_version, {}, {}) %>
+
   <div class="row">
     <div class="col">
       <div class="container row row-no-padding align-items-center" style="margin:auto;" >

--- a/lib/app/views/resource_validator_version.erb
+++ b/lib/app/views/resource_validator_version.erb
@@ -1,0 +1,14 @@
+<% unless Inferno::RESOURCE_VALIDATOR.version_match? %>
+  <div class="row">
+    <div class="col">
+      <div class="container row row-no-padding align-items-center" style="margin:auto;" >
+        <div class="col-12" style="color: #063d75; text-align: center;">
+          <div class="alert alert-danger" role="alert">
+            Inferno expects FHIR Validator Service to be version <code><%= Inferno::RESOURCE_VALIDATOR.expected_version %></code>, 
+            but the available instance is version <code><%= Inferno::RESOURCE_VALIDATOR.version %></code>. To see how to update the validator, please review <a href="https://github.com/onc-healthit/inferno-program#validator-service">the Inferno README</a>.
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+<% end %>

--- a/test/fixtures/hl7_validator_operation_outcome.json
+++ b/test/fixtures/hl7_validator_operation_outcome.json
@@ -30,16 +30,6 @@
     },
     {
       "severity": "error",
-      "code": "structure",
-      "details": {
-        "text": "URL value 'http://hl7.org/fhir/uv/bulkdata/OperationDefinition/group-export' does not resolve"
-      },
-      "expression": [
-        "CapabilityStatement.rest[0].resource[57].operation[0].definition"
-      ]
-    },
-    {
-      "severity": "error",
       "code": "code-invalid",
       "details": {
         "text": "This is a code-invalid error"

--- a/test/unit/hl7_validator_test.rb
+++ b/test/unit/hl7_validator_test.rb
@@ -43,9 +43,9 @@ describe Inferno::HL7Validator do
         )
 
       result = @validator.validate(@resource, FHIR, @profile)
-      assert result[:errors].length == 2
-      assert result[:warnings].length == 1
-      assert result[:information].length == 5
+      assert_equal 2, result[:errors].length
+      assert_equal 1, result[:warnings].length
+      assert_equal 4, result[:information].length
     end
   end
 


### PR DESCRIPTION
# Summary

* Update validator version to 1.2.0 in compose, and remove filter for URL Does Not Resolve errors
* Add an expected validator version to config.yml, and display a (hopefully) helpful error if it doesn't match the fhir-validator-service version

## New behavior

Updated to the latest fhir-validator-wrapper from `master`, which no longer throws `URL Does Not Resolve` errors.
New view that validates the FHIR Validator Service Version against the expected version, and displays a warning if they don't match.
New README section with validator update instructions

## Testing guidance
Reset the validator version in `docker-compose.yml` to something before `1.2.0` (for example, `1.1.0`), run `docker-compose pull` and `docker-compose up --force-recreate`, and ensure that Inferno Program warns you on the homepage that you're not using the right validator version. The link won't work until this PR is merged however.

