### PR TITLE
made skips have return value 1 so task fails if there are skips

### DIFF
--- a/lib/tasks/tasks.rake
+++ b/lib/tasks/tasks.rake
@@ -54,6 +54,7 @@ def execute(instance, sequences)
   sequence_results = []
 
   fails = false
+  skips = false
 
   system 'clear'
   puts "\n"
@@ -138,6 +139,7 @@ def execute(instance, sequences)
       fails = true
     elsif sequence_result.skip?
       puts 'skip '.yellow + '*'.yellow
+      skips = true
     end
     puts "---------------------------------------------\n"
   end
@@ -157,7 +159,7 @@ def execute(instance, sequences)
   puts "\n=============================================\n"
 
   return_value = 0
-  return_value = 1 if fails
+  return_value = 1 if fails || skips
 
   return_value
 end


### PR DESCRIPTION
# Summary
For the execute rake task, now if the inferno tests have a skip it has a return value 1 so ci workflows using this fail on skips.

## New behavior
rake task has return_value 1 if there are skips

## Code changes

## Testing guidance

1. Build this image as `onchealthit/inferno-program:release-latest`

2. Checkout the inferno-reference server on branch `add-github-ci-to-run-inferno-tests` 

3. Run `docker-compose -f ./.github/inferno/docker-compose.yml run -T inferno_program ./wait-for-it.sh -t 0 reference_server:8080 -- bundle exec rake db:create db:migrate inferno:execute[http://reference_server:8080/reference-server/r4,onc_program,UsCoreR4CapabilityStatement,USCore311Patient,USCore311Allergyintolerance,USCore311Careplan,USCore311Careteam,USCore311Condition,USCore311ImplantableDevice,USCore311DiagnosticreportNote,USCore311DiagnosticreportLab,USCore311Documentreference,USCore311Goal,USCore311Immunization,USCore311Medicationrequest,USCore311Smokingstatus,USCore311PediatricWeightForHeight,USCore311ObservationLab,USCore311PediatricBmiForAge,USCore311PulseOximetry,USCore311HeadOccipitalFrontalCircumferencePercentile,USCore311Bodyheight,USCore311Bodytemp,USCore311Bp,USCore311Bodyweight,USCore311Heartrate,USCore311Resprate,USCore311Procedure,USCoreR4ClinicalNotes,USCore311Encounter,USCore311Location,USCore311Organization,USCore311Practitioner,USCore311Practitionerrole,USCore311Provenance,USCoreR4DataAbsentReason] --  --TOKEN SAMPLE_TOKEN --PATIENT_IDS 85,355 --DEVICE_CODES ""`


This should fail with "ERROR:1"