### PR TITLE
FI-1176: Ensure code exists when doing code search with system.

### DIFF
--- a/generator/uscore/uscore_generator.rb
+++ b/generator/uscore/uscore_generator.rb
@@ -1198,8 +1198,9 @@ module Inferno
         return unless token_param
 
         param_description = sequence[:search_param_descriptions][token_param.to_sym]
+        resolve_element_path_method = "#{resolve_element_path(param_description, sequence[:delayed_sequence])}{ |el| get_value_for_search_param(el).present?}"
         %(
-          value_with_system = get_value_for_search_param(#{resolve_element_path(param_description, sequence[:delayed_sequence])}, true)
+          value_with_system = get_value_for_search_param(#{resolve_element_path_method}, true)
           token_with_system_search_params = search_params.merge('#{token_param}': value_with_system)
           reply = get_resource_by_params(versioned_resource_class('#{sequence[:resource]}'), token_with_system_search_params)
           validate_search_reply(versioned_resource_class('#{sequence[:resource]}'), reply, token_with_system_search_params)

--- a/lib/modules/uscore_v3.1.1/bodyheight_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/bodyheight_sequence.rb
@@ -205,7 +205,7 @@ module Inferno
 
             next if search_query_variants_tested_once
 
-            value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'code'), true)
+            value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'code') { |el| get_value_for_search_param(el).present? }, true)
             token_with_system_search_params = search_params.merge('code': value_with_system)
             reply = get_resource_by_params(versioned_resource_class('Observation'), token_with_system_search_params)
             validate_search_reply(versioned_resource_class('Observation'), reply, token_with_system_search_params)
@@ -275,7 +275,7 @@ module Inferno
             validate_search_reply(versioned_resource_class('Observation'), reply, comparator_search_params)
           end
 
-          value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category'), true)
+          value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category') { |el| get_value_for_search_param(el).present? }, true)
           token_with_system_search_params = search_params.merge('category': value_with_system)
           reply = get_resource_by_params(versioned_resource_class('Observation'), token_with_system_search_params)
           validate_search_reply(versioned_resource_class('Observation'), reply, token_with_system_search_params)
@@ -319,7 +319,7 @@ module Inferno
 
           validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
 
-          value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category'), true)
+          value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category') { |el| get_value_for_search_param(el).present? }, true)
           token_with_system_search_params = search_params.merge('category': value_with_system)
           reply = get_resource_by_params(versioned_resource_class('Observation'), token_with_system_search_params)
           validate_search_reply(versioned_resource_class('Observation'), reply, token_with_system_search_params)
@@ -363,7 +363,7 @@ module Inferno
 
           validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
 
-          value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category'), true)
+          value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category') { |el| get_value_for_search_param(el).present? }, true)
           token_with_system_search_params = search_params.merge('category': value_with_system)
           reply = get_resource_by_params(versioned_resource_class('Observation'), token_with_system_search_params)
           validate_search_reply(versioned_resource_class('Observation'), reply, token_with_system_search_params)
@@ -420,7 +420,7 @@ module Inferno
             validate_search_reply(versioned_resource_class('Observation'), reply, comparator_search_params)
           end
 
-          value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'code'), true)
+          value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'code') { |el| get_value_for_search_param(el).present? }, true)
           token_with_system_search_params = search_params.merge('code': value_with_system)
           reply = get_resource_by_params(versioned_resource_class('Observation'), token_with_system_search_params)
           validate_search_reply(versioned_resource_class('Observation'), reply, token_with_system_search_params)

--- a/lib/modules/uscore_v3.1.1/bodytemp_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/bodytemp_sequence.rb
@@ -205,7 +205,7 @@ module Inferno
 
             next if search_query_variants_tested_once
 
-            value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'code'), true)
+            value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'code') { |el| get_value_for_search_param(el).present? }, true)
             token_with_system_search_params = search_params.merge('code': value_with_system)
             reply = get_resource_by_params(versioned_resource_class('Observation'), token_with_system_search_params)
             validate_search_reply(versioned_resource_class('Observation'), reply, token_with_system_search_params)
@@ -275,7 +275,7 @@ module Inferno
             validate_search_reply(versioned_resource_class('Observation'), reply, comparator_search_params)
           end
 
-          value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category'), true)
+          value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category') { |el| get_value_for_search_param(el).present? }, true)
           token_with_system_search_params = search_params.merge('category': value_with_system)
           reply = get_resource_by_params(versioned_resource_class('Observation'), token_with_system_search_params)
           validate_search_reply(versioned_resource_class('Observation'), reply, token_with_system_search_params)
@@ -319,7 +319,7 @@ module Inferno
 
           validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
 
-          value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category'), true)
+          value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category') { |el| get_value_for_search_param(el).present? }, true)
           token_with_system_search_params = search_params.merge('category': value_with_system)
           reply = get_resource_by_params(versioned_resource_class('Observation'), token_with_system_search_params)
           validate_search_reply(versioned_resource_class('Observation'), reply, token_with_system_search_params)
@@ -363,7 +363,7 @@ module Inferno
 
           validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
 
-          value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category'), true)
+          value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category') { |el| get_value_for_search_param(el).present? }, true)
           token_with_system_search_params = search_params.merge('category': value_with_system)
           reply = get_resource_by_params(versioned_resource_class('Observation'), token_with_system_search_params)
           validate_search_reply(versioned_resource_class('Observation'), reply, token_with_system_search_params)
@@ -420,7 +420,7 @@ module Inferno
             validate_search_reply(versioned_resource_class('Observation'), reply, comparator_search_params)
           end
 
-          value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'code'), true)
+          value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'code') { |el| get_value_for_search_param(el).present? }, true)
           token_with_system_search_params = search_params.merge('code': value_with_system)
           reply = get_resource_by_params(versioned_resource_class('Observation'), token_with_system_search_params)
           validate_search_reply(versioned_resource_class('Observation'), reply, token_with_system_search_params)

