### PR TITLE
Fi 1262 search string starts with

### DIFF
--- a/generator/uscore/uscore_generator.rb
+++ b/generator/uscore/uscore_generator.rb
@@ -1398,6 +1398,9 @@ module Inferno
             match_found = values_found.any? do |identifier|
               identifier.value == identifier_value && (!value.include?('|') || identifier.system == identifier_system)
             end)
+        when 'string'
+          %(values = value.split(/(?<!\\\\),/).each { |str| str.gsub!('\\,', ',') }
+            match_found = values_found.any? { |value_in_resource| values.any? { |searched_value| value_in_resource.starts_with? searched_value } })
         else
           # searching by patient requires special case because we are searching by a resource identifier
           # references can also be URL's, so we made need to resolve those url's

--- a/generator/uscore/uscore_generator.rb
+++ b/generator/uscore/uscore_generator.rb
@@ -1399,8 +1399,8 @@ module Inferno
               identifier.value == identifier_value && (!value.include?('|') || identifier.system == identifier_system)
             end)
         when 'string'
-          %(values = value.split(/(?<!\\\\),/).each { |str| str.gsub!('\\,', ',') }
-            match_found = values_found.any? { |value_in_resource| values.any? { |searched_value| value_in_resource.starts_with? searched_value } })
+          %(values = value.downcase.split(/(?<!\\\\),/).each { |str| str.gsub!('\\,', ',') }
+            match_found = values_found.any? { |value_in_resource| values.any? { |searched_value| value_in_resource.downcase.starts_with? searched_value } })
         else
           # searching by patient requires special case because we are searching by a resource identifier
           # references can also be URL's, so we made need to resolve those url's

--- a/lib/modules/uscore_v3.1.1/us_core_location_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_location_sequence.rb
@@ -57,7 +57,7 @@ module Inferno
         when 'name'
           values_found = resolve_path(resource, 'name')
           values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
-          match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
+          match_found = values_found.any? { |value_in_resource| values.any? { |searched_value| value_in_resource.starts_with? searched_value } }
           assert match_found, "name in Location/#{resource.id} (#{values_found}) does not match name requested (#{value})"
 
         when 'address'
@@ -74,19 +74,19 @@ module Inferno
         when 'address-city'
           values_found = resolve_path(resource, 'address.city')
           values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
-          match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
+          match_found = values_found.any? { |value_in_resource| values.any? { |searched_value| value_in_resource.starts_with? searched_value } }
           assert match_found, "address-city in Location/#{resource.id} (#{values_found}) does not match address-city requested (#{value})"
 
         when 'address-state'
           values_found = resolve_path(resource, 'address.state')
           values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
-          match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
+          match_found = values_found.any? { |value_in_resource| values.any? { |searched_value| value_in_resource.starts_with? searched_value } }
           assert match_found, "address-state in Location/#{resource.id} (#{values_found}) does not match address-state requested (#{value})"
 
         when 'address-postalcode'
           values_found = resolve_path(resource, 'address.postalCode')
           values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
-          match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
+          match_found = values_found.any? { |value_in_resource| values.any? { |searched_value| value_in_resource.starts_with? searched_value } }
           assert match_found, "address-postalcode in Location/#{resource.id} (#{values_found}) does not match address-postalcode requested (#{value})"
 
         end

--- a/lib/modules/uscore_v3.1.1/us_core_location_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_location_sequence.rb
@@ -56,8 +56,8 @@ module Inferno
 
         when 'name'
           values_found = resolve_path(resource, 'name')
-          values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
-          match_found = values_found.any? { |value_in_resource| values.any? { |searched_value| value_in_resource.starts_with? searched_value } }
+          values = value.downcase.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
+          match_found = values_found.any? { |value_in_resource| values.any? { |searched_value| value_in_resource.downcase.starts_with? searched_value } }
           assert match_found, "name in Location/#{resource.id} (#{values_found}) does not match name requested (#{value})"
 
         when 'address'
@@ -73,20 +73,20 @@ module Inferno
 
         when 'address-city'
           values_found = resolve_path(resource, 'address.city')
-          values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
-          match_found = values_found.any? { |value_in_resource| values.any? { |searched_value| value_in_resource.starts_with? searched_value } }
+          values = value.downcase.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
+          match_found = values_found.any? { |value_in_resource| values.any? { |searched_value| value_in_resource.downcase.starts_with? searched_value } }
           assert match_found, "address-city in Location/#{resource.id} (#{values_found}) does not match address-city requested (#{value})"
 
         when 'address-state'
           values_found = resolve_path(resource, 'address.state')
