### PR TITLE
Add support for "preprocessing" BCP:13 codes prior to validation

### DIFF
--- a/lib/app/utils/bcp_13.rb
+++ b/lib/app/utils/bcp_13.rb
@@ -13,9 +13,15 @@ module Inferno
         require 'mime/types'
         cs_set = Set.new
         MIME::Types.each do |type|
-          cs_set.add(system: 'urn:ietf:bcp:13', code: type.simplified)
+          cs_set.add(system: 'urn:ietf:bcp:13', code: preprocess_code(type.simplified))
         end
         cs_set
+      end
+
+      # "preprocess" step for BCP13 codes, to remove any of the optional parameters
+      # and downcase them
+      def self.preprocess_code(code)
+        code&.split(';')&.first&.downcase
       end
     end
   end

--- a/lib/app/utils/terminology.rb
+++ b/lib/app/utils/terminology.rb
@@ -24,7 +24,7 @@ module Inferno
     # Code systems to "preprocess" prior to validation, and the function to use
     PREPROCESS_FUNCS = {
       'urn:ietf:bcp:13' => Inferno::Terminology::BCP13.method(:preprocess_code)
-    }
+    }.freeze
 
     PACKAGE_DIR = File.join('tmp', 'terminology', 'fhir')
 
@@ -241,9 +241,7 @@ module Inferno
     def self.validate_code(valueset_url: nil, code:, system: nil)
       # Before we validate the code, see if there's any preprocessing steps we have to do
       # To get the code "ready" for validation
-      if PREPROCESS_FUNCS[system]
-        code = PREPROCESS_FUNCS[system].call(code)
-      end
+      code = PREPROCESS_FUNCS[system].call(code) if PREPROCESS_FUNCS[system]
 
       # Get the valueset from the url. Redundant if the 'system' is not nil,
       # but allows us to throw a better error if the valueset isn't known by Inferno

--- a/lib/app/utils/terminology.rb
+++ b/lib/app/utils/terminology.rb
@@ -21,6 +21,11 @@ module Inferno
       'http://hl7.org/fhir/ValueSet/example-hierarchical' # Example valueset with fake codes
     ].freeze
 
+    # Code systems to "preprocess" prior to validation, and the function to use
+    PREPROCESS_FUNCS = {
+      'urn:ietf:bcp:13' => Inferno::Terminology::BCP13.method(:preprocess_code)
+    }
+
     PACKAGE_DIR = File.join('tmp', 'terminology', 'fhir')
 
     @known_valuesets = {}
@@ -234,6 +239,15 @@ module Inferno
     # @param String system an optional codesystem to validate against. Defaults to nil
     # @return Boolean whether the code or code/system is in the valueset
     def self.validate_code(valueset_url: nil, code:, system: nil)
+      # Before we validate the code, see if there's any preprocessing steps we have to do
+      # To get the code "ready" for validation
+      require 'pry'
+      binding.pry
+      if PREPROCESS_FUNCS[system]
+        code = PREPROCESS_FUNCS[system].call(code)
+      end
+      
+
       # Get the valueset from the url. Redundant if the 'system' is not nil,
       # but allows us to throw a better error if the valueset isn't known by Inferno
       if valueset_url

--- a/lib/app/utils/terminology.rb
+++ b/lib/app/utils/terminology.rb
@@ -241,12 +241,9 @@ module Inferno
     def self.validate_code(valueset_url: nil, code:, system: nil)
       # Before we validate the code, see if there's any preprocessing steps we have to do
       # To get the code "ready" for validation
-      require 'pry'
-      binding.pry
       if PREPROCESS_FUNCS[system]
         code = PREPROCESS_FUNCS[system].call(code)
       end
-      
 
       # Get the valueset from the url. Redundant if the 'system' is not nil,
       # but allows us to throw a better error if the valueset isn't known by Inferno

--- a/lib/app/utils/test/bcp_13_test.rb
+++ b/lib/app/utils/test/bcp_13_test.rb
@@ -3,8 +3,6 @@
 require_relative '../../../../test/test_helper'
 require_relative '../bcp_13'
 
-
-
 describe Inferno::Terminology::BCP13 do
   it 'should remove optional parameters when semicolon-separated' do
     assert_equal 'application/fhir+json', Inferno::Terminology::BCP13.preprocess_code('application/fhir+json; charset=UTF-8')

--- a/lib/app/utils/test/bcp_13_test.rb
+++ b/lib/app/utils/test/bcp_13_test.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require_relative '../../../../test/test_helper'
+require_relative '../bcp_13'
+
+
+
+describe Inferno::Terminology::BCP13 do
+  it 'should remove optional parameters when semicolon-separated' do
+    assert_equal 'application/fhir+json', Inferno::Terminology::BCP13.preprocess_code('application/fhir+json; charset=UTF-8')
+  end
+
+  it 'should do nothing with no optional parameters' do
+    assert_equal 'application/fhir+json', Inferno::Terminology::BCP13.preprocess_code('application/fhir+json')
+  end
+
+  it 'should return MIME types lower-cased' do
+    assert_equal 'application/fhir+json', Inferno::Terminology::BCP13.preprocess_code('Application/FHIR+JSON')
+  end
+end


### PR DESCRIPTION
# Summary
BCP:13 codes (aka `MIME Types`) can have optional "parameters" tacked on after the actual MIME type; like `application/fhir+json; charset=UTF-8`. This is considered "legal" in FHIR, but our Bloom Filters can't handle them, so we have to strip off anything that's not the MIME type itself before validation.

While we're at it, this PR also `downcase`s the MIME type before validation, to avoid case mismatches (since MIIME types are case-insensitive). 

The PR also adds this preprocess step to the BCP:13 bloom filter generation code, so moving forward all the MIME types coming out of the MIME::types gem will be `downcase`d.

## Testing guidance
* Ensure the bloom filters are built/present on your system
* Test a MIME type with parameters against the appropriate valueset, with a Rake task like `rake terminology:check_code['application/fhir+json; CHARSET=utf-8','urn:ietf:bcp:13','http://hl7.org/fhir/ValueSet/mimetypes']`
* Optional: run the same task, but change the MIME type to be gibberish, and ensure the code check fails
* Optional: run the terminology build tasks (after deleting the bloom filters) and test a code like `application/A2L` (which is upcased coming from the `mime-types` gem) and ensure it passes both upcase'd and downcase'd