--- a/lib/modules/uscore_v3.1.1/bodyweight_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/bodyweight_sequence.rb
@@ -205,7 +205,7 @@ module Inferno
 
             next if search_query_variants_tested_once
 
-            value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'code'), true)
+            value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'code') { |el| get_value_for_search_param(el).present? }, true)
             token_with_system_search_params = search_params.merge('code': value_with_system)
             reply = get_resource_by_params(versioned_resource_class('Observation'), token_with_system_search_params)
             validate_search_reply(versioned_resource_class('Observation'), reply, token_with_system_search_params)
@@ -275,7 +275,7 @@ module Inferno
             validate_search_reply(versioned_resource_class('Observation'), reply, comparator_search_params)
           end
 
-          value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category'), true)
+          value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category') { |el| get_value_for_search_param(el).present? }, true)
           token_with_system_search_params = search_params.merge('category': value_with_system)
           reply = get_resource_by_params(versioned_resource_class('Observation'), token_with_system_search_params)
           validate_search_reply(versioned_resource_class('Observation'), reply, token_with_system_search_params)
@@ -319,7 +319,7 @@ module Inferno
 
           validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
 
-          value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category'), true)
+          value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category') { |el| get_value_for_search_param(el).present? }, true)
           token_with_system_search_params = search_params.merge('category': value_with_system)
           reply = get_resource_by_params(versioned_resource_class('Observation'), token_with_system_search_params)
           validate_search_reply(versioned_resource_class('Observation'), reply, token_with_system_search_params)
@@ -363,7 +363,7 @@ module Inferno
 
           validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
 
-          value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category'), true)
+          value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category') { |el| get_value_for_search_param(el).present? }, true)
           token_with_system_search_params = search_params.merge('category': value_with_system)
           reply = get_resource_by_params(versioned_resource_class('Observation'), token_with_system_search_params)
           validate_search_reply(versioned_resource_class('Observation'), reply, token_with_system_search_params)
@@ -420,7 +420,7 @@ module Inferno
             validate_search_reply(versioned_resource_class('Observation'), reply, comparator_search_params)
           end
 
-          value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'code'), true)
+          value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'code') { |el| get_value_for_search_param(el).present? }, true)
           token_with_system_search_params = search_params.merge('code': value_with_system)
           reply = get_resource_by_params(versioned_resource_class('Observation'), token_with_system_search_params)
           validate_search_reply(versioned_resource_class('Observation'), reply, token_with_system_search_params)

--- a/lib/modules/uscore_v3.1.1/bp_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/bp_sequence.rb
@@ -205,7 +205,7 @@ module Inferno
 
             next if search_query_variants_tested_once
 
-            value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'code'), true)
+            value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'code') { |el| get_value_for_search_param(el).present? }, true)
             token_with_system_search_params = search_params.merge('code': value_with_system)
             reply = get_resource_by_params(versioned_resource_class('Observation'), token_with_system_search_params)
             validate_search_reply(versioned_resource_class('Observation'), reply, token_with_system_search_params)
@@ -275,7 +275,7 @@ module Inferno
             validate_search_reply(versioned_resource_class('Observation'), reply, comparator_search_params)
           end
 
-          value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category'), true)
+          value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category') { |el| get_value_for_search_param(el).present? }, true)
           token_with_system_search_params = search_params.merge('category': value_with_system)
           reply = get_resource_by_params(versioned_resource_class('Observation'), token_with_system_search_params)
           validate_search_reply(versioned_resource_class('Observation'), reply, token_with_system_search_params)
@@ -319,7 +319,7 @@ module Inferno
 
           validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
 
-          value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category'), true)
+          value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category') { |el| get_value_for_search_param(el).present? }, true)
           token_with_system_search_params = search_params.merge('category': value_with_system)
           reply = get_resource_by_params(versioned_resource_class('Observation'), token_with_system_search_params)
           validate_search_reply(versioned_resource_class('Observation'), reply, token_with_system_search_params)
@@ -363,7 +363,7 @@ module Inferno
 
           validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
 
-          value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category'), true)
+          value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category') { |el| get_value_for_search_param(el).present? }, true)
           token_with_system_search_params = search_params.merge('category': value_with_system)
           reply = get_resource_by_params(versioned_resource_class('Observation'), token_with_system_search_params)
           validate_search_reply(versioned_resource_class('Observation'), reply, token_with_system_search_params)
@@ -420,7 +420,7 @@ module Inferno
             validate_search_reply(versioned_resource_class('Observation'), reply, comparator_search_params)
           end
 
-          value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'code'), true)
+          value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'code') { |el| get_value_for_search_param(el).present? }, true)
           token_with_system_search_params = search_params.merge('code': value_with_system)
           reply = get_resource_by_params(versioned_resource_class('Observation'), token_with_system_search_params)
           validate_search_reply(versioned_resource_class('Observation'), reply, token_with_system_search_params)

--- a/lib/modules/uscore_v3.1.1/head_occipital_frontal_circumference_percentile_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/head_occipital_frontal_circumference_percentile_sequence.rb
@@ -205,7 +205,7 @@ module Inferno
 
             next if search_query_variants_tested_once
 
-            value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'code'), true)
+            value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'code') { |el| get_value_for_search_param(el).present? }, true)
             token_with_system_search_params = search_params.merge('code': value_with_system)
             reply = get_resource_by_params(versioned_resource_class('Observation'), token_with_system_search_params)
             validate_search_reply(versioned_resource_class('Observation'), reply, token_with_system_search_params)
@@ -275,7 +275,7 @@ module Inferno
             validate_search_reply(versioned_resource_class('Observation'), reply, comparator_search_params)
           end
 
-          value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category'), true)
+          value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category') { |el| get_value_for_search_param(el).present? }, true)
           token_with_system_search_params = search_params.merge('category': value_with_system)
           reply = get_resource_by_params(versioned_resource_class('Observation'), token_with_system_search_params)
           validate_search_reply(versioned_resource_class('Observation'), reply, token_with_system_search_params)
