### PR TITLE
Update the terminology dockerfile and compose file to the new datamapper-less configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,17 +67,6 @@ Documentation](https://github.com/onc-healthit/inferno/wiki/Troubleshooting) for
 help.
 
 ### Terminology Support
-
-#### 2020-November-30 UMLS Auth Workaround
-
-IMPORTANT: As of November 2020, UMLS login now requires the use of a federated login provider, such as Google, Microsoft, or https://login.gov. This change breaks the first step of the terminology build process outlined below.
-
-As a temporary workaround, if you download https://download.nlm.nih.gov/umls/kss/2019AB/umls-2019AB-full.zip (note: this file is several GB in size), rename it `umls.zip` and place it in `<inferno root>/tmp/terminology`, that should allow the terminology processing to skip the download step and continue normally. This also eliminates the need to create the `.env` file (outlined below).
-
-We hope to have this login system supported in the near future, which will re-enable the ability to do a completely automated terminology build from start to finish.
-
-For more information on the UTS sign-in process changes, visit https://www.nlm.nih.gov/research/umls/uts-changes.html.
-
 #### Terminology prerequisites
 
 In order to validate terminologies, Inferno must be loaded with files generated
@@ -103,14 +92,11 @@ You can prebuild the terminology docker container by running the following comma
 docker-compose -f terminology_compose.yml build
 ```
 
-Once the container is built, you will have to add your UMLS username and passwords to a file named `.env` at the root of the inferno project. The file should look like this (replacing `your_username` and `your_password` with your UMLS username/password, respectively):
+Once the container is built, you will have to download the UMLS zip file from the NIH website. This is because UMLS login now requires the use of a federated login provider, such as Google, Microsoft, or https://login.gov.
 
-```sh
-UMLS_USERNAME=your_username
-UMLS_PASSWORD=your_password
-```
+To accomplish this, download https://download.nlm.nih.gov/umls/kss/2019AB/umls-2019AB-full.zip (note: this file is several GB in size), rename it `umls.zip` and place it in `<inferno root>/tmp/terminology`.
 
-Note that _anything_ after the equals sign in `.env` will be considered part of the variable, so don't wrap your username/password in quotation marks (unless they're actually part of your username).
+For more information on the UTS sign-in process changes, visit https://www.nlm.nih.gov/research/umls/uts-changes.html.
 
 Once that file exists, you can run the terminology creation task by using the following commands, in order:
 
@@ -118,7 +104,7 @@ Once that file exists, you can run the terminology creation task by using the fo
 docker-compose -f terminology_compose.yml up
 ```
 
-This will run the terminology creation steps in order, using the UMLS credentials supplied in `.env`. These tasks may take several hours. If the creation task is cancelled in progress and restarted, it will restart after the last _completed_ step. Intermediate files are saved to `tmp/terminology` in the Inferno repository that the Docker Compose job is run from, and the validators are saved to `resources/terminology/validators/bloom`, where Inferno can use them for validation.
+This will run the terminology creation steps in order. These tasks may take several hours. If the creation task is cancelled in progress and restarted, it will restart after the last _completed_ step. Intermediate files are saved to `tmp/terminology` in the Inferno repository that the Docker Compose job is run from, and the validators are saved to `resources/terminology/validators/bloom`, where Inferno can use them for validation.
 
 #### Cleanup
 

--- a/bin/run_terminology.sh
+++ b/bin/run_terminology.sh
@@ -14,19 +14,9 @@ fi
 temp_folder="tmp/terminology"
 
 if [[ ! -f "$temp_folder/umls.zip" ]]; then
-  [[ -z "$UMLS_USERNAME" ]] && { echo "UMLS Username environment variable is empty" >&2 ; exit 1; }
-  [[ -z "$UMLS_PASSWORD" ]] && { echo "UMLS Password environment variable is empty" >&2 ; exit 1; }
-  function control_c_download {
-    kill -INT "$child"
-    rm -f "$temp_folder/umls.zip"
-    exit $?
-  }
-  trap control_c_download SIGHUP SIGINT SIGTERM SIGQUIT SIGKILL SIGTSTP
-  bundle exec rake terminology:download_umls["$UMLS_USERNAME","$UMLS_PASSWORD"] &
-  child=$!
-  wait "$child"
-else
-  echo "UMLS Zip already exists; skipping UMLS download Rake task."
+  echo "The UMLS zip file must be manually downloaded and placed in the tmp/terminology folder."
+  echo "For more info, see the 'terminology support' section of the README."
+  exit 1
 fi
 
 if [[ ! -e "$temp_folder/umls" ]]; then

--- a/terminology_compose.yml
+++ b/terminology_compose.yml
@@ -5,6 +5,9 @@ services:
       context: .
       dockerfile: terminology_dockerfile
     volumes:
+      - ./config.yml:/var/www/inferno/config.yml
+      - ./data:/var/www/inferno/data
+      - ./batch:/var/www/inferno/batch
       - type: bind
         source: "./resources/terminology/validators"
         target: "/var/www/inferno/resources/terminology/validators"

--- a/terminology_dockerfile
+++ b/terminology_dockerfile
@@ -2,6 +2,10 @@ FROM ruby:2.7.2
 
 WORKDIR /var/www/inferno
 
+RUN apt-get -y update && \
+    apt-get -y upgrade && \
+    apt-get install -y sqlite3
+
 ### Install dependencies
 COPY Gemfile.postgres /var/www/inferno/Gemfile
 COPY Gemfile.postgres.lock /var/www/inferno/Gemfile.lock

--- a/terminology_dockerfile
+++ b/terminology_dockerfile
@@ -1,27 +1,26 @@
-FROM ruby:2.5.6
+FROM ruby:2.7.2
 
 WORKDIR /var/www/inferno
 
 ### Install dependencies
-
-RUN apt-get -y update && \
-    apt-get -y upgrade && \
-    apt-get install -y sqlite3
-
-COPY Gemfile* /var/www/inferno/
+COPY Gemfile.postgres /var/www/inferno/Gemfile
+COPY Gemfile.postgres.lock /var/www/inferno/Gemfile.lock
 RUN gem install bundler
 # Throw an error if Gemfile & Gemfile.lock are out of sync
 RUN bundle config --global frozen 1
 RUN bundle install
 
+### Install Inferno
+
 RUN mkdir data
 COPY public /var/www/inferno/public
+COPY resources /var/www/inferno/resources
 COPY config* /var/www/inferno/
 COPY Rakefile /var/www/inferno/
-COPY bin /var/www/inferno/bin
 COPY test /var/www/inferno/test
 COPY lib /var/www/inferno/lib
-COPY resources /var/www/inferno/resources
+COPY db /var/www/inferno/db
+COPY bin /var/www/inferno/bin
 
 RUN rm /bin/sh && ln -s /bin/bash /bin/sh
 


### PR DESCRIPTION
# Summary
Need to make some changes to `terminology_dockerfile` and `terminology_compose.yml` to make them work with Inferno now that Datamapper has been removed. Also need to bump Ruby to 2.7.2. 

## New behavior

## Code changes

## Testing guidance
Remove everything from `tmp/terminology/` except `umls.zip`, and run `docker-compose -f terminology_compose.yml up --build`. Ensure it runs, and doesn't error out with `could not load database configuration. No such file - ["db/config.yml"]`
