### PR TITLE
Exclude devices from resource count check.

### DIFF
--- a/lib/modules/uscore_v3.1.1/bodyheight_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/bodyheight_sequence.rb
@@ -217,6 +217,7 @@ module Inferno
 
             assert_response_ok(reply)
             assert_bundle_response(reply)
+
             search_with_type = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
             search_with_type.select! { |resource| resource.resourceType == 'Observation' }
             assert search_with_type.length == resources_returned.length, 'Expected search by Patient/ID to have the same results as search by ID'

--- a/lib/modules/uscore_v3.1.1/bodytemp_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/bodytemp_sequence.rb
@@ -217,6 +217,7 @@ module Inferno
 
             assert_response_ok(reply)
             assert_bundle_response(reply)
+
             search_with_type = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
             search_with_type.select! { |resource| resource.resourceType == 'Observation' }
             assert search_with_type.length == resources_returned.length, 'Expected search by Patient/ID to have the same results as search by ID'

--- a/lib/modules/uscore_v3.1.1/bodyweight_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/bodyweight_sequence.rb
@@ -217,6 +217,7 @@ module Inferno
 
             assert_response_ok(reply)
             assert_bundle_response(reply)
+
             search_with_type = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
             search_with_type.select! { |resource| resource.resourceType == 'Observation' }
             assert search_with_type.length == resources_returned.length, 'Expected search by Patient/ID to have the same results as search by ID'

--- a/lib/modules/uscore_v3.1.1/bp_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/bp_sequence.rb
@@ -217,6 +217,7 @@ module Inferno
 
             assert_response_ok(reply)
             assert_bundle_response(reply)
+
             search_with_type = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
             search_with_type.select! { |resource| resource.resourceType == 'Observation' }
             assert search_with_type.length == resources_returned.length, 'Expected search by Patient/ID to have the same results as search by ID'

--- a/lib/modules/uscore_v3.1.1/head_occipital_frontal_circumference_percentile_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/head_occipital_frontal_circumference_percentile_sequence.rb
@@ -217,6 +217,7 @@ module Inferno
 
             assert_response_ok(reply)
             assert_bundle_response(reply)
+
             search_with_type = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
             search_with_type.select! { |resource| resource.resourceType == 'Observation' }
             assert search_with_type.length == resources_returned.length, 'Expected search by Patient/ID to have the same results as search by ID'

--- a/lib/modules/uscore_v3.1.1/heartrate_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/heartrate_sequence.rb
@@ -217,6 +217,7 @@ module Inferno
 
             assert_response_ok(reply)
             assert_bundle_response(reply)
+
             search_with_type = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
             search_with_type.select! { |resource| resource.resourceType == 'Observation' }
             assert search_with_type.length == resources_returned.length, 'Expected search by Patient/ID to have the same results as search by ID'

--- a/lib/modules/uscore_v3.1.1/pediatric_bmi_for_age_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/pediatric_bmi_for_age_sequence.rb
@@ -217,6 +217,7 @@ module Inferno
 
             assert_response_ok(reply)
             assert_bundle_response(reply)
+
             search_with_type = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
             search_with_type.select! { |resource| resource.resourceType == 'Observation' }
             assert search_with_type.length == resources_returned.length, 'Expected search by Patient/ID to have the same results as search by ID'

--- a/lib/modules/uscore_v3.1.1/pediatric_weight_for_height_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/pediatric_weight_for_height_sequence.rb
@@ -217,6 +217,7 @@ module Inferno
 
             assert_response_ok(reply)
             assert_bundle_response(reply)
+
             search_with_type = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
             search_with_type.select! { |resource| resource.resourceType == 'Observation' }
             assert search_with_type.length == resources_returned.length, 'Expected search by Patient/ID to have the same results as search by ID'

--- a/lib/modules/uscore_v3.1.1/resprate_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/resprate_sequence.rb
@@ -217,6 +217,7 @@ module Inferno
 
             assert_response_ok(reply)
             assert_bundle_response(reply)
+
             search_with_type = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
             search_with_type.select! { |resource| resource.resourceType == 'Observation' }
             assert search_with_type.length == resources_returned.length, 'Expected search by Patient/ID to have the same results as search by ID'

--- a/lib/modules/uscore_v3.1.1/us_core_allergyintolerance_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_allergyintolerance_sequence.rb
@@ -184,6 +184,7 @@ module Inferno
           reply = get_resource_by_params(versioned_resource_class('AllergyIntolerance'), search_params)
           assert_response_ok(reply)
           assert_bundle_response(reply)