@@ -319,7 +319,7 @@ module Inferno
 
           validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
 
-          value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category'), true)
+          value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category') { |el| get_value_for_search_param(el).present? }, true)
           token_with_system_search_params = search_params.merge('category': value_with_system)
           reply = get_resource_by_params(versioned_resource_class('Observation'), token_with_system_search_params)
           validate_search_reply(versioned_resource_class('Observation'), reply, token_with_system_search_params)
@@ -363,7 +363,7 @@ module Inferno
 
           validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
 
-          value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category'), true)
+          value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category') { |el| get_value_for_search_param(el).present? }, true)
           token_with_system_search_params = search_params.merge('category': value_with_system)
           reply = get_resource_by_params(versioned_resource_class('Observation'), token_with_system_search_params)
           validate_search_reply(versioned_resource_class('Observation'), reply, token_with_system_search_params)
@@ -420,7 +420,7 @@ module Inferno
             validate_search_reply(versioned_resource_class('Observation'), reply, comparator_search_params)
           end
 
-          value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'code'), true)
+          value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'code') { |el| get_value_for_search_param(el).present? }, true)
           token_with_system_search_params = search_params.merge('code': value_with_system)
           reply = get_resource_by_params(versioned_resource_class('Observation'), token_with_system_search_params)
           validate_search_reply(versioned_resource_class('Observation'), reply, token_with_system_search_params)

--- a/lib/modules/uscore_v3.1.1/heartrate_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/heartrate_sequence.rb
@@ -205,7 +205,7 @@ module Inferno
 
             next if search_query_variants_tested_once
 
-            value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'code'), true)
+            value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'code') { |el| get_value_for_search_param(el).present? }, true)
             token_with_system_search_params = search_params.merge('code': value_with_system)
             reply = get_resource_by_params(versioned_resource_class('Observation'), token_with_system_search_params)
             validate_search_reply(versioned_resource_class('Observation'), reply, token_with_system_search_params)
@@ -275,7 +275,7 @@ module Inferno
             validate_search_reply(versioned_resource_class('Observation'), reply, comparator_search_params)
           end
 
-          value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category'), true)
+          value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category') { |el| get_value_for_search_param(el).present? }, true)
           token_with_system_search_params = search_params.merge('category': value_with_system)
           reply = get_resource_by_params(versioned_resource_class('Observation'), token_with_system_search_params)
           validate_search_reply(versioned_resource_class('Observation'), reply, token_with_system_search_params)
@@ -319,7 +319,7 @@ module Inferno
 
           validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
 
-          value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category'), true)
+          value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category') { |el| get_value_for_search_param(el).present? }, true)
           token_with_system_search_params = search_params.merge('category': value_with_system)
           reply = get_resource_by_params(versioned_resource_class('Observation'), token_with_system_search_params)
           validate_search_reply(versioned_resource_class('Observation'), reply, token_with_system_search_params)
@@ -363,7 +363,7 @@ module Inferno
 
           validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
 
-          value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category'), true)
+          value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category') { |el| get_value_for_search_param(el).present? }, true)
           token_with_system_search_params = search_params.merge('category': value_with_system)
           reply = get_resource_by_params(versioned_resource_class('Observation'), token_with_system_search_params)
           validate_search_reply(versioned_resource_class('Observation'), reply, token_with_system_search_params)
@@ -420,7 +420,7 @@ module Inferno
             validate_search_reply(versioned_resource_class('Observation'), reply, comparator_search_params)
           end
 
-          value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'code'), true)
+          value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'code') { |el| get_value_for_search_param(el).present? }, true)
           token_with_system_search_params = search_params.merge('code': value_with_system)
           reply = get_resource_by_params(versioned_resource_class('Observation'), token_with_system_search_params)
           validate_search_reply(versioned_resource_class('Observation'), reply, token_with_system_search_params)

--- a/lib/modules/uscore_v3.1.1/pediatric_bmi_for_age_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/pediatric_bmi_for_age_sequence.rb
@@ -205,7 +205,7 @@ module Inferno
 
             next if search_query_variants_tested_once
 
-            value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'code'), true)
+            value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'code') { |el| get_value_for_search_param(el).present? }, true)
             token_with_system_search_params = search_params.merge('code': value_with_system)
             reply = get_resource_by_params(versioned_resource_class('Observation'), token_with_system_search_params)
             validate_search_reply(versioned_resource_class('Observation'), reply, token_with_system_search_params)
@@ -275,7 +275,7 @@ module Inferno
             validate_search_reply(versioned_resource_class('Observation'), reply, comparator_search_params)
           end
 
-          value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category'), true)
+          value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category') { |el| get_value_for_search_param(el).present? }, true)
           token_with_system_search_params = search_params.merge('category': value_with_system)
           reply = get_resource_by_params(versioned_resource_class('Observation'), token_with_system_search_params)
           validate_search_reply(versioned_resource_class('Observation'), reply, token_with_system_search_params)
@@ -319,7 +319,7 @@ module Inferno
 
           validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
 
-          value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category'), true)
+          value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category') { |el| get_value_for_search_param(el).present? }, true)
           token_with_system_search_params = search_params.merge('category': value_with_system)
           reply = get_resource_by_params(versioned_resource_class('Observation'), token_with_system_search_params)
           validate_search_reply(versioned_resource_class('Observation'), reply, token_with_system_search_params)
@@ -363,7 +363,7 @@ module Inferno
 
           validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
 
-          value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category'), true)
+          value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category') { |el| get_value_for_search_param(el).present? }, true)
           token_with_system_search_params = search_params.merge('category': value_with_system)
           reply = get_resource_by_params(versioned_resource_class('Observation'), token_with_system_search_params)
           validate_search_reply(versioned_resource_class('Observation'), reply, token_with_system_search_params)
@@ -420,7 +420,7 @@ module Inferno
             validate_search_reply(versioned_resource_class('Observation'), reply, comparator_search_params)
           end
 