-          values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
-          match_found = values_found.any? { |value_in_resource| values.any? { |searched_value| value_in_resource.starts_with? searched_value } }
+          values = value.downcase.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
+          match_found = values_found.any? { |value_in_resource| values.any? { |searched_value| value_in_resource.downcase.starts_with? searched_value } }
           assert match_found, "address-state in Location/#{resource.id} (#{values_found}) does not match address-state requested (#{value})"
 
         when 'address-postalcode'
           values_found = resolve_path(resource, 'address.postalCode')
-          values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
-          match_found = values_found.any? { |value_in_resource| values.any? { |searched_value| value_in_resource.starts_with? searched_value } }
+          values = value.downcase.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
+          match_found = values_found.any? { |value_in_resource| values.any? { |searched_value| value_in_resource.downcase.starts_with? searched_value } }
           assert match_found, "address-postalcode in Location/#{resource.id} (#{values_found}) does not match address-postalcode requested (#{value})"
 
         end

--- a/lib/modules/uscore_v3.1.1/us_core_organization_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_organization_sequence.rb
@@ -57,7 +57,7 @@ module Inferno
         when 'name'
           values_found = resolve_path(resource, 'name')
           values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
-          match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
+          match_found = values_found.any? { |value_in_resource| values.any? { |searched_value| value_in_resource.starts_with? searched_value } }
           assert match_found, "name in Organization/#{resource.id} (#{values_found}) does not match name requested (#{value})"
 
         when 'address'

--- a/lib/modules/uscore_v3.1.1/us_core_organization_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_organization_sequence.rb
@@ -56,8 +56,8 @@ module Inferno
 
         when 'name'
           values_found = resolve_path(resource, 'name')
-          values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
-          match_found = values_found.any? { |value_in_resource| values.any? { |searched_value| value_in_resource.starts_with? searched_value } }
+          values = value.downcase.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
+          match_found = values_found.any? { |value_in_resource| values.any? { |searched_value| value_in_resource.downcase.starts_with? searched_value } }
           assert match_found, "name in Organization/#{resource.id} (#{values_found}) does not match name requested (#{value})"
 
         when 'address'

--- a/lib/modules/uscore_v3.1.1/us_core_patient_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_patient_sequence.rb
@@ -86,8 +86,8 @@ module Inferno
 
         when 'family'
           values_found = resolve_path(resource, 'name.family')
-          values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
-          match_found = values_found.any? { |value_in_resource| values.any? { |searched_value| value_in_resource.starts_with? searched_value } }
+          values = value.downcase.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
+          match_found = values_found.any? { |value_in_resource| values.any? { |searched_value| value_in_resource.downcase.starts_with? searched_value } }
           assert match_found, "family in Patient/#{resource.id} (#{values_found}) does not match family requested (#{value})"
 
         when 'gender'
@@ -98,8 +98,8 @@ module Inferno
 
         when 'given'
           values_found = resolve_path(resource, 'name.given')
-          values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
-          match_found = values_found.any? { |value_in_resource| values.any? { |searched_value| value_in_resource.starts_with? searched_value } }
+          values = value.downcase.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
+          match_found = values_found.any? { |value_in_resource| values.any? { |searched_value| value_in_resource.downcase.starts_with? searched_value } }
           assert match_found, "given in Patient/#{resource.id} (#{values_found}) does not match given requested (#{value})"
 
         when 'identifier'

--- a/lib/modules/uscore_v3.1.1/us_core_patient_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_patient_sequence.rb
@@ -87,7 +87,7 @@ module Inferno
         when 'family'
           values_found = resolve_path(resource, 'name.family')
           values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
-          match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
+          match_found = values_found.any? { |value_in_resource| values.any? { |searched_value| value_in_resource.starts_with? searched_value } }
           assert match_found, "family in Patient/#{resource.id} (#{values_found}) does not match family requested (#{value})"
 
         when 'gender'
@@ -99,7 +99,7 @@ module Inferno
         when 'given'
           values_found = resolve_path(resource, 'name.given')
           values = value.split(/(?<!\\),/).each { |str| str.gsub!('\,', ',') }
-          match_found = values_found.any? { |value_in_resource| values.include? value_in_resource }
+          match_found = values_found.any? { |value_in_resource| values.any? { |searched_value| value_in_resource.starts_with? searched_value } }
           assert match_found, "given in Patient/#{resource.id} (#{values_found}) does not match given requested (#{value})"
 
         when 'identifier'

--- a/test/unit/sequence_base_test.rb
+++ b/test/unit/sequence_base_test.rb
@@ -58,6 +58,32 @@ class SequenceBaseTest < MiniTest::Test
         end
       end
     end