+
           search_with_type = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
           search_with_type.select! { |resource| resource.resourceType == 'AllergyIntolerance' }
           assert search_with_type.length == @allergy_intolerance_ary[patient].length, 'Expected search by Patient/ID to have the same results as search by ID'

--- a/lib/modules/uscore_v3.1.1/us_core_careplan_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_careplan_sequence.rb
@@ -202,6 +202,7 @@ module Inferno
 
             assert_response_ok(reply)
             assert_bundle_response(reply)
+
             search_with_type = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
             search_with_type.select! { |resource| resource.resourceType == 'CarePlan' }
             assert search_with_type.length == resources_returned.length, 'Expected search by Patient/ID to have the same results as search by ID'

--- a/lib/modules/uscore_v3.1.1/us_core_careteam_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_careteam_sequence.rb
@@ -175,6 +175,7 @@ module Inferno
 
             assert_response_ok(reply)
             assert_bundle_response(reply)
+
             search_with_type = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
             search_with_type.select! { |resource| resource.resourceType == 'CareTeam' }
             assert search_with_type.length == resources_returned.length, 'Expected search by Patient/ID to have the same results as search by ID'

--- a/lib/modules/uscore_v3.1.1/us_core_condition_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_condition_sequence.rb
@@ -215,6 +215,7 @@ module Inferno
           reply = get_resource_by_params(versioned_resource_class('Condition'), search_params)
           assert_response_ok(reply)
           assert_bundle_response(reply)
+
           search_with_type = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
           search_with_type.select! { |resource| resource.resourceType == 'Condition' }
           assert search_with_type.length == @condition_ary[patient].length, 'Expected search by Patient/ID to have the same results as search by ID'

--- a/lib/modules/uscore_v3.1.1/us_core_diagnosticreport_lab_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_diagnosticreport_lab_sequence.rb
@@ -220,6 +220,7 @@ module Inferno
 
             assert_response_ok(reply)
             assert_bundle_response(reply)
+
             search_with_type = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
             search_with_type.select! { |resource| resource.resourceType == 'DiagnosticReport' }
             assert search_with_type.length == resources_returned.length, 'Expected search by Patient/ID to have the same results as search by ID'

--- a/lib/modules/uscore_v3.1.1/us_core_diagnosticreport_note_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_diagnosticreport_note_sequence.rb
@@ -220,6 +220,7 @@ module Inferno
 
             assert_response_ok(reply)
             assert_bundle_response(reply)
+
             search_with_type = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
             search_with_type.select! { |resource| resource.resourceType == 'DiagnosticReport' }
             assert search_with_type.length == resources_returned.length, 'Expected search by Patient/ID to have the same results as search by ID'

--- a/lib/modules/uscore_v3.1.1/us_core_documentreference_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_documentreference_sequence.rb
@@ -224,6 +224,7 @@ module Inferno
           reply = get_resource_by_params(versioned_resource_class('DocumentReference'), search_params)
           assert_response_ok(reply)
           assert_bundle_response(reply)
+
           search_with_type = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
           search_with_type.select! { |resource| resource.resourceType == 'DocumentReference' }
           assert search_with_type.length == @document_reference_ary[patient].length, 'Expected search by Patient/ID to have the same results as search by ID'

--- a/lib/modules/uscore_v3.1.1/us_core_goal_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_goal_sequence.rb
@@ -182,6 +182,7 @@ module Inferno
           reply = get_resource_by_params(versioned_resource_class('Goal'), search_params)
           assert_response_ok(reply)
           assert_bundle_response(reply)
+
           search_with_type = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
           search_with_type.select! { |resource| resource.resourceType == 'Goal' }
           assert search_with_type.length == @goal_ary[patient].length, 'Expected search by Patient/ID to have the same results as search by ID'

--- a/lib/modules/uscore_v3.1.1/us_core_immunization_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_immunization_sequence.rb
@@ -182,6 +182,7 @@ module Inferno
           reply = get_resource_by_params(versioned_resource_class('Immunization'), search_params)
           assert_response_ok(reply)
           assert_bundle_response(reply)
+
           search_with_type = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
           search_with_type.select! { |resource| resource.resourceType == 'Immunization' }
           assert search_with_type.length == @immunization_ary[patient].length, 'Expected search by Patient/ID to have the same results as search by ID'