-          value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'code'), true)
+          value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'code') { |el| get_value_for_search_param(el).present? }, true)
           token_with_system_search_params = search_params.merge('code': value_with_system)
           reply = get_resource_by_params(versioned_resource_class('Observation'), token_with_system_search_params)
           validate_search_reply(versioned_resource_class('Observation'), reply, token_with_system_search_params)

--- a/lib/modules/uscore_v3.1.1/pediatric_weight_for_height_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/pediatric_weight_for_height_sequence.rb
@@ -205,7 +205,7 @@ module Inferno
 
             next if search_query_variants_tested_once
 
-            value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'code'), true)
+            value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'code') { |el| get_value_for_search_param(el).present? }, true)
             token_with_system_search_params = search_params.merge('code': value_with_system)
             reply = get_resource_by_params(versioned_resource_class('Observation'), token_with_system_search_params)
             validate_search_reply(versioned_resource_class('Observation'), reply, token_with_system_search_params)
@@ -275,7 +275,7 @@ module Inferno
             validate_search_reply(versioned_resource_class('Observation'), reply, comparator_search_params)
           end
 
-          value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category'), true)
+          value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category') { |el| get_value_for_search_param(el).present? }, true)
           token_with_system_search_params = search_params.merge('category': value_with_system)
           reply = get_resource_by_params(versioned_resource_class('Observation'), token_with_system_search_params)
           validate_search_reply(versioned_resource_class('Observation'), reply, token_with_system_search_params)
@@ -319,7 +319,7 @@ module Inferno
 
           validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
 
-          value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category'), true)
+          value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category') { |el| get_value_for_search_param(el).present? }, true)
           token_with_system_search_params = search_params.merge('category': value_with_system)
           reply = get_resource_by_params(versioned_resource_class('Observation'), token_with_system_search_params)
           validate_search_reply(versioned_resource_class('Observation'), reply, token_with_system_search_params)
@@ -363,7 +363,7 @@ module Inferno
 
           validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
 
-          value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category'), true)
+          value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category') { |el| get_value_for_search_param(el).present? }, true)
           token_with_system_search_params = search_params.merge('category': value_with_system)
           reply = get_resource_by_params(versioned_resource_class('Observation'), token_with_system_search_params)
           validate_search_reply(versioned_resource_class('Observation'), reply, token_with_system_search_params)
@@ -420,7 +420,7 @@ module Inferno
             validate_search_reply(versioned_resource_class('Observation'), reply, comparator_search_params)
           end
 
-          value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'code'), true)
+          value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'code') { |el| get_value_for_search_param(el).present? }, true)
           token_with_system_search_params = search_params.merge('code': value_with_system)
           reply = get_resource_by_params(versioned_resource_class('Observation'), token_with_system_search_params)
           validate_search_reply(versioned_resource_class('Observation'), reply, token_with_system_search_params)

--- a/lib/modules/uscore_v3.1.1/resprate_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/resprate_sequence.rb
@@ -205,7 +205,7 @@ module Inferno
 
             next if search_query_variants_tested_once
 
-            value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'code'), true)
+            value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'code') { |el| get_value_for_search_param(el).present? }, true)
             token_with_system_search_params = search_params.merge('code': value_with_system)
             reply = get_resource_by_params(versioned_resource_class('Observation'), token_with_system_search_params)
             validate_search_reply(versioned_resource_class('Observation'), reply, token_with_system_search_params)
@@ -275,7 +275,7 @@ module Inferno
             validate_search_reply(versioned_resource_class('Observation'), reply, comparator_search_params)
           end
 
-          value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category'), true)
+          value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category') { |el| get_value_for_search_param(el).present? }, true)
           token_with_system_search_params = search_params.merge('category': value_with_system)
           reply = get_resource_by_params(versioned_resource_class('Observation'), token_with_system_search_params)
           validate_search_reply(versioned_resource_class('Observation'), reply, token_with_system_search_params)
@@ -319,7 +319,7 @@ module Inferno
 
           validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
 
-          value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category'), true)
+          value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category') { |el| get_value_for_search_param(el).present? }, true)
           token_with_system_search_params = search_params.merge('category': value_with_system)
           reply = get_resource_by_params(versioned_resource_class('Observation'), token_with_system_search_params)
           validate_search_reply(versioned_resource_class('Observation'), reply, token_with_system_search_params)
@@ -363,7 +363,7 @@ module Inferno
 
           validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
 
-          value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category'), true)
+          value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category') { |el| get_value_for_search_param(el).present? }, true)
           token_with_system_search_params = search_params.merge('category': value_with_system)
           reply = get_resource_by_params(versioned_resource_class('Observation'), token_with_system_search_params)
           validate_search_reply(versioned_resource_class('Observation'), reply, token_with_system_search_params)
@@ -420,7 +420,7 @@ module Inferno
             validate_search_reply(versioned_resource_class('Observation'), reply, comparator_search_params)
           end
 
-          value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'code'), true)
+          value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'code') { |el| get_value_for_search_param(el).present? }, true)
           token_with_system_search_params = search_params.merge('code': value_with_system)
           reply = get_resource_by_params(versioned_resource_class('Observation'), token_with_system_search_params)
           validate_search_reply(versioned_resource_class('Observation'), reply, token_with_system_search_params)

--- a/lib/modules/uscore_v3.1.1/test/us_core_patient_test.rb
+++ b/lib/modules/uscore_v3.1.1/test/us_core_patient_test.rb
@@ -280,23 +280,6 @@ describe Inferno::Sequence::USCore311PatientSequence do
 
       @sequence.run_test(@test)
     end
