### PR TITLE
Updated Provenance Test to not require search

### DIFF
--- a/lib/modules/uscore_v3.1.1/us_core_provenance_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_provenance_sequence.rb
@@ -211,7 +211,7 @@ module Inferno
           versions :r4
         end
 
-        skip_if_known_not_supported(:Provenance, [:search, :read])
+        skip_if_known_not_supported(:Provenance, [:read])
         skip_if_not_found(resource_type: 'Provenance', delayed: true)
 
         validated_resources = Set.new


### PR DESCRIPTION

# Summary
USCPROV-04 fails on the reference server because the test required Provenance search. The reference server conformance statement do not support search as US Core does not require it. Updated the test to only check for read.

## New behavior
The reference server should pass all Single Patient Api tests (specifically USCPROV-04)