+
+    it 'passes when string value starts with searched value' do
+      @instance = Inferno::TestingInstance.create!
+      client = FHIR::Client.new('')
+      patient_sequence = Inferno::Sequence::USCore311PatientSequence.new(@instance, client, true)
+      patient_resource = FHIR::Patient.new(
+        name: [{
+          family: 'LastName'
+        }]
+      )
+      patient_sequence.validate_resource_item(patient_resource, 'family', 'las')
+    end
+
+    it 'fails when string value does not start with searched value' do
+      @instance = Inferno::TestingInstance.create!
+      client = FHIR::Client.new('')
+      patient_sequence = Inferno::Sequence::USCore311PatientSequence.new(@instance, client, true)
+      patient_resource = FHIR::Patient.new(
+        name: [{
+          family: 'LastName'
+        }]
+      )
+      assert_raises(Inferno::AssertionException) do
+        patient_sequence.validate_resource_item(patient_resource, 'family', 'something')
+      end
+    end
   end
 
   describe '#date_comparator_value' do

--- a/test/unit/sequence_base_test.rb
+++ b/test/unit/sequence_base_test.rb
@@ -69,6 +69,8 @@ class SequenceBaseTest < MiniTest::Test
         }]
       )
       patient_sequence.validate_resource_item(patient_resource, 'family', 'las')
+      patient_sequence.validate_resource_item(patient_resource, 'family', 'Las')
+      patient_sequence.validate_resource_item(patient_resource, 'family', 'LastName')
     end
 
     it 'fails when string value does not start with searched value' do
@@ -82,6 +84,49 @@ class SequenceBaseTest < MiniTest::Test
       )
       assert_raises(Inferno::AssertionException) do
         patient_sequence.validate_resource_item(patient_resource, 'family', 'something')
+      end
+    end
+
+    # NOTE: The base FHIR spec says that name search can be fuzzy, but we do not currently support this.
+    it 'passes for all required name search variants' do
+      @instance = Inferno::TestingInstance.create!
+      client = FHIR::Client.new('')
+      patient_sequence = Inferno::Sequence::USCore311PatientSequence.new(@instance, client, true)
+      patient_resource = FHIR::Patient.new(
+        name: [{
+          given: ['FirstName', 'MiddleName'],
+          family: 'LastName',
+          suffix: 'iii',
+          prefix: 'Mr.',
+          text: 'Mr. FirstName MiddleName LastName III'
+        }]
+      )
+      patient_sequence.validate_resource_item(patient_resource, 'name', 'LastName')
+      patient_sequence.validate_resource_item(patient_resource, 'name', 'last')
+      patient_sequence.validate_resource_item(patient_resource, 'name', 'Last')
+      patient_sequence.validate_resource_item(patient_resource, 'name', 'FirstName')
+      patient_sequence.validate_resource_item(patient_resource, 'name', 'first')
+      patient_sequence.validate_resource_item(patient_resource, 'name', 'MiddleName')
+      patient_sequence.validate_resource_item(patient_resource, 'name', 'middle')
+      patient_sequence.validate_resource_item(patient_resource, 'name', 'iii')
+      patient_sequence.validate_resource_item(patient_resource, 'name', 'Mr. FirstName')
+    end
+
+    it 'fails for all invalid name searches' do
+      @instance = Inferno::TestingInstance.create!
+      client = FHIR::Client.new('')
+      patient_sequence = Inferno::Sequence::USCore311PatientSequence.new(@instance, client, true)
+      patient_resource = FHIR::Patient.new(
+        name: [{
+          given: ['FirstName', 'MiddleName'],
+          family: 'LastName',
+          suffix: 'iii',
+          prefix: 'Mr.',
+          text: 'Mr. FirstName MiddleName LastName III'
+        }]
+      )
+      assert_raises(Inferno::AssertionException) do
+        patient_sequence.validate_resource_item(patient_resource, 'name', 'XYZ')
       end
     end
   end


### PR DESCRIPTION
# Summary
This addresses an issue where tests that searched against a string target value incorrectly failed. This happens because the validation checked if the searched value was the value in the resource. It should instead just check if the value in the resource starts with the searched value. https://www.hl7.org/fhir/search.html#string

Eg.) searching for family="test" might return two patients with family="test" and family="testing". The "testing" value would've incorrectly failed validation. 

## New behavior
Searches against string values will check that the value starts with the searched value.

## Code changes
I changed the validation portion of validate_resource_item for parameters that had a string search value.

## Testing guidance