-
-    it 'succeeds when name has comma in text' do
-      # remove patient's family name and give name so that
-      # inferno has to use the name.text for search
-      @patient.name.first.family = nil
-      @patient.name.first.given = nil
-
-      @query = {
-        'name': @sequence.get_value_for_search_param(@sequence.resolve_element_from_path(@patient_ary[@sequence.patient_ids.first], 'name'))
-      }
-
-      stub_request(:get, "#{@base_url}/Patient")
-        .with(query: @query, headers: @auth_header)
-        .to_return(status: 200, body: wrap_resources_in_bundle(@patient_ary.values.flatten).to_json)
-
-      @sequence.run_test(@test)
-    end
   end
 
   describe 'Patient search by birthdate+name test' do

--- a/lib/modules/uscore_v3.1.1/us_core_allergyintolerance_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_allergyintolerance_sequence.rb
@@ -226,7 +226,7 @@ module Inferno
 
           validate_search_reply(versioned_resource_class('AllergyIntolerance'), reply, search_params)
 
-          value_with_system = get_value_for_search_param(resolve_element_from_path(@allergy_intolerance_ary[patient], 'clinicalStatus'), true)
+          value_with_system = get_value_for_search_param(resolve_element_from_path(@allergy_intolerance_ary[patient], 'clinicalStatus') { |el| get_value_for_search_param(el).present? }, true)
           token_with_system_search_params = search_params.merge('clinical-status': value_with_system)
           reply = get_resource_by_params(versioned_resource_class('AllergyIntolerance'), token_with_system_search_params)
           validate_search_reply(versioned_resource_class('AllergyIntolerance'), reply, token_with_system_search_params)

--- a/lib/modules/uscore_v3.1.1/us_core_careplan_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_careplan_sequence.rb
@@ -190,7 +190,7 @@ module Inferno
 
             next if search_query_variants_tested_once
 
-            value_with_system = get_value_for_search_param(resolve_element_from_path(@care_plan_ary[patient], 'category'), true)
+            value_with_system = get_value_for_search_param(resolve_element_from_path(@care_plan_ary[patient], 'category') { |el| get_value_for_search_param(el).present? }, true)
             token_with_system_search_params = search_params.merge('category': value_with_system)
             reply = get_resource_by_params(versioned_resource_class('CarePlan'), token_with_system_search_params)
             validate_search_reply(versioned_resource_class('CarePlan'), reply, token_with_system_search_params)
@@ -248,7 +248,7 @@ module Inferno
 
           validate_search_reply(versioned_resource_class('CarePlan'), reply, search_params)
 
-          value_with_system = get_value_for_search_param(resolve_element_from_path(@care_plan_ary[patient], 'category'), true)
+          value_with_system = get_value_for_search_param(resolve_element_from_path(@care_plan_ary[patient], 'category') { |el| get_value_for_search_param(el).present? }, true)
           token_with_system_search_params = search_params.merge('category': value_with_system)
           reply = get_resource_by_params(versioned_resource_class('CarePlan'), token_with_system_search_params)
           validate_search_reply(versioned_resource_class('CarePlan'), reply, token_with_system_search_params)

--- a/lib/modules/uscore_v3.1.1/us_core_condition_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_condition_sequence.rb
@@ -259,7 +259,7 @@ module Inferno
 
           validate_search_reply(versioned_resource_class('Condition'), reply, search_params)
 
-          value_with_system = get_value_for_search_param(resolve_element_from_path(@condition_ary[patient], 'category'), true)
+          value_with_system = get_value_for_search_param(resolve_element_from_path(@condition_ary[patient], 'category') { |el| get_value_for_search_param(el).present? }, true)
           token_with_system_search_params = search_params.merge('category': value_with_system)
           reply = get_resource_by_params(versioned_resource_class('Condition'), token_with_system_search_params)
           validate_search_reply(versioned_resource_class('Condition'), reply, token_with_system_search_params)
@@ -302,7 +302,7 @@ module Inferno
 
           validate_search_reply(versioned_resource_class('Condition'), reply, search_params)
 
-          value_with_system = get_value_for_search_param(resolve_element_from_path(@condition_ary[patient], 'clinicalStatus'), true)
+          value_with_system = get_value_for_search_param(resolve_element_from_path(@condition_ary[patient], 'clinicalStatus') { |el| get_value_for_search_param(el).present? }, true)
           token_with_system_search_params = search_params.merge('clinical-status': value_with_system)
           reply = get_resource_by_params(versioned_resource_class('Condition'), token_with_system_search_params)
           validate_search_reply(versioned_resource_class('Condition'), reply, token_with_system_search_params)
@@ -347,7 +347,7 @@ module Inferno
 
           validate_search_reply(versioned_resource_class('Condition'), reply, search_params)
 
-          value_with_system = get_value_for_search_param(resolve_element_from_path(@condition_ary[patient], 'code'), true)
+          value_with_system = get_value_for_search_param(resolve_element_from_path(@condition_ary[patient], 'code') { |el| get_value_for_search_param(el).present? }, true)
           token_with_system_search_params = search_params.merge('code': value_with_system)
           reply = get_resource_by_params(versioned_resource_class('Condition'), token_with_system_search_params)
           validate_search_reply(versioned_resource_class('Condition'), reply, token_with_system_search_params)

--- a/lib/modules/uscore_v3.1.1/us_core_diagnosticreport_lab_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_diagnosticreport_lab_sequence.rb
@@ -208,7 +208,7 @@ module Inferno
 
             next if search_query_variants_tested_once
 
-            value_with_system = get_value_for_search_param(resolve_element_from_path(@diagnostic_report_ary[patient], 'category'), true)
+            value_with_system = get_value_for_search_param(resolve_element_from_path(@diagnostic_report_ary[patient], 'category') { |el| get_value_for_search_param(el).present? }, true)
             token_with_system_search_params = search_params.merge('category': value_with_system)
             reply = get_resource_by_params(versioned_resource_class('DiagnosticReport'), token_with_system_search_params)
             validate_search_reply(versioned_resource_class('DiagnosticReport'), reply, token_with_system_search_params)
@@ -308,7 +308,7 @@ module Inferno
             validate_search_reply(versioned_resource_class('DiagnosticReport'), reply, comparator_search_params)
           end
 
