### PR TITLE
Move negative authorization code tests to its own sequence

### DIFF
--- a/lib/modules/core/shared_tests.rb
+++ b/lib/modules/core/shared_tests.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+module Inferno
+  module Sequence
+    module SharedTests
+      def self.included(klass)
+        klass.extend(ClassMethods)
+      end
+
+      module ClassMethods
+        def test_is_deprecated(index:, name:, version:)
+          test "test_is_deprecated_#{index}" do
+            metadata do
+              id index
+              name "#{name} is deprecated"
+              link 'http://hl7.org/fhir'
+              description %(
+                Test #{name} is deprecated from version #{version}
+              )
+              optional
+            end
+
+            omit
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/modules/onc_program/onc_ehr_launch_sequence.rb
+++ b/lib/modules/onc_program/onc_ehr_launch_sequence.rb
@@ -1,11 +1,13 @@
 # frozen_string_literal: true
 
 require_relative './shared_onc_launch_tests'
+require_relative '../core/shared_tests'
 
 module Inferno
   module Sequence
     class OncEHRLaunchSequence < SequenceBase
       include Inferno::Sequence::SharedONCLaunchTests
+      include Inferno::Sequence::SharedTests
 
       title 'ONC EHR Launch Sequence'
 
@@ -183,9 +185,9 @@ module Inferno
 
       token_endpoint_tls_test(index: '06')
 
-      invalid_code_test(index: '07')
+      test_is_deprecated(index: '07', name: 'OAuth token exchange fails when supplied invalid code', version: '1.7.0')
 
-      invalid_client_id_test(index: '08')
+      test_is_deprecated(index: '08', name: 'OAuth token exchange fails when supplied invalid client ID', version: '1.7.0')
 
       successful_token_exchange_test(index: '09')
 

--- a/lib/modules/onc_program/onc_standalone_launch_sequence.rb
+++ b/lib/modules/onc_program/onc_standalone_launch_sequence.rb
@@ -1,11 +1,13 @@
 # frozen_string_literal: true
 
 require_relative './shared_onc_launch_tests'
+require_relative '../core/shared_tests'
 
 module Inferno
   module Sequence
     class OncStandaloneLaunchSequence < SequenceBase
       include Inferno::Sequence::SharedONCLaunchTests
+      include Inferno::Sequence::SharedTests
 
       title 'ONC Standalone Launch Sequence'
 
@@ -154,9 +156,9 @@ module Inferno
 
       token_endpoint_tls_test(index: '04')
 
-      invalid_code_test(index: '05')
+      test_is_deprecated(index: '05', name: 'OAuth token exchange fails when supplied invalid code', version: '1.7.0')
 
-      invalid_client_id_test(index: '06')
+      test_is_deprecated(index: '06', name: 'OAuth token exchange fails when supplied invalid client ID', version: '1.7.0')
 
       successful_token_exchange_test(index: '07')
 

--- a/lib/modules/onc_program/onc_standalone_restricted_launch_sequence.rb
+++ b/lib/modules/onc_program/onc_standalone_restricted_launch_sequence.rb
@@ -1,11 +1,13 @@
 # frozen_string_literal: true
 
 require_relative './shared_onc_launch_tests'
+require_relative '../core/shared_tests'
 
 module Inferno
   module Sequence
     class OncStandaloneRestrictedLaunchSequence < SequenceBase
       include Inferno::Sequence::SharedONCLaunchTests
+      include Inferno::Sequence::SharedTests
 
       title 'ONC Standalone Launch Sequence'
 
@@ -154,9 +156,9 @@ module Inferno
 
       token_endpoint_tls_test(index: '04')
 
-      invalid_code_test(index: '05')
+      test_is_deprecated(index: '05', name: 'OAuth token exchange fails when supplied invalid code', version: '1.7.0')
 
-      invalid_client_id_test(index: '06')
+      test_is_deprecated(index: '06', name: 'OAuth token exchange fails when supplied invalid client ID', version: '1.7.0')
 
       successful_token_exchange_test(index: '07')
 

