### PR TITLE
read config file from rake tests to set disable verify peer correctly

### DIFF
--- a/lib/tasks/tasks.rake
+++ b/lib/tasks/tasks.rake
@@ -7,7 +7,6 @@ require 'csv'
 require 'colorize'
 require 'optparse'
 require 'rubocop/rake_task'
-require 'yaml'
 
 require_relative '../app'
 require_relative '../app/endpoint'
@@ -78,10 +77,7 @@ def execute(instance, sequences)
     end
     instance.save!
 
-    # manually read config yaml file
-    config = YAML.load_file(ENV['INFERNO_CONFIG_FILE'] || 'config.yml')
-    disable_verify_peer = config['disable_verify_peer']
-
+    disable_verify_peer = Inferno::App::Endpoint.settings.disable_verify_peer
     sequence_instance = sequence.new(instance, client, disable_verify_peer)
     sequence_result = nil
 

--- a/lib/tasks/tasks.rake
+++ b/lib/tasks/tasks.rake
@@ -7,6 +7,7 @@ require 'csv'
 require 'colorize'
 require 'optparse'
 require 'rubocop/rake_task'
+require 'yaml'
 
 require_relative '../app'
 require_relative '../app/endpoint'
@@ -76,7 +77,12 @@ def execute(instance, sequences)
       end
     end
     instance.save!
-    sequence_instance = sequence.new(instance, client, false)
+    
+    # manually read config yaml file
+    config = YAML.load_file(ENV['INFERNO_CONFIG_FILE'] || 'config.yml')
+    disable_verify_peer = config['disable_verify_peer']
+
+    sequence_instance = sequence.new(instance, client, disable_verify_peer)
     sequence_result = nil
 
     suppress_output { sequence_result = sequence_instance.start }

--- a/lib/tasks/tasks.rake
+++ b/lib/tasks/tasks.rake
@@ -77,7 +77,7 @@ def execute(instance, sequences)
       end
     end
     instance.save!
-    
+
     # manually read config yaml file
     config = YAML.load_file(ENV['INFERNO_CONFIG_FILE'] || 'config.yml')
     disable_verify_peer = config['disable_verify_peer']


### PR DESCRIPTION
# Summary
Updating running tests from tasks.rake so it reads the config file

## New behavior
Now tasks.rake manually reads the config file to learn about verify_peer

## Code changes

## Testing guidance
Change the config's disable_verify_peer Run inferno tests from rake to test and confirm that USCCAP-01 is ommited