-          value_with_system = get_value_for_search_param(resolve_element_from_path(@diagnostic_report_ary[patient], 'category'), true)
+          value_with_system = get_value_for_search_param(resolve_element_from_path(@diagnostic_report_ary[patient], 'category') { |el| get_value_for_search_param(el).present? }, true)
           token_with_system_search_params = search_params.merge('category': value_with_system)
           reply = get_resource_by_params(versioned_resource_class('DiagnosticReport'), token_with_system_search_params)
           validate_search_reply(versioned_resource_class('DiagnosticReport'), reply, token_with_system_search_params)
@@ -352,7 +352,7 @@ module Inferno
 
           validate_search_reply(versioned_resource_class('DiagnosticReport'), reply, search_params)
 
-          value_with_system = get_value_for_search_param(resolve_element_from_path(@diagnostic_report_ary[patient], 'code'), true)
+          value_with_system = get_value_for_search_param(resolve_element_from_path(@diagnostic_report_ary[patient], 'code') { |el| get_value_for_search_param(el).present? }, true)
           token_with_system_search_params = search_params.merge('code': value_with_system)
           reply = get_resource_by_params(versioned_resource_class('DiagnosticReport'), token_with_system_search_params)
           validate_search_reply(versioned_resource_class('DiagnosticReport'), reply, token_with_system_search_params)
@@ -447,7 +447,7 @@ module Inferno
             validate_search_reply(versioned_resource_class('DiagnosticReport'), reply, comparator_search_params)
           end
 
-          value_with_system = get_value_for_search_param(resolve_element_from_path(@diagnostic_report_ary[patient], 'code'), true)
+          value_with_system = get_value_for_search_param(resolve_element_from_path(@diagnostic_report_ary[patient], 'code') { |el| get_value_for_search_param(el).present? }, true)
           token_with_system_search_params = search_params.merge('code': value_with_system)
           reply = get_resource_by_params(versioned_resource_class('DiagnosticReport'), token_with_system_search_params)
           validate_search_reply(versioned_resource_class('DiagnosticReport'), reply, token_with_system_search_params)

--- a/lib/modules/uscore_v3.1.1/us_core_diagnosticreport_note_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_diagnosticreport_note_sequence.rb
@@ -208,7 +208,7 @@ module Inferno
 
             next if search_query_variants_tested_once
 
-            value_with_system = get_value_for_search_param(resolve_element_from_path(@diagnostic_report_ary[patient], 'category'), true)
+            value_with_system = get_value_for_search_param(resolve_element_from_path(@diagnostic_report_ary[patient], 'category') { |el| get_value_for_search_param(el).present? }, true)
             token_with_system_search_params = search_params.merge('category': value_with_system)
             reply = get_resource_by_params(versioned_resource_class('DiagnosticReport'), token_with_system_search_params)
             validate_search_reply(versioned_resource_class('DiagnosticReport'), reply, token_with_system_search_params)
@@ -308,7 +308,7 @@ module Inferno
             validate_search_reply(versioned_resource_class('DiagnosticReport'), reply, comparator_search_params)
           end
 
-          value_with_system = get_value_for_search_param(resolve_element_from_path(@diagnostic_report_ary[patient], 'category'), true)
+          value_with_system = get_value_for_search_param(resolve_element_from_path(@diagnostic_report_ary[patient], 'category') { |el| get_value_for_search_param(el).present? }, true)
           token_with_system_search_params = search_params.merge('category': value_with_system)
           reply = get_resource_by_params(versioned_resource_class('DiagnosticReport'), token_with_system_search_params)
           validate_search_reply(versioned_resource_class('DiagnosticReport'), reply, token_with_system_search_params)
@@ -352,7 +352,7 @@ module Inferno
 
           validate_search_reply(versioned_resource_class('DiagnosticReport'), reply, search_params)
 
-          value_with_system = get_value_for_search_param(resolve_element_from_path(@diagnostic_report_ary[patient], 'code'), true)
+          value_with_system = get_value_for_search_param(resolve_element_from_path(@diagnostic_report_ary[patient], 'code') { |el| get_value_for_search_param(el).present? }, true)
           token_with_system_search_params = search_params.merge('code': value_with_system)
           reply = get_resource_by_params(versioned_resource_class('DiagnosticReport'), token_with_system_search_params)
           validate_search_reply(versioned_resource_class('DiagnosticReport'), reply, token_with_system_search_params)
@@ -447,7 +447,7 @@ module Inferno
             validate_search_reply(versioned_resource_class('DiagnosticReport'), reply, comparator_search_params)
           end
 
-          value_with_system = get_value_for_search_param(resolve_element_from_path(@diagnostic_report_ary[patient], 'code'), true)
+          value_with_system = get_value_for_search_param(resolve_element_from_path(@diagnostic_report_ary[patient], 'code') { |el| get_value_for_search_param(el).present? }, true)
           token_with_system_search_params = search_params.merge('code': value_with_system)
           reply = get_resource_by_params(versioned_resource_class('DiagnosticReport'), token_with_system_search_params)
           validate_search_reply(versioned_resource_class('DiagnosticReport'), reply, token_with_system_search_params)

--- a/lib/modules/uscore_v3.1.1/us_core_documentreference_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_documentreference_sequence.rb
@@ -305,7 +305,7 @@ module Inferno
 
           validate_search_reply(versioned_resource_class('DocumentReference'), reply, search_params)
 
-          value_with_system = get_value_for_search_param(resolve_element_from_path(@document_reference_ary[patient], 'type'), true)
+          value_with_system = get_value_for_search_param(resolve_element_from_path(@document_reference_ary[patient], 'type') { |el| get_value_for_search_param(el).present? }, true)
           token_with_system_search_params = search_params.merge('type': value_with_system)
           reply = get_resource_by_params(versioned_resource_class('DocumentReference'), token_with_system_search_params)
           validate_search_reply(versioned_resource_class('DocumentReference'), reply, token_with_system_search_params)
