### PR TITLE
FI-1237: Release DB connections after requests

### DIFF
--- a/db/config.postgres.yml
+++ b/db/config.postgres.yml
@@ -4,7 +4,7 @@ development:
   username: postgres
   host: db
   pool: 10
-  timeout: 5000
+  idle_timeout: 60
 
 production:
   adapter: postgresql
@@ -12,7 +12,7 @@ production:
   username: postgres
   host: db
   pool: 10
-  timeout: 5000
+  idle_timeout: 60
 
 test: &test
   adapter: postgresql
@@ -20,4 +20,4 @@ test: &test
   username: postgres
   host: db
   pool: 10
-  timeout: 5000
+  idle_timeout: 60

--- a/lib/app/endpoint.rb
+++ b/lib/app/endpoint.rb
@@ -62,6 +62,10 @@ module Inferno
       set(:prefix) { '/' << name[/[^:]+$/].underscore }
       set :protection, except: :frame_options # necessary for SMART EHR Launches
 
+      after do
+        logger.debug "ActiveRecord connections: #{ActiveRecord::Base.connection_pool.stat}"
+      end
+
       def render_index
         unless defined?(settings.presets).nil? || settings.presets.nil?
           base_url = request.base_url

--- a/lib/app/endpoint/oauth2_endpoints.rb
+++ b/lib/app/endpoint/oauth2_endpoints.rb
@@ -179,6 +179,7 @@ module Inferno
 
                 query_target = "#{test_group.id}/#{query_target}" unless test_group.nil?
 
+                ActiveRecord::Base.connection_pool.release_connection
                 out << js_redirect("#{base_path}/#{@instance.id}/test_sets/#{test_set.id}/##{query_target}") if finished
               end
             else

--- a/lib/app/endpoint/test_set_endpoints.rb
+++ b/lib/app/endpoint/test_set_endpoints.rb
@@ -220,6 +220,7 @@ module Inferno
 
               query_target = "#{test_group.id}/#{query_target}" unless test_group.nil?
 
+              ActiveRecord::Base.connection_pool.release_connection
               out << js_redirect("#{base_path}/#{params[:id]}/test_sets/#{params[:test_set_id]}/##{query_target}") if finished
             end
           end


### PR DESCRIPTION
# Summary
Make ActiveRecord release connections at the end of requests.

## New behavior

## Code changes

## Testing guidance
In `endpoint.rb` If you change the `logger.debug` in the `after` block to `logger.info`, you'll see the connection info in the logs and can verify that it doesn't keep increasing.