--- a/lib/modules/uscore_v3.1.1/us_core_implantable_device_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_implantable_device_sequence.rb
@@ -163,9 +163,6 @@ module Inferno
           reply = get_resource_by_params(versioned_resource_class('Device'), search_params)
           assert_response_ok(reply)
           assert_bundle_response(reply)
-          search_with_type = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
-          search_with_type.select! { |resource| resource.resourceType == 'Device' }
-          assert search_with_type.length == @device_ary[patient].length, 'Expected search by Patient/ID to have the same results as search by ID'
         end
 
         skip_if_not_found(resource_type: 'Device', delayed: false)

--- a/lib/modules/uscore_v3.1.1/us_core_medicationrequest_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_medicationrequest_sequence.rb
@@ -232,6 +232,7 @@ module Inferno
 
             assert_response_ok(reply)
             assert_bundle_response(reply)
+
             search_with_type = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
             search_with_type.select! { |resource| resource.resourceType == 'MedicationRequest' }
             assert search_with_type.length == resources_returned.length, 'Expected search by Patient/ID to have the same results as search by ID'

--- a/lib/modules/uscore_v3.1.1/us_core_observation_lab_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_observation_lab_sequence.rb
@@ -217,6 +217,7 @@ module Inferno
 
             assert_response_ok(reply)
             assert_bundle_response(reply)
+
             search_with_type = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
             search_with_type.select! { |resource| resource.resourceType == 'Observation' }
             assert search_with_type.length == resources_returned.length, 'Expected search by Patient/ID to have the same results as search by ID'

--- a/lib/modules/uscore_v3.1.1/us_core_procedure_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_procedure_sequence.rb
@@ -196,6 +196,7 @@ module Inferno
           reply = get_resource_by_params(versioned_resource_class('Procedure'), search_params)
           assert_response_ok(reply)
           assert_bundle_response(reply)
+
           search_with_type = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
           search_with_type.select! { |resource| resource.resourceType == 'Procedure' }
           assert search_with_type.length == @procedure_ary[patient].length, 'Expected search by Patient/ID to have the same results as search by ID'

--- a/lib/modules/uscore_v3.1.1/us_core_pulse_oximetry_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_pulse_oximetry_sequence.rb
@@ -217,6 +217,7 @@ module Inferno
 
             assert_response_ok(reply)
             assert_bundle_response(reply)
+
             search_with_type = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
             search_with_type.select! { |resource| resource.resourceType == 'Observation' }
             assert search_with_type.length == resources_returned.length, 'Expected search by Patient/ID to have the same results as search by ID'

--- a/lib/modules/uscore_v3.1.1/us_core_smokingstatus_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_smokingstatus_sequence.rb
@@ -221,6 +221,7 @@ module Inferno
 
             assert_response_ok(reply)
             assert_bundle_response(reply)
+
             search_with_type = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
             search_with_type.select! { |resource| resource.resourceType == 'Observation' }
             assert search_with_type.length == resources_returned.length, 'Expected search by Patient/ID to have the same results as search by ID'


### PR DESCRIPTION
# Summary

The first search in each US Core profile sequence check both the `patient=Patient/id` and `patient=id` search variants to make sure there are the same number of results for each variant.  In the case of devices, we have special logic to filter out results that are non-implantable if a user specifies to exclude all but certain device types.  The tests do not apply the filter to both of the search variants, so if you include a code that actually filters the device results, the test will fail.

## New behavior

Because the logic to check for devices requires a couple of lines of code, and because there isn't much value thoroughly checking this search option for each profile, this fix simply excludes checking that both variants return the same number of results for the Implantable Device profile.  Instead, just for Device resource types, returning a Bundle and a 200OK is sufficient.  Adding even more complex code to handle this case in the generator does not seem worth the extra complexity.

## Code changes

Updated the generator, which causes just the Device profile to exclude the result equality check.  An empty space is added to the other profiles, because getting that removed would be challenging.

## Testing guidance

1) For ease of testing, I suggest removing all but CapabilityStatement and ImplantableDevice tests in onc_program_module.yml.
2) For the old/existing single patient api tests against the inferno.healthit.gov/reference-server preset, put in anything in the code field to filter out all device types (e.g. 'ABC').  It should fail instead of skipping.
3) For the new tests, it should skip when you put in an invalid code.  It should also pass when you leave it blank, or put in a valid code (`72506001` is valid)