@@ -354,7 +354,7 @@ module Inferno
 
           validate_search_reply(versioned_resource_class('DocumentReference'), reply, search_params)
 
-          value_with_system = get_value_for_search_param(resolve_element_from_path(@document_reference_ary[patient], 'category'), true)
+          value_with_system = get_value_for_search_param(resolve_element_from_path(@document_reference_ary[patient], 'category') { |el| get_value_for_search_param(el).present? }, true)
           token_with_system_search_params = search_params.merge('category': value_with_system)
           reply = get_resource_by_params(versioned_resource_class('DocumentReference'), token_with_system_search_params)
           validate_search_reply(versioned_resource_class('DocumentReference'), reply, token_with_system_search_params)
@@ -398,7 +398,7 @@ module Inferno
 
           validate_search_reply(versioned_resource_class('DocumentReference'), reply, search_params)
 
-          value_with_system = get_value_for_search_param(resolve_element_from_path(@document_reference_ary[patient], 'category'), true)
+          value_with_system = get_value_for_search_param(resolve_element_from_path(@document_reference_ary[patient], 'category') { |el| get_value_for_search_param(el).present? }, true)
           token_with_system_search_params = search_params.merge('category': value_with_system)
           reply = get_resource_by_params(versioned_resource_class('DocumentReference'), token_with_system_search_params)
           validate_search_reply(versioned_resource_class('DocumentReference'), reply, token_with_system_search_params)
@@ -455,7 +455,7 @@ module Inferno
             validate_search_reply(versioned_resource_class('DocumentReference'), reply, comparator_search_params)
           end
 
-          value_with_system = get_value_for_search_param(resolve_element_from_path(@document_reference_ary[patient], 'type'), true)
+          value_with_system = get_value_for_search_param(resolve_element_from_path(@document_reference_ary[patient], 'type') { |el| get_value_for_search_param(el).present? }, true)
           token_with_system_search_params = search_params.merge('type': value_with_system)
           reply = get_resource_by_params(versioned_resource_class('DocumentReference'), token_with_system_search_params)
           validate_search_reply(versioned_resource_class('DocumentReference'), reply, token_with_system_search_params)

--- a/lib/modules/uscore_v3.1.1/us_core_implantable_device_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_implantable_device_sequence.rb
@@ -205,7 +205,7 @@ module Inferno
 
           validate_search_reply(versioned_resource_class('Device'), reply, search_params)
 
-          value_with_system = get_value_for_search_param(resolve_element_from_path(@device_ary[patient], 'type'), true)
+          value_with_system = get_value_for_search_param(resolve_element_from_path(@device_ary[patient], 'type') { |el| get_value_for_search_param(el).present? }, true)
           token_with_system_search_params = search_params.merge('type': value_with_system)
           reply = get_resource_by_params(versioned_resource_class('Device'), token_with_system_search_params)
           validate_search_reply(versioned_resource_class('Device'), reply, token_with_system_search_params)

--- a/lib/modules/uscore_v3.1.1/us_core_observation_lab_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_observation_lab_sequence.rb
@@ -205,7 +205,7 @@ module Inferno
 
             next if search_query_variants_tested_once
 
-            value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category'), true)
+            value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category') { |el| get_value_for_search_param(el).present? }, true)
             token_with_system_search_params = search_params.merge('category': value_with_system)
             reply = get_resource_by_params(versioned_resource_class('Observation'), token_with_system_search_params)
             validate_search_reply(versioned_resource_class('Observation'), reply, token_with_system_search_params)
@@ -263,7 +263,7 @@ module Inferno
 
           validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
 
-          value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'code'), true)
+          value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'code') { |el| get_value_for_search_param(el).present? }, true)
           token_with_system_search_params = search_params.merge('code': value_with_system)
           reply = get_resource_by_params(versioned_resource_class('Observation'), token_with_system_search_params)
           validate_search_reply(versioned_resource_class('Observation'), reply, token_with_system_search_params)
@@ -319,7 +319,7 @@ module Inferno
             validate_search_reply(versioned_resource_class('Observation'), reply, comparator_search_params)
           end
 
-          value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category'), true)
+          value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category') { |el| get_value_for_search_param(el).present? }, true)
           token_with_system_search_params = search_params.merge('category': value_with_system)
           reply = get_resource_by_params(versioned_resource_class('Observation'), token_with_system_search_params)
           validate_search_reply(versioned_resource_class('Observation'), reply, token_with_system_search_params)
@@ -363,7 +363,7 @@ module Inferno
 
           validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
 
-          value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category'), true)
+          value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category') { |el| get_value_for_search_param(el).present? }, true)
           token_with_system_search_params = search_params.merge('category': value_with_system)
           reply = get_resource_by_params(versioned_resource_class('Observation'), token_with_system_search_params)
           validate_search_reply(versioned_resource_class('Observation'), reply, token_with_system_search_params)
@@ -420,7 +420,7 @@ module Inferno
             validate_search_reply(versioned_resource_class('Observation'), reply, comparator_search_params)
           end
 
-          value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'code'), true)
+          value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'code') { |el| get_value_for_search_param(el).present? }, true)
           token_with_system_search_params = search_params.merge('code': value_with_system)
           reply = get_resource_by_params(versioned_resource_class('Observation'), token_with_system_search_params)
           validate_search_reply(versioned_resource_class('Observation'), reply, token_with_system_search_params)

--- a/lib/modules/uscore_v3.1.1/us_core_patient_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_patient_sequence.rb
@@ -216,7 +216,7 @@ module Inferno
 
           validate_search_reply(versioned_resource_class('Patient'), reply, search_params)
 
-          value_with_system = get_value_for_search_param(resolve_element_from_path(@patient_ary[patient], 'identifier'), true)
+          value_with_system = get_value_for_search_param(resolve_element_from_path(@patient_ary[patient], 'identifier') { |el| get_value_for_search_param(el).present? }, true)
           token_with_system_search_params = search_params.merge('identifier': value_with_system)
           reply = get_resource_by_params(versioned_resource_class('Patient'), token_with_system_search_params)
           validate_search_reply(versioned_resource_class('Patient'), reply, token_with_system_search_params)

