### PR TITLE
Added PractitionerRole as prepopulated scope for UI

### DIFF
--- a/lib/app/views/onc_program.erb
+++ b/lib/app/views/onc_program.erb
@@ -560,7 +560,7 @@
               label: 'EHR-launched Scope',
               description: 'OAuth 2.0 scope provided by system to enable all required functionality',
               instance: instance,
-              value: instance.scopes || 'launch openid fhirUser offline_access user/Medication.read user/AllergyIntolerance.read user/CarePlan.read user/CareTeam.read user/Condition.read user/Device.read user/DiagnosticReport.read user/DocumentReference.read user/Encounter.read user/Goal.read user/Immunization.read user/Location.read user/MedicationRequest.read user/Observation.read user/Organization.read user/Patient.read user/Practitioner.read user/Procedure.read user/Provenance.read',
+              value: instance.scopes || 'launch openid fhirUser offline_access user/Medication.read user/AllergyIntolerance.read user/CarePlan.read user/CareTeam.read user/Condition.read user/Device.read user/DiagnosticReport.read user/DocumentReference.read user/Encounter.read user/Goal.read user/Immunization.read user/Location.read user/MedicationRequest.read user/Observation.read user/Organization.read user/Patient.read user/Practitioner.read user/Procedure.read user/Provenance.read patient/PractitionerRole.read',
               type: 'textarea',
               required: true,
               })%>
@@ -570,7 +570,7 @@
               description: 'OAuth 2.0 scope provided by system to enable all required functionality',
               instance: instance,
               type: 'textarea',
-              value: instance.onc_sl_scopes || 'launch/patient openid fhirUser offline_access patient/Medication.read patient/AllergyIntolerance.read patient/CarePlan.read patient/CareTeam.read patient/Condition.read patient/Device.read patient/DiagnosticReport.read patient/DocumentReference.read patient/Encounter.read patient/Goal.read patient/Immunization.read patient/Location.read patient/MedicationRequest.read patient/Observation.read patient/Organization.read patient/Patient.read patient/Practitioner.read patient/Procedure.read patient/Provenance.read'
+              value: instance.onc_sl_scopes || 'launch/patient openid fhirUser offline_access patient/Medication.read patient/AllergyIntolerance.read patient/CarePlan.read patient/CareTeam.read patient/Condition.read patient/Device.read patient/DiagnosticReport.read patient/DocumentReference.read patient/Encounter.read patient/Goal.read patient/Immunization.read patient/Location.read patient/MedicationRequest.read patient/Observation.read patient/Organization.read patient/Patient.read patient/Practitioner.read patient/Procedure.read patient/Provenance.read patient/PractitionerRole.read'
                })%>
 
         <%= erb(:prerequisite_field,{},{prerequisite: :onc_public_scopes,
@@ -578,7 +578,7 @@
               description: 'OAuth 2.0 scope provided by system to enable public client access for a patient standalone launch',
               instance: instance,
               type: 'textarea',
-              value: instance.onc_public_scopes || 'launch/patient openid fhirUser patient/Medication.read patient/AllergyIntolerance.read patient/CarePlan.read patient/CareTeam.read patient/Condition.read patient/Device.read patient/DiagnosticReport.read patient/DocumentReference.read patient/Encounter.read patient/Goal.read patient/Immunization.read patient/Location.read patient/MedicationRequest.read patient/Observation.read patient/Organization.read patient/Patient.read patient/Practitioner.read patient/Procedure.read patient/Provenance.read'
+              value: instance.onc_public_scopes || 'launch/patient openid fhirUser patient/Medication.read patient/AllergyIntolerance.read patient/CarePlan.read patient/CareTeam.read patient/Condition.read patient/Device.read patient/DiagnosticReport.read patient/DocumentReference.read patient/Encounter.read patient/Goal.read patient/Immunization.read patient/Location.read patient/MedicationRequest.read patient/Observation.read patient/Organization.read patient/Patient.read patient/Practitioner.read patient/Procedure.read patient/Provenance.read patient/PractitionerRole.read'
                })%>
 
         <%= erb(:prerequisite_field,{},{prerequisite: :onc_sl_expected_resources,


### PR DESCRIPTION
added PractictionerRole as prepopulated scope for the standalone patient app, limited app, and ehr practitioner app

# Summary
This scope was missing from default scopes causing 

## New behavior
Practitioner role scope is populated, USCPROV-04 passes on reference server

## Code changes

## Testing guidance