--- a/lib/modules/onc_program/smart_invalid_authorization_code_sequence.rb
+++ b/lib/modules/onc_program/smart_invalid_authorization_code_sequence.rb
@@ -1,0 +1,107 @@
+# frozen_string_literal: true
+
+require_relative './shared_onc_launch_tests'
+
+module Inferno
+  module Sequence
+    class SMARTInvalidAuthorizationCodeSequence < SequenceBase
+      include Inferno::Sequence::SharedONCLaunchTests
+
+      title 'SMART App Launch Error: Invalid Authorization Code'
+      description 'Demonstrate that the server properly validates Authorization code'
+
+      test_id_prefix 'SIAC'
+
+      requires :onc_sl_client_id,
+               :onc_sl_confidential_client,
+               :onc_sl_client_secret,
+               :onc_sl_scopes,
+               :oauth_authorize_endpoint,
+               :oauth_token_endpoint,
+               :initiate_login_uri,
+               :redirect_uris
+
+      show_uris
+
+      details %(
+        # Background
+
+        The Invalid AuthorizationCode Sequence verifies that a SMART Launch Sequence,
+        specifically the [Standalone
+        Launch](http://hl7.org/fhir/smart-app-launch/#standalone-launch-sequence)
+        Sequence, does not work in the case where the client sends an invalid
+        Authorization code during launch.  This must fail to ensure
+        that a genuine bearer token is not leaked to a counterfit resource server.
+
+        This test is not included as part of a regular SMART Launch Sequence
+        because some servers may revoke current authorization code after the test.
+      )
+
+      def url_property
+        'onc_sl_url'
+      end
+
+      def instance_url
+        @instance.send(url_property)
+      end
+
+      def instance_client_id
+        @instance.onc_sl_client_id
+      end
+
+      def instance_confidential_client
+        @instance.onc_sl_confidential_client
+      end
+
+      def instance_client_secret
+        @instance.onc_sl_client_secret
+      end
+
+      def instance_scopes
+        @instance.onc_sl_scopes
+      end
+
+      test 'OAuth server redirects client browser to app redirect URI' do
+        metadata do
+          id '01'
+          link 'http://www.hl7.org/fhir/smart-app-launch/'
+          description %(
+            Client browser redirected from OAuth server to redirect URI of
+            client app as described in SMART authorization sequence.
+          )
+        end
+        @instance.save
+        @instance.update(state: SecureRandom.uuid)
+
+        oauth2_params = {
+          'response_type' => 'code',
+          'client_id' => @instance.onc_sl_client_id,
+          'redirect_uri' => @instance.redirect_uris,
+          'scope' => instance_scopes,
+          'state' => @instance.state,
+          'aud' => @instance.onc_sl_url
+        }
+
+        oauth_authorize_endpoint = @instance.oauth_authorize_endpoint
+
+        oauth2_auth_query = oauth_authorize_endpoint
+
+        oauth2_auth_query += if oauth_authorize_endpoint.include? '?'
+                               '&'
+                             else
+                               '?'
+                             end
+
+        oauth2_params.each do |key, value|
+          oauth2_auth_query += "#{key}=#{CGI.escape(value)}&"
+        end
+
+        redirect oauth2_auth_query[0..-2], 'redirect'
+      end
+
+      code_and_state_received_test(index: '02')
+      invalid_code_test(index: '03')
+      invalid_client_id_test(index: '04')
+    end
+  end
+end

--- a/lib/modules/onc_program_module.yml
+++ b/lib/modules/onc_program_module.yml
@@ -220,4 +220,7 @@ test_sets:
           - sequence: SMARTInvalidLaunchSequence
             variable_defaults:
               confidential_client: 'true'
+          - sequence: SMARTInvalidAuthorizationCodeSequence
+            variable_defaults:
+              confidential_client: 'true'
           - ONCVisualInspectionSequence


### PR DESCRIPTION
# Summary
Some servers may revoke authorization code after negative test which blocks following tests in authorization test sequence. To avoid that, we moved negative authorization code tests to its own sequence as an additional test in "other" tab.

## New behavior
Replace two negative authorization code tests in ONC EHR Launch Sequece, ONC Standalone Launch Sequence, and ONC Standalone Restricted Launch Sequence 

Add Invalid Authorization Code Sequence

## Code changes

## Testing guidance