--- a/lib/modules/uscore_v3.1.1/us_core_procedure_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_procedure_sequence.rb
@@ -340,7 +340,7 @@ module Inferno
             validate_search_reply(versioned_resource_class('Procedure'), reply, comparator_search_params)
           end
 
-          value_with_system = get_value_for_search_param(resolve_element_from_path(@procedure_ary[patient], 'code'), true)
+          value_with_system = get_value_for_search_param(resolve_element_from_path(@procedure_ary[patient], 'code') { |el| get_value_for_search_param(el).present? }, true)
           token_with_system_search_params = search_params.merge('code': value_with_system)
           reply = get_resource_by_params(versioned_resource_class('Procedure'), token_with_system_search_params)
           validate_search_reply(versioned_resource_class('Procedure'), reply, token_with_system_search_params)

--- a/lib/modules/uscore_v3.1.1/us_core_pulse_oximetry_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_pulse_oximetry_sequence.rb
@@ -205,7 +205,7 @@ module Inferno
 
             next if search_query_variants_tested_once
 
-            value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'code'), true)
+            value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'code') { |el| get_value_for_search_param(el).present? }, true)
             token_with_system_search_params = search_params.merge('code': value_with_system)
             reply = get_resource_by_params(versioned_resource_class('Observation'), token_with_system_search_params)
             validate_search_reply(versioned_resource_class('Observation'), reply, token_with_system_search_params)
@@ -275,7 +275,7 @@ module Inferno
             validate_search_reply(versioned_resource_class('Observation'), reply, comparator_search_params)
           end
 
-          value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category'), true)
+          value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category') { |el| get_value_for_search_param(el).present? }, true)
           token_with_system_search_params = search_params.merge('category': value_with_system)
           reply = get_resource_by_params(versioned_resource_class('Observation'), token_with_system_search_params)
           validate_search_reply(versioned_resource_class('Observation'), reply, token_with_system_search_params)
@@ -319,7 +319,7 @@ module Inferno
 
           validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
 
-          value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category'), true)
+          value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category') { |el| get_value_for_search_param(el).present? }, true)
           token_with_system_search_params = search_params.merge('category': value_with_system)
           reply = get_resource_by_params(versioned_resource_class('Observation'), token_with_system_search_params)
           validate_search_reply(versioned_resource_class('Observation'), reply, token_with_system_search_params)
@@ -363,7 +363,7 @@ module Inferno
 
           validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
 
-          value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category'), true)
+          value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category') { |el| get_value_for_search_param(el).present? }, true)
           token_with_system_search_params = search_params.merge('category': value_with_system)
           reply = get_resource_by_params(versioned_resource_class('Observation'), token_with_system_search_params)
           validate_search_reply(versioned_resource_class('Observation'), reply, token_with_system_search_params)
@@ -420,7 +420,7 @@ module Inferno
             validate_search_reply(versioned_resource_class('Observation'), reply, comparator_search_params)
           end
 
-          value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'code'), true)
+          value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'code') { |el| get_value_for_search_param(el).present? }, true)
           token_with_system_search_params = search_params.merge('code': value_with_system)
           reply = get_resource_by_params(versioned_resource_class('Observation'), token_with_system_search_params)
           validate_search_reply(versioned_resource_class('Observation'), reply, token_with_system_search_params)

--- a/lib/modules/uscore_v3.1.1/us_core_smokingstatus_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_smokingstatus_sequence.rb
@@ -209,7 +209,7 @@ module Inferno
 
             next if search_query_variants_tested_once
 
-            value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'code'), true)
+            value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'code') { |el| get_value_for_search_param(el).present? }, true)
             token_with_system_search_params = search_params.merge('code': value_with_system)
             reply = get_resource_by_params(versioned_resource_class('Observation'), token_with_system_search_params)
             validate_search_reply(versioned_resource_class('Observation'), reply, token_with_system_search_params)


### PR DESCRIPTION
# Summary
Our searches are set up to choose which values to populate search criteria with based on data that has already been seen.  Since it is technically valid to not populate many values in the resource, including values which may be searched by, we have to ensure that we do not pick values that are null / filled with DARs.

We are doing this properly for most searches.  However, it turns out we are not doing this properly when we re-do a "code" search with the equivalent "system|code" search.  So for the first search (just by code), we locate and use a valid code, but then when we redo the search with system, our code picks up a different resource with a code not filled in, if we are unlucky.

This only occurs if the first resource returned has no code to search by, so you have to be a little unlucky for this to happen, and which is why we hadn't seen this before.  This is what the query looks like:

![Screen Shot 2021-03-08 at 9 54 32 PM](https://user-images.githubusercontent.com/412901/110412366-156fea00-805a-11eb-87f8-3612d23f263b.png)

Note the invalid search in the second request.

This addresses #248 

## New behavior

The search by system+code now will pick up the same code as the "just by code" search.  Note the valid second request now:

![Screen Shot 2021-03-08 at 9 57 28 PM](https://user-images.githubusercontent.com/412901/110412462-3fc1a780-805a-11eb-8ef0-183124851199.png)

## Code changes

The generated was updated slightly to include the same guard for picking codes that aren't filled in.

## Testing guidance

Unfortunately updating our generated unit tests to try this out seems very challenging.  I tested it manually by:

1) Running the reference server locally
2) Running Inferno's Lab Result Observation test against the reference server (I updated the onc_program_module.yml file to only include a couple of the single patient api tests to speed things up)
3) Noting which resource was returned first in USCLRO-02.
4) Since there was only one resource, I duplicated it with Postman
5) Run again, check to see which resource was returned first
6) Update the resource that was returned first to only have a "text" for "Observation.code"
7) Run again, check to make sure that the test passes
8) Revert to the old version, check to make sure that the test fails
