### PR TITLE
Allows additional value in response's content-type

### DIFF
--- a/lib/modules/onc_program/bulk_data_group_validation_sequence.rb
+++ b/lib/modules/onc_program/bulk_data_group_validation_sequence.rb
@@ -106,7 +106,7 @@ module Inferno
         }
 
         streamed_ndjson_get(file['url'], headers) do |response, resource|
-          assert response.header['Content-Type'].include?('application/fhir+ndjson'), "Content type must have 'application/fhir+ndjson' but found '#{response.header['Content-type']}'"
+          assert response.header['Content-Type']&.include?('application/fhir+ndjson'), "Content type must have 'application/fhir+ndjson' but found '#{response.header['Content-type']}'"
 
           break if !validate_all && line_count >= lines_to_validate && (klass != 'Patient' || @patient_ids_seen.length >= MIN_RESOURCE_COUNT)
 

--- a/lib/modules/onc_program/bulk_data_group_validation_sequence.rb
+++ b/lib/modules/onc_program/bulk_data_group_validation_sequence.rb
@@ -106,7 +106,7 @@ module Inferno
         }
 
         streamed_ndjson_get(file['url'], headers) do |response, resource|
-          assert response.header['Content-Type']&.include?('application/fhir+ndjson'), "Content type must have 'application/fhir+ndjson' but found '#{response.header['Content-type']}'"
+          assert response.header['Content-Type']&.start_with?('application/fhir+ndjson'), "Content type must have 'application/fhir+ndjson' but found '#{response.header['Content-type']}'"
 
           break if !validate_all && line_count >= lines_to_validate && (klass != 'Patient' || @patient_ids_seen.length >= MIN_RESOURCE_COUNT)
 

--- a/lib/modules/onc_program/bulk_data_group_validation_sequence.rb
+++ b/lib/modules/onc_program/bulk_data_group_validation_sequence.rb
@@ -106,7 +106,7 @@ module Inferno
         }
 
         streamed_ndjson_get(file['url'], headers) do |response, resource|
-          assert response.header['Content-Type'] == 'application/fhir+ndjson', "Content type must be 'application/fhir+ndjson' but is '#{response.header['Content-type']}'"
+          assert response.header['Content-Type'].include?('application/fhir+ndjson'), "Content type must have 'application/fhir+ndjson' but found '#{response.header['Content-type']}'"
 
           break if !validate_all && line_count >= lines_to_validate && (klass != 'Patient' || @patient_ids_seen.length >= MIN_RESOURCE_COUNT)
 


### PR DESCRIPTION
# Summary
Allow additional values in response's content-type header

## New behavior
After receiving response for file download request, Inferno checks if response's content-type header contains application/fhir+ndjson

## Code changes
bulk_data_group_validation_sequence: change string compare to string include
add unit test for content-type header with multiple values

## Testing guidance
