### PR TITLE
FI-1189 CCG Scope Updates

### DIFF
--- a/generator/uscore/templates/access_verify_sequence.rb.erb
+++ b/generator/uscore/templates/access_verify_sequence.rb.erb
@@ -12,14 +12,13 @@ module Inferno
       test_id_prefix 'AVR'
       details %(
         This test ensures that patients are able to grant or deny access to a
-        subset of resources to an app. It also verifies that patients can
-        prevent issuance of a refresh token by denying the `offline_access`
-        scope. The tester provides a list of resources that will be granted
-        during the SMART App Launch process, and this test verifies that the
-        scopes granted are consistent with what the tester provided. It also
-        formulates queries to ensure that the app is either given access to,
-        or denied access to, the appropriate resource types based on those
-        chosen by the tester.
+        subset of resources to an app as requied by the certification
+        criteria. The tester provides a list of resources that will be
+        granted during the SMART App Launch process, and this test verifies
+        that the scopes granted are consistent with what the tester provided.
+        It also formulates queries to ensure that the app is either given
+        access to, or denied access to, the appropriate resource types based
+        on those chosen by the tester.
  
         Resources that can be mapped to USCDI are checked in this test, including:
         <% non_delayed_sequences.group_by{|sequence| sequence[:resource]}.values.map(&:first).each do |resource| %>

--- a/generator/uscore/templates/access_verify_sequence.rb.erb
+++ b/generator/uscore/templates/access_verify_sequence.rb.erb
@@ -163,7 +163,6 @@ module Inferno
        assert unexpected_resources.empty?, "This test expected the user to deny access to the following resources that are present in scopes received during token exchange response: #{unexpected_resources.join(', ')}"
        improperly_denied_resources = allowed_resources.reject { |resource| scope_granting_access(resource, @instance.received_scopes).present? }
        assert improperly_denied_resources.empty?, "This test expected the user to grant access to the following resources that are not received during token exhange response: #{improperly_denied_resources.join(', ')}"
-       assert @instance.received_scopes.split(' ').exclude?('offline_access'), 'This test expects the user to deny offline access to demonstrate that refresh tokens require user approval'
        pass "Resources to be denied: #{denied_resources.join(',')}"
        <% else %>
        # Consider all directly-mapped USCDI resources, as well as Encounter, Practitioner and Organization

--- a/generator/uscore/templates/unit_tests/access_verify_restricted_unit_test.rb.erb
+++ b/generator/uscore/templates/unit_tests/access_verify_restricted_unit_test.rb.erb
@@ -86,10 +86,16 @@ describe Inferno::Sequence::USCore<%=reformatted_version%>ONCAccessVerifyRestric
       assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
     end
 
-    it 'fails if offline_acess received' do
+    it 'passes if offline_acess received' do
       @instance.received_scopes = 'launch/patient offline_access openid fhirUser patient/Observation.read patient/Condition.read patient/Patient.read'
       assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
     end
+
+    it 'passes if offline_access not received' do
+      @instance.received_scopes = 'launch/patient openid fhirUser patient/Observation.read patient/Condition.read patient/Patient.read'
+      assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+    end
+
   end
 
   describe 'Validate Patient Authorization' do

--- a/generator/uscore/templates/unit_tests/access_verify_restricted_unit_test.rb.erb
+++ b/generator/uscore/templates/unit_tests/access_verify_restricted_unit_test.rb.erb
@@ -86,7 +86,7 @@ describe Inferno::Sequence::USCore<%=reformatted_version%>ONCAccessVerifyRestric
       assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
     end
 
-    it 'passes if offline_acess received' do
+    it 'passes if offline_access received' do
       @instance.received_scopes = 'launch/patient offline_access openid fhirUser patient/Observation.read patient/Condition.read patient/Patient.read'
       assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
     end

--- a/generator/uscore/templates/unit_tests/access_verify_restricted_unit_test.rb.erb
+++ b/generator/uscore/templates/unit_tests/access_verify_restricted_unit_test.rb.erb
@@ -88,12 +88,12 @@ describe Inferno::Sequence::USCore<%=reformatted_version%>ONCAccessVerifyRestric
 
     it 'passes if offline_access received' do
       @instance.received_scopes = 'launch/patient offline_access openid fhirUser patient/Observation.read patient/Condition.read patient/Patient.read'
-      assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+      assert_raises(Inferno::PassException) { @sequence.run_test(@test) }
     end
 
     it 'passes if offline_access not received' do
       @instance.received_scopes = 'launch/patient openid fhirUser patient/Observation.read patient/Condition.read patient/Patient.read'
-      assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+      assert_raises(Inferno::PassException) { @sequence.run_test(@test) }
     end
 
   end

--- a/generator/uscore/templates/unit_tests/access_verify_unrestricted_unit_test.rb.erb
+++ b/generator/uscore/templates/unit_tests/access_verify_unrestricted_unit_test.rb.erb
@@ -95,6 +95,25 @@ describe Inferno::Sequence::USCore<%=reformatted_version%>ONCAccessVerifyUnrestr
                                   'patient/Procedure.read patient/Provenance.read'
       assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
     end
+
+    it 'passes if user scopes used on non-USCDI/non-Patient Compartment resources' do
+      @instance.received_scopes = 'launch/patient openid fhirUser offline_access user/Medication.read patient/AllergyIntolerance.read patient/CarePlan.read '\
+                                  'patient/CareTeam.read patient/Condition.read user/Device.read patient/DiagnosticReport.read patient/DocumentReference.read '\
+                                  'user/Encounter.read patient/Goal.read patient/Immunization.read user/Location.read patient/MedicationRequest.read '\
+                                  'patient/Observation.read user/Organization.read patient/Patient.read user/Practitioner.read '\
+                                  'patient/Procedure.read patient/Provenance.read'
+      assert_raises(Inferno::PassException) { @sequence.run_test(@test) }
+    end
+
+    it 'fails if user scopes used on Patient Compartment resources' do
+      @instance.received_scopes = 'launch/patient openid fhirUser offline_access patient/Medication.read user/AllergyIntolerance.read patient/CarePlan.read '\
+                                  'patient/CareTeam.read patient/Condition.read patient/Device.read patient/DiagnosticReport.read patient/DocumentReference.read '\
+                                  'patient/Encounter.read patient/Goal.read patient/Immunization.read patient/Location.read patient/MedicationRequest.read '\
+                                  'patient/Observation.read patient/Organization.read patient/Patient.read patient/Practitioner.read '\
+                                  'patient/Procedure.read patient/Provenance.read'
+      assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+    end
+
   end
 
   describe 'Validate Patient Authorization' do

--- a/lib/modules/onc_program/onc_standalone_restricted_launch_sequence.rb
+++ b/lib/modules/onc_program/onc_standalone_restricted_launch_sequence.rb
@@ -178,12 +178,12 @@ module Inferno
           name 'OAuth token exchange response grants scope that is limited to those selected by user'
           link 'http://www.hl7.org/fhir/smart-app-launch/scopes-and-launch-context/index.html#quick-start'
           description %(
-            The ONC certification criteria requires that patients are capable of choosing which
-            FHIR resources to authorize to the application, and patients must be
-            given the choice to grant `offline_access`.  For this test, the tester specifies
-            which resources will be selected during authorization, and this verifies that only
-            those resources are granted according to the scopes returned during the access token
-            response.
+            The ONC certification criteria requires that patients are capable
+            of choosing which FHIR resources to authorize to the application.
+            For this test, the tester specifies which resources will be
+            selected during authorization, and this verifies that only those
+            resources are granted according to the scopes returned during the
+            access token response.
           )
         end
 
@@ -215,8 +215,6 @@ module Inferno
 
         assert improperly_granted_resources.empty?, "User expected to deny the following resources that were granted: #{improperly_granted_resources.join(', ')}"
         assert improperly_denied_resources.empty?, "User expected to grant access to the following resources: #{improperly_denied_resources.join(', ')}"
-
-        assert !received_scopes.split(' ').include?('offline_access'), 'Scopes returned in access token response contained offline_access.  User must deny this scope to pass this test.'
       end
     end
   end

--- a/lib/modules/onc_program/onc_visual_inspection_sequence.rb
+++ b/lib/modules/onc_program/onc_visual_inspection_sequence.rb
@@ -74,16 +74,16 @@ module Inferno
         pass @instance.onc_visual_single_scopes_notes if @instance.onc_visual_single_scopes_notes.present?
       end
 
-      test 'Health IT Module demonstrated a graphical user interface to authorize offline access.' do
+      test 'Health IT Module informed patient when offline access scope is being granted during authorization.' do
         metadata do
           id '04'
           link 'https://www.federalregister.gov/documents/2020/05/01/2020-07419/21st-century-cures-act-interoperability-information-blocking-and-the-onc-health-it-certification'
           description %(
-            Health IT Module demonstrated a graphical user interface for user to authorize offline access.
+            Health IT Module informed patient when offline access scope is being granted during authorization.
           )
         end
 
-        assert @instance.onc_visual_single_offline_access == 'true', 'Health IT Module did not demonstrate a graphical user interface for user to authorize offline access'
+        assert @instance.onc_visual_single_offline_access == 'true', 'Health IT Module did not inform patient when offline access scope is being granted during authorization.'
         pass @instance.onc_visual_single_offline_access_notes if @instance.onc_visual_single_offline_access_notes.present?
       end
 

--- a/lib/modules/onc_program/shared_onc_launch_tests.rb
+++ b/lib/modules/onc_program/shared_onc_launch_tests.rb
@@ -395,10 +395,18 @@ module Inferno
                 scope_pieces = scope.split('/')
 
                 assert scope_pieces.count == 2, bad_format_message
-                assert scope_pieces[0] == patient_or_user, bad_format_message
 
                 resource_access = scope_pieces[1].split('.')
                 bad_resource_message = "'#{resource_access[0]}' must be either a valid resource type or '*'"
+
+                non_patient_compartment_resources = ['Encounter', 'Device', 'Location', 'Medication', 'Organization',
+                                                     'Practitioner', 'PractitionerRole', 'RelatedPerson']
+
+                if patient_or_user == 'patient' && non_patient_compartment_resources.include?(resource_access[0])
+                  assert ['user', 'patient'].include?(scope_pieces[0]), "#{received_or_requested.capitalize} scope '#{scope}' must begin with either 'user/' or 'patient/'"
+                else
+                  assert scope_pieces[0] == patient_or_user, bad_format_message
+                end
 
                 assert resource_access.count == 2, bad_format_message
                 assert valid_resource_types.include?(resource_access[0]), bad_resource_message

--- a/lib/modules/onc_program_module.yml
+++ b/lib/modules/onc_program_module.yml
@@ -56,16 +56,13 @@ test_sets:
           Launch to a [SMART on FHIR](http://www.hl7.org/fhir/smart-app-launch/)
           confidential client with limited access granted to the app based on user input.
           The tester is expected to grant the application access to a subset of
-          desired resource types, and to deny requests for "offline_access"
-          refresh tokens.
+          desired resource types.
         input_instructions: |
           The purpose of this test is to demonstrate that users can restrict
-          access granted to apps to a limited number of resources and does
-          not force the user to have offline_access refresh tokens.  Enter
-          which resources the user will grant access to below, and during
-          the launch process only grant access to those resources. Additionally,
-          do not grant access to offline_access refresh tokens.  Inferno
-          will verify that access granted matches these expectations.
+          access granted to apps to a limited number of resources. Enter
+          which resources the user will grant access to below, and during the
+          launch process only grant access to those resources. Inferno will
+          verify that access granted matches these expectations.
         lock_variables: 
           - redirect_uris
           - onc_sl_url

--- a/lib/modules/uscore_v3.1.1/access_verify_restricted_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/access_verify_restricted_sequence.rb
@@ -135,7 +135,6 @@ module Inferno
         assert unexpected_resources.empty?, "This test expected the user to deny access to the following resources that are present in scopes received during token exchange response: #{unexpected_resources.join(', ')}"
         improperly_denied_resources = allowed_resources.reject { |resource| scope_granting_access(resource, @instance.received_scopes).present? }
         assert improperly_denied_resources.empty?, "This test expected the user to grant access to the following resources that are not received during token exhange response: #{improperly_denied_resources.join(', ')}"
-        assert @instance.received_scopes.split(' ').exclude?('offline_access'), 'This test expects the user to deny offline access to demonstrate that refresh tokens require user approval'
         pass "Resources to be denied: #{denied_resources.join(',')}"
       end
 

--- a/lib/modules/uscore_v3.1.1/access_verify_restricted_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/access_verify_restricted_sequence.rb
@@ -9,14 +9,13 @@ module Inferno
       test_id_prefix 'AVR'
       details %(
         This test ensures that patients are able to grant or deny access to a
-        subset of resources to an app. It also verifies that patients can
-        prevent issuance of a refresh token by denying the `offline_access`
-        scope. The tester provides a list of resources that will be granted
-        during the SMART App Launch process, and this test verifies that the
-        scopes granted are consistent with what the tester provided. It also
-        formulates queries to ensure that the app is either given access to,
-        or denied access to, the appropriate resource types based on those
-        chosen by the tester.
+        subset of resources to an app as requied by the certification
+        criteria. The tester provides a list of resources that will be
+        granted during the SMART App Launch process, and this test verifies
+        that the scopes granted are consistent with what the tester provided.
+        It also formulates queries to ensure that the app is either given
+        access to, or denied access to, the appropriate resource types based
+        on those chosen by the tester.
 
         Resources that can be mapped to USCDI are checked in this test, including:
 

--- a/lib/modules/uscore_v3.1.1/access_verify_unrestricted_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/access_verify_unrestricted_sequence.rb
@@ -88,8 +88,13 @@ module Inferno
       end
 
       def scope_granting_access(resource, scopes)
+        non_patient_compartment_resources = ['Encounter', 'Device', 'Location', 'Medication', 'Organization',
+                                             'Practitioner', 'PractitionerRole', 'RelatedPerson']
+
         scopes.split(' ').find do |scope|
-          ['patient/*.read', 'patient/*.*', "patient/#{resource}.read", "patient/#{resource}.*"].include? scope
+          return true if non_patient_compartment_resources.include?(resource) && ["user/#{resource}.read", "user/#{resource}.*"].include?(scope)
+
+          ['patient/*.read', 'patient/*.*', "patient/#{resource}.read", "patient/#{resource}.*"].include?(scope)
         end
       end
 

--- a/lib/modules/uscore_v3.1.1/test/access_verify_restricted_test.rb
+++ b/lib/modules/uscore_v3.1.1/test/access_verify_restricted_test.rb
@@ -86,8 +86,13 @@ describe Inferno::Sequence::USCore311ONCAccessVerifyRestrictedSequence do
       assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
     end
 
-    it 'fails if offline_acess received' do
+    it 'passes if offline_acess received' do
       @instance.received_scopes = 'launch/patient offline_access openid fhirUser patient/Observation.read patient/Condition.read patient/Patient.read'
+      assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+    end
+
+    it 'passes if offline_access not received' do
+      @instance.received_scopes = 'launch/patient openid fhirUser patient/Observation.read patient/Condition.read patient/Patient.read'
       assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
     end
   end

--- a/lib/modules/uscore_v3.1.1/test/access_verify_restricted_test.rb
+++ b/lib/modules/uscore_v3.1.1/test/access_verify_restricted_test.rb
@@ -88,12 +88,12 @@ describe Inferno::Sequence::USCore311ONCAccessVerifyRestrictedSequence do
 
     it 'passes if offline_access received' do
       @instance.received_scopes = 'launch/patient offline_access openid fhirUser patient/Observation.read patient/Condition.read patient/Patient.read'
-      assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+      assert_raises(Inferno::PassException) { @sequence.run_test(@test) }
     end
 
     it 'passes if offline_access not received' do
       @instance.received_scopes = 'launch/patient openid fhirUser patient/Observation.read patient/Condition.read patient/Patient.read'
-      assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+      assert_raises(Inferno::PassException) { @sequence.run_test(@test) }
     end
   end
 

--- a/lib/modules/uscore_v3.1.1/test/access_verify_restricted_test.rb
+++ b/lib/modules/uscore_v3.1.1/test/access_verify_restricted_test.rb
@@ -86,7 +86,7 @@ describe Inferno::Sequence::USCore311ONCAccessVerifyRestrictedSequence do
       assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
     end
 
-    it 'passes if offline_acess received' do
+    it 'passes if offline_access received' do
       @instance.received_scopes = 'launch/patient offline_access openid fhirUser patient/Observation.read patient/Condition.read patient/Patient.read'
       assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
     end

--- a/lib/modules/uscore_v3.1.1/test/access_verify_unrestricted_test.rb
+++ b/lib/modules/uscore_v3.1.1/test/access_verify_unrestricted_test.rb
@@ -95,6 +95,24 @@ describe Inferno::Sequence::USCore311ONCAccessVerifyUnrestrictedSequence do
                                   'patient/Procedure.read patient/Provenance.read'
       assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
     end
+
+    it 'passes if user scopes used on non-USCDI/non-Patient Compartment resources' do
+      @instance.received_scopes = 'launch/patient openid fhirUser offline_access user/Medication.read patient/AllergyIntolerance.read patient/CarePlan.read '\
+                                  'patient/CareTeam.read patient/Condition.read user/Device.read patient/DiagnosticReport.read patient/DocumentReference.read '\
+                                  'user/Encounter.read patient/Goal.read patient/Immunization.read user/Location.read patient/MedicationRequest.read '\
+                                  'patient/Observation.read user/Organization.read patient/Patient.read user/Practitioner.read '\
+                                  'patient/Procedure.read patient/Provenance.read'
+      assert_raises(Inferno::PassException) { @sequence.run_test(@test) }
+    end
+
+    it 'fails if user scopes used on Patient Compartment resources' do
+      @instance.received_scopes = 'launch/patient openid fhirUser offline_access patient/Medication.read user/AllergyIntolerance.read patient/CarePlan.read '\
+                                  'patient/CareTeam.read patient/Condition.read patient/Device.read patient/DiagnosticReport.read patient/DocumentReference.read '\
+                                  'patient/Encounter.read patient/Goal.read patient/Immunization.read patient/Location.read patient/MedicationRequest.read '\
+                                  'patient/Observation.read patient/Organization.read patient/Patient.read patient/Practitioner.read '\
+                                  'patient/Procedure.read patient/Provenance.read'
+      assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+    end
   end
 
   describe 'Validate Patient Authorization' do


### PR DESCRIPTION
# Summary

Addresses CCG updates regarding  the absence of a requirement for denying `offline_access` scope, and allowing systems to use `user` scopes for non-Patient compartment resources for patient app launches.  Note that this addresses both FI-1189 and FI-1188 in our internal tracker due to the close relationship of the two CCG clarifications.

## New behavior

For the 'limited access tests', there should be no mention of needing to deny "offline_access", and when you run the test it should pass if you allow "offline_access".

For the 'standalone patient app' tests, you can change the defaulted "patient" scope to "user" for non-patient compartment resources (and technically not encounter either since it is not uscdi v1).  Try changing some scopes to 'user', it should fail if you do it on a patient compartment resource (e.g. Condition), but pass if you do it on any/all non-patient compartment resources (e.g. Practitioner).

## Code changes

Changes the standalone patient app launch tests and the limited access tests.  Also updated the unit tests.

## Testing guidance

See 'new behavior' above. 
