### PR TITLE
FI-1215 Skip search with patient id if patient does not exist

### DIFF
--- a/lib/modules/uscore_v3.1.1/bodyheight_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/bodyheight_sequence.rb
@@ -284,6 +284,8 @@ module Inferno
         resolved_one = false
 
         patient_ids.each do |patient|
+          next unless @observation_ary[patient].present?
+
           search_params = {
             'patient': patient,
             'category': get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category') { |el| get_value_for_search_param(el).present? }),
@@ -336,6 +338,8 @@ module Inferno
         resolved_one = false
 
         patient_ids.each do |patient|
+          next unless @observation_ary[patient].present?
+
           search_params = {
             'patient': patient,
             'category': get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category') { |el| get_value_for_search_param(el).present? })
@@ -381,6 +385,8 @@ module Inferno
         resolved_one = false
 
         patient_ids.each do |patient|
+          next unless @observation_ary[patient].present?
+
           search_params = {
             'patient': patient,
             'category': get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category') { |el| get_value_for_search_param(el).present? }),
@@ -429,6 +435,8 @@ module Inferno
         resolved_one = false
 
         patient_ids.each do |patient|
+          next unless @observation_ary[patient].present?
+
           search_params = {
             'patient': patient,
             'code': get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'code') { |el| get_value_for_search_param(el).present? }),

--- a/lib/modules/uscore_v3.1.1/bodytemp_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/bodytemp_sequence.rb
@@ -284,6 +284,8 @@ module Inferno
         resolved_one = false
 
         patient_ids.each do |patient|
+          next unless @observation_ary[patient].present?
+
           search_params = {
             'patient': patient,
             'category': get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category') { |el| get_value_for_search_param(el).present? }),
@@ -336,6 +338,8 @@ module Inferno
         resolved_one = false
 
         patient_ids.each do |patient|
+          next unless @observation_ary[patient].present?
+
           search_params = {
             'patient': patient,
             'category': get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category') { |el| get_value_for_search_param(el).present? })
@@ -381,6 +385,8 @@ module Inferno
         resolved_one = false
 
         patient_ids.each do |patient|
+          next unless @observation_ary[patient].present?
+
           search_params = {
             'patient': patient,
             'category': get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category') { |el| get_value_for_search_param(el).present? }),
@@ -429,6 +435,8 @@ module Inferno
         resolved_one = false
 
         patient_ids.each do |patient|
+          next unless @observation_ary[patient].present?
+
           search_params = {
             'patient': patient,
             'code': get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'code') { |el| get_value_for_search_param(el).present? }),

--- a/lib/modules/uscore_v3.1.1/bodyweight_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/bodyweight_sequence.rb
@@ -284,6 +284,8 @@ module Inferno
         resolved_one = false
 
         patient_ids.each do |patient|
+          next unless @observation_ary[patient].present?
+
           search_params = {
             'patient': patient,
             'category': get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category') { |el| get_value_for_search_param(el).present? }),
@@ -336,6 +338,8 @@ module Inferno
         resolved_one = false
 
         patient_ids.each do |patient|
+          next unless @observation_ary[patient].present?
+
           search_params = {
             'patient': patient,
             'category': get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category') { |el| get_value_for_search_param(el).present? })
@@ -381,6 +385,8 @@ module Inferno
         resolved_one = false
 
         patient_ids.each do |patient|
+          next unless @observation_ary[patient].present?
+
           search_params = {
             'patient': patient,
             'category': get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category') { |el| get_value_for_search_param(el).present? }),
@@ -429,6 +435,8 @@ module Inferno
         resolved_one = false
 
         patient_ids.each do |patient|
+          next unless @observation_ary[patient].present?
+
           search_params = {
             'patient': patient,
             'code': get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'code') { |el| get_value_for_search_param(el).present? }),

--- a/lib/modules/uscore_v3.1.1/bp_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/bp_sequence.rb
@@ -284,6 +284,8 @@ module Inferno
         resolved_one = false
 
         patient_ids.each do |patient|
+          next unless @observation_ary[patient].present?
+
           search_params = {
             'patient': patient,
             'category': get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category') { |el| get_value_for_search_param(el).present? }),
@@ -336,6 +338,8 @@ module Inferno
         resolved_one = false
 
         patient_ids.each do |patient|
+          next unless @observation_ary[patient].present?
+
           search_params = {
             'patient': patient,
             'category': get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category') { |el| get_value_for_search_param(el).present? })
@@ -381,6 +385,8 @@ module Inferno
         resolved_one = false
 
         patient_ids.each do |patient|
+          next unless @observation_ary[patient].present?
+
           search_params = {
             'patient': patient,
             'category': get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category') { |el| get_value_for_search_param(el).present? }),
@@ -429,6 +435,8 @@ module Inferno
         resolved_one = false
 
         patient_ids.each do |patient|
+          next unless @observation_ary[patient].present?
+
           search_params = {
             'patient': patient,
             'code': get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'code') { |el| get_value_for_search_param(el).present? }),

--- a/lib/modules/uscore_v3.1.1/head_occipital_frontal_circumference_percentile_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/head_occipital_frontal_circumference_percentile_sequence.rb
@@ -284,6 +284,8 @@ module Inferno
         resolved_one = false
 
         patient_ids.each do |patient|
+          next unless @observation_ary[patient].present?
+
           search_params = {
             'patient': patient,
             'category': get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category') { |el| get_value_for_search_param(el).present? }),
@@ -336,6 +338,8 @@ module Inferno
         resolved_one = false
 
         patient_ids.each do |patient|
+          next unless @observation_ary[patient].present?
+
           search_params = {
             'patient': patient,
             'category': get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category') { |el| get_value_for_search_param(el).present? })
@@ -381,6 +385,8 @@ module Inferno
         resolved_one = false
 
         patient_ids.each do |patient|
+          next unless @observation_ary[patient].present?
+
           search_params = {
             'patient': patient,
             'category': get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category') { |el| get_value_for_search_param(el).present? }),
@@ -429,6 +435,8 @@ module Inferno
         resolved_one = false
 
         patient_ids.each do |patient|
+          next unless @observation_ary[patient].present?
+
           search_params = {
             'patient': patient,
             'code': get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'code') { |el| get_value_for_search_param(el).present? }),

--- a/lib/modules/uscore_v3.1.1/heartrate_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/heartrate_sequence.rb
@@ -284,6 +284,8 @@ module Inferno
         resolved_one = false
 
         patient_ids.each do |patient|
+          next unless @observation_ary[patient].present?
+
           search_params = {
             'patient': patient,
             'category': get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category') { |el| get_value_for_search_param(el).present? }),
@@ -336,6 +338,8 @@ module Inferno
         resolved_one = false
 
         patient_ids.each do |patient|
+          next unless @observation_ary[patient].present?
+
           search_params = {
             'patient': patient,
             'category': get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category') { |el| get_value_for_search_param(el).present? })
@@ -381,6 +385,8 @@ module Inferno
         resolved_one = false
 
         patient_ids.each do |patient|
+          next unless @observation_ary[patient].present?
+
           search_params = {
             'patient': patient,
             'category': get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category') { |el| get_value_for_search_param(el).present? }),
@@ -429,6 +435,8 @@ module Inferno
         resolved_one = false
 
         patient_ids.each do |patient|
+          next unless @observation_ary[patient].present?
+
           search_params = {
             'patient': patient,
             'code': get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'code') { |el| get_value_for_search_param(el).present? }),

--- a/lib/modules/uscore_v3.1.1/pediatric_bmi_for_age_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/pediatric_bmi_for_age_sequence.rb
@@ -284,6 +284,8 @@ module Inferno
         resolved_one = false
 
         patient_ids.each do |patient|
+          next unless @observation_ary[patient].present?
+
           search_params = {
             'patient': patient,
             'category': get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category') { |el| get_value_for_search_param(el).present? }),
@@ -336,6 +338,8 @@ module Inferno
         resolved_one = false
 
         patient_ids.each do |patient|
+          next unless @observation_ary[patient].present?
+
           search_params = {
             'patient': patient,
             'category': get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category') { |el| get_value_for_search_param(el).present? })
@@ -381,6 +385,8 @@ module Inferno
         resolved_one = false
 
         patient_ids.each do |patient|
+          next unless @observation_ary[patient].present?
+
           search_params = {
             'patient': patient,
             'category': get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category') { |el| get_value_for_search_param(el).present? }),
@@ -429,6 +435,8 @@ module Inferno
         resolved_one = false
 
         patient_ids.each do |patient|
+          next unless @observation_ary[patient].present?
+
           search_params = {
             'patient': patient,
             'code': get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'code') { |el| get_value_for_search_param(el).present? }),

--- a/lib/modules/uscore_v3.1.1/pediatric_weight_for_height_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/pediatric_weight_for_height_sequence.rb
@@ -284,6 +284,8 @@ module Inferno
         resolved_one = false
 
         patient_ids.each do |patient|
+          next unless @observation_ary[patient].present?
+
           search_params = {
             'patient': patient,
             'category': get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category') { |el| get_value_for_search_param(el).present? }),
@@ -336,6 +338,8 @@ module Inferno
         resolved_one = false
 
         patient_ids.each do |patient|
+          next unless @observation_ary[patient].present?
+
           search_params = {
             'patient': patient,
             'category': get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category') { |el| get_value_for_search_param(el).present? })
@@ -381,6 +385,8 @@ module Inferno
         resolved_one = false
 
         patient_ids.each do |patient|
+          next unless @observation_ary[patient].present?
+
           search_params = {
             'patient': patient,
             'category': get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category') { |el| get_value_for_search_param(el).present? }),
@@ -429,6 +435,8 @@ module Inferno
         resolved_one = false
 
         patient_ids.each do |patient|
+          next unless @observation_ary[patient].present?
+
           search_params = {
             'patient': patient,
             'code': get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'code') { |el| get_value_for_search_param(el).present? }),

--- a/lib/modules/uscore_v3.1.1/resprate_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/resprate_sequence.rb
@@ -284,6 +284,8 @@ module Inferno
         resolved_one = false
 
         patient_ids.each do |patient|
+          next unless @observation_ary[patient].present?
+
           search_params = {
             'patient': patient,
             'category': get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category') { |el| get_value_for_search_param(el).present? }),
@@ -336,6 +338,8 @@ module Inferno
         resolved_one = false
 
         patient_ids.each do |patient|
+          next unless @observation_ary[patient].present?
+
           search_params = {
             'patient': patient,
             'category': get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category') { |el| get_value_for_search_param(el).present? })
@@ -381,6 +385,8 @@ module Inferno
         resolved_one = false
 
         patient_ids.each do |patient|
+          next unless @observation_ary[patient].present?
+
           search_params = {
             'patient': patient,
             'category': get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category') { |el| get_value_for_search_param(el).present? }),
@@ -429,6 +435,8 @@ module Inferno
         resolved_one = false
 
         patient_ids.each do |patient|
+          next unless @observation_ary[patient].present?
+
           search_params = {
             'patient': patient,
             'code': get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'code') { |el| get_value_for_search_param(el).present? }),

--- a/lib/modules/uscore_v3.1.1/us_core_allergyintolerance_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_allergyintolerance_sequence.rb
@@ -238,6 +238,8 @@ module Inferno
         resolved_one = false
 
         patient_ids.each do |patient|
+          next unless @allergy_intolerance_ary[patient].present?
+
           search_params = {
             'patient': patient,
             'clinical-status': get_value_for_search_param(resolve_element_from_path(@allergy_intolerance_ary[patient], 'clinicalStatus') { |el| get_value_for_search_param(el).present? })

--- a/lib/modules/uscore_v3.1.1/us_core_careplan_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_careplan_sequence.rb
@@ -266,6 +266,8 @@ module Inferno
         resolved_one = false
 
         patient_ids.each do |patient|
+          next unless @care_plan_ary[patient].present?
+
           search_params = {
             'patient': patient,
             'category': get_value_for_search_param(resolve_element_from_path(@care_plan_ary[patient], 'category') { |el| get_value_for_search_param(el).present? }),

--- a/lib/modules/uscore_v3.1.1/us_core_condition_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_condition_sequence.rb
@@ -269,6 +269,8 @@ module Inferno
         resolved_one = false
 
         patient_ids.each do |patient|
+          next unless @condition_ary[patient].present?
+
           search_params = {
             'patient': patient,
             'category': get_value_for_search_param(resolve_element_from_path(@condition_ary[patient], 'category') { |el| get_value_for_search_param(el).present? })
@@ -314,6 +316,8 @@ module Inferno
         resolved_one = false
 
         patient_ids.each do |patient|
+          next unless @condition_ary[patient].present?
+
           search_params = {
             'patient': patient,
             'clinical-status': get_value_for_search_param(resolve_element_from_path(@condition_ary[patient], 'clinicalStatus') { |el| get_value_for_search_param(el).present? })
@@ -357,6 +361,8 @@ module Inferno
         resolved_one = false
 
         patient_ids.each do |patient|
+          next unless @condition_ary[patient].present?
+
           search_params = {
             'patient': patient,
             'code': get_value_for_search_param(resolve_element_from_path(@condition_ary[patient], 'code') { |el| get_value_for_search_param(el).present? })

--- a/lib/modules/uscore_v3.1.1/us_core_diagnosticreport_lab_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_diagnosticreport_lab_sequence.rb
@@ -281,6 +281,8 @@ module Inferno
         skip_if_not_found(resource_type: 'DiagnosticReport', delayed: false)
 
         patient_ids.each do |patient|
+          next unless @diagnostic_report_ary[patient].present?
+
           search_params = {
             'patient': patient
           }
@@ -317,6 +319,8 @@ module Inferno
         resolved_one = false
 
         patient_ids.each do |patient|
+          next unless @diagnostic_report_ary[patient].present?
+
           search_params = {
             'patient': patient,
             'category': get_value_for_search_param(resolve_element_from_path(@diagnostic_report_ary[patient], 'category') { |el| get_value_for_search_param(el).present? }),
@@ -369,6 +373,8 @@ module Inferno
         resolved_one = false
 
         patient_ids.each do |patient|
+          next unless @diagnostic_report_ary[patient].present?
+
           search_params = {
             'patient': patient,
             'code': get_value_for_search_param(resolve_element_from_path(@diagnostic_report_ary[patient], 'code') { |el| get_value_for_search_param(el).present? })
@@ -414,6 +420,8 @@ module Inferno
         resolved_one = false
 
         patient_ids.each do |patient|
+          next unless @diagnostic_report_ary[patient].present?
+
           search_params = {
             'patient': patient,
             'status': get_value_for_search_param(resolve_element_from_path(@diagnostic_report_ary[patient], 'status') { |el| get_value_for_search_param(el).present? })
@@ -456,6 +464,8 @@ module Inferno
         resolved_one = false
 
         patient_ids.each do |patient|
+          next unless @diagnostic_report_ary[patient].present?
+
           search_params = {
             'patient': patient,
             'code': get_value_for_search_param(resolve_element_from_path(@diagnostic_report_ary[patient], 'code') { |el| get_value_for_search_param(el).present? }),

--- a/lib/modules/uscore_v3.1.1/us_core_diagnosticreport_note_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_diagnosticreport_note_sequence.rb
@@ -281,6 +281,8 @@ module Inferno
         skip_if_not_found(resource_type: 'DiagnosticReport', delayed: false)
 
         patient_ids.each do |patient|
+          next unless @diagnostic_report_ary[patient].present?
+
           search_params = {
             'patient': patient
           }
@@ -317,6 +319,8 @@ module Inferno
         resolved_one = false
 
         patient_ids.each do |patient|
+          next unless @diagnostic_report_ary[patient].present?
+
           search_params = {
             'patient': patient,
             'category': get_value_for_search_param(resolve_element_from_path(@diagnostic_report_ary[patient], 'category') { |el| get_value_for_search_param(el).present? }),
@@ -369,6 +373,8 @@ module Inferno
         resolved_one = false
 
         patient_ids.each do |patient|
+          next unless @diagnostic_report_ary[patient].present?
+
           search_params = {
             'patient': patient,
             'code': get_value_for_search_param(resolve_element_from_path(@diagnostic_report_ary[patient], 'code') { |el| get_value_for_search_param(el).present? })
@@ -414,6 +420,8 @@ module Inferno
         resolved_one = false
 
         patient_ids.each do |patient|
+          next unless @diagnostic_report_ary[patient].present?
+
           search_params = {
             'patient': patient,
             'status': get_value_for_search_param(resolve_element_from_path(@diagnostic_report_ary[patient], 'status') { |el| get_value_for_search_param(el).present? })
@@ -456,6 +464,8 @@ module Inferno
         resolved_one = false
 
         patient_ids.each do |patient|
+          next unless @diagnostic_report_ary[patient].present?
+
           search_params = {
             'patient': patient,
             'code': get_value_for_search_param(resolve_element_from_path(@diagnostic_report_ary[patient], 'code') { |el| get_value_for_search_param(el).present? }),

--- a/lib/modules/uscore_v3.1.1/us_core_documentreference_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_documentreference_sequence.rb
@@ -315,6 +315,8 @@ module Inferno
         resolved_one = false
 
         patient_ids.each do |patient|
+          next unless @document_reference_ary[patient].present?
+
           search_params = {
             'patient': patient,
             'type': get_value_for_search_param(resolve_element_from_path(@document_reference_ary[patient], 'type') { |el| get_value_for_search_param(el).present? })
@@ -363,6 +365,8 @@ module Inferno
         resolved_one = false
 
         patient_ids.each do |patient|
+          next unless @document_reference_ary[patient].present?
+
           search_params = {
             'patient': patient,
             'category': get_value_for_search_param(resolve_element_from_path(@document_reference_ary[patient], 'category') { |el| get_value_for_search_param(el).present? }),
@@ -408,6 +412,8 @@ module Inferno
         resolved_one = false
 
         patient_ids.each do |patient|
+          next unless @document_reference_ary[patient].present?
+
           search_params = {
             'patient': patient,
             'category': get_value_for_search_param(resolve_element_from_path(@document_reference_ary[patient], 'category') { |el| get_value_for_search_param(el).present? })
@@ -457,6 +463,8 @@ module Inferno
         resolved_one = false
 
         patient_ids.each do |patient|
+          next unless @document_reference_ary[patient].present?
+
           search_params = {
             'patient': patient,
             'type': get_value_for_search_param(resolve_element_from_path(@document_reference_ary[patient], 'type') { |el| get_value_for_search_param(el).present? }),
@@ -510,6 +518,8 @@ module Inferno
         resolved_one = false
 
         patient_ids.each do |patient|
+          next unless @document_reference_ary[patient].present?
+
           search_params = {
             'patient': patient,
             'status': get_value_for_search_param(resolve_element_from_path(@document_reference_ary[patient], 'status') { |el| get_value_for_search_param(el).present? })

--- a/lib/modules/uscore_v3.1.1/us_core_goal_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_goal_sequence.rb
@@ -236,6 +236,8 @@ module Inferno
         resolved_one = false
 
         patient_ids.each do |patient|
+          next unless @goal_ary[patient].present?
+
           search_params = {
             'patient': patient,
             'lifecycle-status': get_value_for_search_param(resolve_element_from_path(@goal_ary[patient], 'lifecycleStatus') { |el| get_value_for_search_param(el).present? })

--- a/lib/modules/uscore_v3.1.1/us_core_immunization_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_immunization_sequence.rb
@@ -240,6 +240,8 @@ module Inferno
         resolved_one = false
 
         patient_ids.each do |patient|
+          next unless @immunization_ary[patient].present?
+
           search_params = {
             'patient': patient,
             'date': get_value_for_search_param(resolve_element_from_path(@immunization_ary[patient], 'occurrence') { |el| get_value_for_search_param(el).present? })
@@ -287,6 +289,8 @@ module Inferno
         resolved_one = false
 
         patient_ids.each do |patient|
+          next unless @immunization_ary[patient].present?
+
           search_params = {
             'patient': patient,
             'status': get_value_for_search_param(resolve_element_from_path(@immunization_ary[patient], 'status') { |el| get_value_for_search_param(el).present? })

--- a/lib/modules/uscore_v3.1.1/us_core_implantable_device_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_implantable_device_sequence.rb
@@ -209,6 +209,8 @@ module Inferno
         resolved_one = false
 
         patient_ids.each do |patient|
+          next unless @device_ary[patient].present?
+
           search_params = {
             'patient': patient,
             'type': get_value_for_search_param(resolve_element_from_path(@device_ary[patient], 'type') { |el| get_value_for_search_param(el).present? })

--- a/lib/modules/uscore_v3.1.1/us_core_medicationrequest_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_medicationrequest_sequence.rb
@@ -301,6 +301,8 @@ module Inferno
         resolved_one = false
 
         patient_ids.each do |patient|
+          next unless @medication_request_ary[patient].present?
+
           search_params = {
             'patient': patient,
             'intent': get_value_for_search_param(resolve_element_from_path(@medication_request_ary[patient], 'intent') { |el| get_value_for_search_param(el).present? }),
@@ -350,6 +352,8 @@ module Inferno
         resolved_one = false
 
         patient_ids.each do |patient|
+          next unless @medication_request_ary[patient].present?
+
           search_params = {
             'patient': patient,
             'intent': get_value_for_search_param(resolve_element_from_path(@medication_request_ary[patient], 'intent') { |el| get_value_for_search_param(el).present? }),
@@ -405,6 +409,8 @@ module Inferno
         resolved_one = false
 
         patient_ids.each do |patient|
+          next unless @medication_request_ary[patient].present?
+
           search_params = {
             'patient': patient,
             'intent': get_value_for_search_param(resolve_element_from_path(@medication_request_ary[patient], 'intent') { |el| get_value_for_search_param(el).present? }),
@@ -719,6 +725,8 @@ module Inferno
 
         found_second_val = false
         patient_ids.each do |patient|
+          next unless @medication_request_ary[patient].present?
+
           search_params = {
             'patient': patient,
             'intent': get_value_for_search_param(resolve_element_from_path(@medication_request_ary[patient], 'intent') { |el| get_value_for_search_param(el).present? }),

--- a/lib/modules/uscore_v3.1.1/us_core_observation_lab_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_observation_lab_sequence.rb
@@ -280,6 +280,8 @@ module Inferno
         resolved_one = false
 
         patient_ids.each do |patient|
+          next unless @observation_ary[patient].present?
+
           search_params = {
             'patient': patient,
             'code': get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'code') { |el| get_value_for_search_param(el).present? })
@@ -328,6 +330,8 @@ module Inferno
         resolved_one = false
 
         patient_ids.each do |patient|
+          next unless @observation_ary[patient].present?
+
           search_params = {
             'patient': patient,
             'category': get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category') { |el| get_value_for_search_param(el).present? }),
@@ -381,6 +385,8 @@ module Inferno
         resolved_one = false
 
         patient_ids.each do |patient|
+          next unless @observation_ary[patient].present?
+
           search_params = {
             'patient': patient,
             'category': get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category') { |el| get_value_for_search_param(el).present? }),
@@ -429,6 +435,8 @@ module Inferno
         resolved_one = false
 
         patient_ids.each do |patient|
+          next unless @observation_ary[patient].present?
+
           search_params = {
             'patient': patient,
             'code': get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'code') { |el| get_value_for_search_param(el).present? }),

--- a/lib/modules/uscore_v3.1.1/us_core_procedure_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_procedure_sequence.rb
@@ -253,6 +253,8 @@ module Inferno
         resolved_one = false
 
         patient_ids.each do |patient|
+          next unless @procedure_ary[patient].present?
+
           search_params = {
             'patient': patient,
             'date': get_value_for_search_param(resolve_element_from_path(@procedure_ary[patient], 'performed') { |el| get_value_for_search_param(el).present? })
@@ -300,6 +302,8 @@ module Inferno
         resolved_one = false
 
         patient_ids.each do |patient|
+          next unless @procedure_ary[patient].present?
+
           search_params = {
             'patient': patient,
             'status': get_value_for_search_param(resolve_element_from_path(@procedure_ary[patient], 'status') { |el| get_value_for_search_param(el).present? })
@@ -342,6 +346,8 @@ module Inferno
         resolved_one = false
 
         patient_ids.each do |patient|
+          next unless @procedure_ary[patient].present?
+
           search_params = {
             'patient': patient,
             'code': get_value_for_search_param(resolve_element_from_path(@procedure_ary[patient], 'code') { |el| get_value_for_search_param(el).present? }),

--- a/lib/modules/uscore_v3.1.1/us_core_pulse_oximetry_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_pulse_oximetry_sequence.rb
@@ -284,6 +284,8 @@ module Inferno
         resolved_one = false
 
         patient_ids.each do |patient|
+          next unless @observation_ary[patient].present?
+
           search_params = {
             'patient': patient,
             'category': get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category') { |el| get_value_for_search_param(el).present? }),
@@ -336,6 +338,8 @@ module Inferno
         resolved_one = false
 
         patient_ids.each do |patient|
+          next unless @observation_ary[patient].present?
+
           search_params = {
             'patient': patient,
             'category': get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category') { |el| get_value_for_search_param(el).present? })
@@ -381,6 +385,8 @@ module Inferno
         resolved_one = false
 
         patient_ids.each do |patient|
+          next unless @observation_ary[patient].present?
+
           search_params = {
             'patient': patient,
             'category': get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category') { |el| get_value_for_search_param(el).present? }),
@@ -429,6 +435,8 @@ module Inferno
         resolved_one = false
 
         patient_ids.each do |patient|
+          next unless @observation_ary[patient].present?
+
           search_params = {
             'patient': patient,
             'code': get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'code') { |el| get_value_for_search_param(el).present? }),


### PR DESCRIPTION
# Summary
Fix the failure on DiagnosticReport if patient does not exist

## New behavior
Code generator add line to skip search with patient id (except first search) if patient does not exist

## Code changes
uscore_generator.rb
add next if logic at get_search_params()
remove grab_first_value parameter from get_search_params() since it is not used by any caller

## Testing guidance
Add an no existing patient id to the input popup. All tests shall still pass
