### PR TITLE
updated group_id value to match rebase bulk-data-server

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -158,4 +158,4 @@ presets:
     bulk_token_endpoint: https://inferno.healthit.gov/bulk-data-server/auth/token
     bulk_client_id: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6InJlZ2lzdHJhdGlvbi10b2tlbiJ9.eyJqd2tzX3VybCI6Imh0dHBzOi8vaW5mZXJuby5oZWFsdGhpdC5nb3YvaW5mZXJuby8ud2VsbC1rbm93bi9qd2tzLmpzb24iLCJhY2Nlc3NUb2tlbnNFeHBpcmVJbiI6MTUsImlhdCI6MTU5OTE1NzgyMX0.-wulnE05BlY_Zcm5iP77Meqxr6iNiYxBsOADB5CGE8I
     bulk_scope: system/*.read
-    group_id: 3d7d2344-ca49-40ac-9e1f-88b40fff3bd9
+    group_id: 1


### PR DESCRIPTION
# Summary
After rebasing the bulk-data-server to match the smart-on-fhir version, the expected group id changed to require the db id rather than the group id key. Updated preset to have the db id.

## New behavior
The preset value has changed.

## Code changes
The config file has changed.

## Testing guidance
Test using the presets on the multi-patient tests

