### PR TITLE
Fi 1269 reference server pass USCPROV 04

### DIFF
--- a/generator/uscore/uscore_generator.rb
+++ b/generator/uscore/uscore_generator.rb
@@ -716,7 +716,7 @@ module Inferno
       def create_resource_profile_test(sequence)
         test_key = :validate_resources
         test = {
-          tests_that: "#{sequence[:resource]} resources returned from previous search conform to the #{sequence[:profile_name]}.",
+          tests_that: "#{sequence[:resource]} resources returned conform to the #{sequence[:profile_name]}.",
           key: test_key,
           index: sequence[:tests].length + 1,
           link: sequence[:profile],
@@ -924,7 +924,6 @@ module Inferno
 
         resource_array = sequence[:delayed_sequence] ? "@#{sequence[:resource].underscore}_ary" : "@#{sequence[:resource].underscore}_ary&.values&.flatten"
         test[:test_code] = %(
-              skip_if_known_not_supported(:#{sequence[:resource]}, [:search, :read])
               #{skip_if_not_found_code(sequence)}
 
               validated_resources = Set.new

--- a/generator/uscore/uscore_generator.rb
+++ b/generator/uscore/uscore_generator.rb
@@ -716,7 +716,7 @@ module Inferno
       def create_resource_profile_test(sequence)
         test_key = :validate_resources
         test = {
-          tests_that: "#{sequence[:resource]} resources returned conform to the #{sequence[:profile_name]}.",
+          tests_that: "#{sequence[:resource]} resources returned during previous tests conform to the #{sequence[:profile_name]}.",
           key: test_key,
           index: sequence[:tests].length + 1,
           link: sequence[:profile],

--- a/lib/modules/uscore_v3.1.1/bodyheight_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/bodyheight_sequence.rb
@@ -564,7 +564,7 @@ module Inferno
       test :validate_resources do
         metadata do
           id '10'
-          name 'Observation resources returned from previous search conform to the Observation Body Height Profile.'
+          name 'Observation resources returned conform to the Observation Body Height Profile.'
           link 'http://hl7.org/fhir/StructureDefinition/bodyheight'
           description %(
 
@@ -695,7 +695,6 @@ module Inferno
           versions :r4
         end
 
-        skip_if_known_not_supported(:Observation, [:search, :read])
         skip_if_not_found(resource_type: 'Observation', delayed: false)
 
         validated_resources = Set.new

--- a/lib/modules/uscore_v3.1.1/bodyheight_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/bodyheight_sequence.rb
@@ -564,7 +564,7 @@ module Inferno
       test :validate_resources do
         metadata do
           id '10'
-          name 'Observation resources returned conform to the Observation Body Height Profile.'
+          name 'Observation resources returned during previous tests conform to the Observation Body Height Profile.'
           link 'http://hl7.org/fhir/StructureDefinition/bodyheight'
           description %(
 

--- a/lib/modules/uscore_v3.1.1/bodytemp_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/bodytemp_sequence.rb
@@ -564,7 +564,7 @@ module Inferno
       test :validate_resources do
         metadata do
           id '10'
-          name 'Observation resources returned conform to the Observation Body Temperature Profile.'
+          name 'Observation resources returned during previous tests conform to the Observation Body Temperature Profile.'
           link 'http://hl7.org/fhir/StructureDefinition/bodytemp'
           description %(
 

--- a/lib/modules/uscore_v3.1.1/bodytemp_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/bodytemp_sequence.rb
@@ -564,7 +564,7 @@ module Inferno
       test :validate_resources do
         metadata do
           id '10'
-          name 'Observation resources returned from previous search conform to the Observation Body Temperature Profile.'
+          name 'Observation resources returned conform to the Observation Body Temperature Profile.'
           link 'http://hl7.org/fhir/StructureDefinition/bodytemp'
           description %(
 
@@ -695,7 +695,6 @@ module Inferno
           versions :r4
         end
 
-        skip_if_known_not_supported(:Observation, [:search, :read])
         skip_if_not_found(resource_type: 'Observation', delayed: false)
 
         validated_resources = Set.new

--- a/lib/modules/uscore_v3.1.1/bodyweight_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/bodyweight_sequence.rb
@@ -564,7 +564,7 @@ module Inferno
       test :validate_resources do
         metadata do
           id '10'
-          name 'Observation resources returned from previous search conform to the Observation Body Weight Profile.'
+          name 'Observation resources returned conform to the Observation Body Weight Profile.'
           link 'http://hl7.org/fhir/StructureDefinition/bodyweight'
           description %(
 
@@ -695,7 +695,6 @@ module Inferno
           versions :r4
         end
 
-        skip_if_known_not_supported(:Observation, [:search, :read])
         skip_if_not_found(resource_type: 'Observation', delayed: false)
 
         validated_resources = Set.new

--- a/lib/modules/uscore_v3.1.1/bodyweight_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/bodyweight_sequence.rb
@@ -564,7 +564,7 @@ module Inferno
       test :validate_resources do
         metadata do
           id '10'
-          name 'Observation resources returned conform to the Observation Body Weight Profile.'
+          name 'Observation resources returned during previous tests conform to the Observation Body Weight Profile.'
           link 'http://hl7.org/fhir/StructureDefinition/bodyweight'
           description %(
 

--- a/lib/modules/uscore_v3.1.1/bp_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/bp_sequence.rb
@@ -564,7 +564,7 @@ module Inferno
       test :validate_resources do
         metadata do
           id '10'
-          name 'Observation resources returned conform to the Observation Blood Pressure Profile.'
+          name 'Observation resources returned during previous tests conform to the Observation Blood Pressure Profile.'
           link 'http://hl7.org/fhir/StructureDefinition/bp'
           description %(
 

--- a/lib/modules/uscore_v3.1.1/bp_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/bp_sequence.rb
@@ -564,7 +564,7 @@ module Inferno
       test :validate_resources do
         metadata do
           id '10'
-          name 'Observation resources returned from previous search conform to the Observation Blood Pressure Profile.'
+          name 'Observation resources returned conform to the Observation Blood Pressure Profile.'
           link 'http://hl7.org/fhir/StructureDefinition/bp'
           description %(
 
@@ -689,7 +689,6 @@ module Inferno
           versions :r4
         end
 
-        skip_if_known_not_supported(:Observation, [:search, :read])
         skip_if_not_found(resource_type: 'Observation', delayed: false)
 
         validated_resources = Set.new

--- a/lib/modules/uscore_v3.1.1/head_occipital_frontal_circumference_percentile_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/head_occipital_frontal_circumference_percentile_sequence.rb
@@ -564,7 +564,7 @@ module Inferno
       test :validate_resources do
         metadata do
           id '10'
-          name 'Observation resources returned from previous search conform to the US Core Pediatric Head Occipital-frontal Circumference Percentile Profile.'
+          name 'Observation resources returned conform to the US Core Pediatric Head Occipital-frontal Circumference Percentile Profile.'
           link 'http://hl7.org/fhir/us/core/StructureDefinition/head-occipital-frontal-circumference-percentile'
           description %(
 
@@ -694,7 +694,6 @@ module Inferno
           versions :r4
         end
 
-        skip_if_known_not_supported(:Observation, [:search, :read])
         skip_if_not_found(resource_type: 'Observation', delayed: false)
 
         validated_resources = Set.new

--- a/lib/modules/uscore_v3.1.1/head_occipital_frontal_circumference_percentile_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/head_occipital_frontal_circumference_percentile_sequence.rb
@@ -564,7 +564,7 @@ module Inferno
       test :validate_resources do
         metadata do
           id '10'
-          name 'Observation resources returned conform to the US Core Pediatric Head Occipital-frontal Circumference Percentile Profile.'
+          name 'Observation resources returned during previous tests conform to the US Core Pediatric Head Occipital-frontal Circumference Percentile Profile.'
           link 'http://hl7.org/fhir/us/core/StructureDefinition/head-occipital-frontal-circumference-percentile'
           description %(
 

--- a/lib/modules/uscore_v3.1.1/heartrate_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/heartrate_sequence.rb
@@ -564,7 +564,7 @@ module Inferno
       test :validate_resources do
         metadata do
           id '10'
-          name 'Observation resources returned conform to the Observation Heart Rate Profile.'
+          name 'Observation resources returned during previous tests conform to the Observation Heart Rate Profile.'
           link 'http://hl7.org/fhir/StructureDefinition/heartrate'
           description %(
 

--- a/lib/modules/uscore_v3.1.1/heartrate_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/heartrate_sequence.rb
@@ -564,7 +564,7 @@ module Inferno
       test :validate_resources do
         metadata do
           id '10'
-          name 'Observation resources returned from previous search conform to the Observation Heart Rate Profile.'
+          name 'Observation resources returned conform to the Observation Heart Rate Profile.'
           link 'http://hl7.org/fhir/StructureDefinition/heartrate'
           description %(
 
@@ -695,7 +695,6 @@ module Inferno
           versions :r4
         end
 
-        skip_if_known_not_supported(:Observation, [:search, :read])
         skip_if_not_found(resource_type: 'Observation', delayed: false)
 
         validated_resources = Set.new

--- a/lib/modules/uscore_v3.1.1/pediatric_bmi_for_age_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/pediatric_bmi_for_age_sequence.rb
@@ -564,7 +564,7 @@ module Inferno
       test :validate_resources do
         metadata do
           id '10'
-          name 'Observation resources returned from previous search conform to the US Core Pediatric BMI for Age Observation Profile.'
+          name 'Observation resources returned conform to the US Core Pediatric BMI for Age Observation Profile.'
           link 'http://hl7.org/fhir/us/core/StructureDefinition/pediatric-bmi-for-age'
           description %(
 
@@ -694,7 +694,6 @@ module Inferno
           versions :r4
         end
 
-        skip_if_known_not_supported(:Observation, [:search, :read])
         skip_if_not_found(resource_type: 'Observation', delayed: false)
 
         validated_resources = Set.new

--- a/lib/modules/uscore_v3.1.1/pediatric_bmi_for_age_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/pediatric_bmi_for_age_sequence.rb
@@ -564,7 +564,7 @@ module Inferno
       test :validate_resources do
         metadata do
           id '10'
-          name 'Observation resources returned conform to the US Core Pediatric BMI for Age Observation Profile.'
+          name 'Observation resources returned during previous tests conform to the US Core Pediatric BMI for Age Observation Profile.'
           link 'http://hl7.org/fhir/us/core/StructureDefinition/pediatric-bmi-for-age'
           description %(
 

--- a/lib/modules/uscore_v3.1.1/pediatric_weight_for_height_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/pediatric_weight_for_height_sequence.rb
@@ -564,7 +564,7 @@ module Inferno
       test :validate_resources do
         metadata do
           id '10'
-          name 'Observation resources returned from previous search conform to the US Core Pediatric Weight for Height Observation Profile.'
+          name 'Observation resources returned conform to the US Core Pediatric Weight for Height Observation Profile.'
           link 'http://hl7.org/fhir/us/core/StructureDefinition/pediatric-weight-for-height'
           description %(
 
@@ -694,7 +694,6 @@ module Inferno
           versions :r4
         end
 
-        skip_if_known_not_supported(:Observation, [:search, :read])
         skip_if_not_found(resource_type: 'Observation', delayed: false)
 
         validated_resources = Set.new

--- a/lib/modules/uscore_v3.1.1/pediatric_weight_for_height_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/pediatric_weight_for_height_sequence.rb
@@ -564,7 +564,7 @@ module Inferno
       test :validate_resources do
         metadata do
           id '10'
-          name 'Observation resources returned conform to the US Core Pediatric Weight for Height Observation Profile.'
+          name 'Observation resources returned during previous tests conform to the US Core Pediatric Weight for Height Observation Profile.'
           link 'http://hl7.org/fhir/us/core/StructureDefinition/pediatric-weight-for-height'
           description %(
 

--- a/lib/modules/uscore_v3.1.1/resprate_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/resprate_sequence.rb
@@ -564,7 +564,7 @@ module Inferno
       test :validate_resources do
         metadata do
           id '10'
-          name 'Observation resources returned from previous search conform to the Observation Respiratory Rate Profile.'
+          name 'Observation resources returned conform to the Observation Respiratory Rate Profile.'
           link 'http://hl7.org/fhir/StructureDefinition/resprate'
           description %(
 
@@ -695,7 +695,6 @@ module Inferno
           versions :r4
         end
 
-        skip_if_known_not_supported(:Observation, [:search, :read])
         skip_if_not_found(resource_type: 'Observation', delayed: false)
 
         validated_resources = Set.new

--- a/lib/modules/uscore_v3.1.1/resprate_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/resprate_sequence.rb
@@ -564,7 +564,7 @@ module Inferno
       test :validate_resources do
         metadata do
           id '10'
-          name 'Observation resources returned conform to the Observation Respiratory Rate Profile.'
+          name 'Observation resources returned during previous tests conform to the Observation Respiratory Rate Profile.'
           link 'http://hl7.org/fhir/StructureDefinition/resprate'
           description %(
 

--- a/lib/modules/uscore_v3.1.1/us_core_allergyintolerance_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_allergyintolerance_sequence.rb
@@ -356,7 +356,7 @@ module Inferno
       test :validate_resources do
         metadata do
           id '07'
-          name 'AllergyIntolerance resources returned from previous search conform to the US  Core AllergyIntolerance Profile.'
+          name 'AllergyIntolerance resources returned conform to the US  Core AllergyIntolerance Profile.'
           link 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-allergyintolerance'
           description %(
 
@@ -484,7 +484,6 @@ module Inferno
           versions :r4
         end
 
-        skip_if_known_not_supported(:AllergyIntolerance, [:search, :read])
         skip_if_not_found(resource_type: 'AllergyIntolerance', delayed: false)
 
         validated_resources = Set.new

--- a/lib/modules/uscore_v3.1.1/us_core_allergyintolerance_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_allergyintolerance_sequence.rb
@@ -356,7 +356,7 @@ module Inferno
       test :validate_resources do
         metadata do
           id '07'
-          name 'AllergyIntolerance resources returned conform to the US  Core AllergyIntolerance Profile.'
+          name 'AllergyIntolerance resources returned during previous tests conform to the US  Core AllergyIntolerance Profile.'
           link 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-allergyintolerance'
           description %(
 

--- a/lib/modules/uscore_v3.1.1/us_core_careplan_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_careplan_sequence.rb
@@ -392,7 +392,7 @@ module Inferno
       test :validate_resources do
         metadata do
           id '07'
-          name 'CarePlan resources returned conform to the US Core CarePlan Profile.'
+          name 'CarePlan resources returned during previous tests conform to the US Core CarePlan Profile.'
           link 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-careplan'
           description %(
 

--- a/lib/modules/uscore_v3.1.1/us_core_careplan_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_careplan_sequence.rb
@@ -392,7 +392,7 @@ module Inferno
       test :validate_resources do
         metadata do
           id '07'
-          name 'CarePlan resources returned from previous search conform to the US Core CarePlan Profile.'
+          name 'CarePlan resources returned conform to the US Core CarePlan Profile.'
           link 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-careplan'
           description %(
 
@@ -514,7 +514,6 @@ module Inferno
           versions :r4
         end
 
-        skip_if_known_not_supported(:CarePlan, [:search, :read])
         skip_if_not_found(resource_type: 'CarePlan', delayed: false)
 
         validated_resources = Set.new

--- a/lib/modules/uscore_v3.1.1/us_core_careteam_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_careteam_sequence.rb
@@ -317,7 +317,7 @@ module Inferno
       test :validate_resources do
         metadata do
           id '06'
-          name 'CareTeam resources returned from previous search conform to the US Core CareTeam Profile.'
+          name 'CareTeam resources returned conform to the US Core CareTeam Profile.'
           link 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-careteam'
           description %(
 
@@ -477,7 +477,6 @@ module Inferno
           versions :r4
         end
 
-        skip_if_known_not_supported(:CareTeam, [:search, :read])
         skip_if_not_found(resource_type: 'CareTeam', delayed: false)
 
         validated_resources = Set.new

--- a/lib/modules/uscore_v3.1.1/us_core_careteam_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_careteam_sequence.rb
@@ -317,7 +317,7 @@ module Inferno
       test :validate_resources do
         metadata do
           id '06'
-          name 'CareTeam resources returned conform to the US Core CareTeam Profile.'
+          name 'CareTeam resources returned during previous tests conform to the US Core CareTeam Profile.'
           link 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-careteam'
           description %(
 

--- a/lib/modules/uscore_v3.1.1/us_core_condition_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_condition_sequence.rb
@@ -477,7 +477,7 @@ module Inferno
       test :validate_resources do
         metadata do
           id '09'
-          name 'Condition resources returned conform to the US Core Condition Profile.'
+          name 'Condition resources returned during previous tests conform to the US Core Condition Profile.'
           link 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-condition'
           description %(
 

--- a/lib/modules/uscore_v3.1.1/us_core_condition_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_condition_sequence.rb
@@ -477,7 +477,7 @@ module Inferno
       test :validate_resources do
         metadata do
           id '09'
-          name 'Condition resources returned from previous search conform to the US Core Condition Profile.'
+          name 'Condition resources returned conform to the US Core Condition Profile.'
           link 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-condition'
           description %(
 
@@ -604,7 +604,6 @@ module Inferno
           versions :r4
         end
 
-        skip_if_known_not_supported(:Condition, [:search, :read])
         skip_if_not_found(resource_type: 'Condition', delayed: false)
 
         validated_resources = Set.new

--- a/lib/modules/uscore_v3.1.1/us_core_diagnosticreport_lab_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_diagnosticreport_lab_sequence.rb
@@ -591,7 +591,7 @@ module Inferno
       test :validate_resources do
         metadata do
           id '11'
-          name 'DiagnosticReport resources returned conform to the US Core DiagnosticReport Profile for Laboratory Results Reporting.'
+          name 'DiagnosticReport resources returned during previous tests conform to the US Core DiagnosticReport Profile for Laboratory Results Reporting.'
           link 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-diagnosticreport-lab'
           description %(
 

--- a/lib/modules/uscore_v3.1.1/us_core_diagnosticreport_lab_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_diagnosticreport_lab_sequence.rb
@@ -591,7 +591,7 @@ module Inferno
       test :validate_resources do
         metadata do
           id '11'
-          name 'DiagnosticReport resources returned from previous search conform to the US Core DiagnosticReport Profile for Laboratory Results Reporting.'
+          name 'DiagnosticReport resources returned conform to the US Core DiagnosticReport Profile for Laboratory Results Reporting.'
           link 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-diagnosticreport-lab'
           description %(
 
@@ -715,7 +715,6 @@ module Inferno
           versions :r4
         end
 
-        skip_if_known_not_supported(:DiagnosticReport, [:search, :read])
         skip_if_not_found(resource_type: 'DiagnosticReport', delayed: false)
 
         validated_resources = Set.new

--- a/lib/modules/uscore_v3.1.1/us_core_diagnosticreport_note_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_diagnosticreport_note_sequence.rb
@@ -591,7 +591,7 @@ module Inferno
       test :validate_resources do
         metadata do
           id '11'
-          name 'DiagnosticReport resources returned from previous search conform to the US Core DiagnosticReport Profile for Report and Note exchange.'
+          name 'DiagnosticReport resources returned conform to the US Core DiagnosticReport Profile for Report and Note exchange.'
           link 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-diagnosticreport-note'
           description %(
 
@@ -706,7 +706,6 @@ module Inferno
           versions :r4
         end
 
-        skip_if_known_not_supported(:DiagnosticReport, [:search, :read])
         skip_if_not_found(resource_type: 'DiagnosticReport', delayed: false)
 
         validated_resources = Set.new

--- a/lib/modules/uscore_v3.1.1/us_core_diagnosticreport_note_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_diagnosticreport_note_sequence.rb
@@ -591,7 +591,7 @@ module Inferno
       test :validate_resources do
         metadata do
           id '11'
-          name 'DiagnosticReport resources returned conform to the US Core DiagnosticReport Profile for Report and Note exchange.'
+          name 'DiagnosticReport resources returned during previous tests conform to the US Core DiagnosticReport Profile for Report and Note exchange.'
           link 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-diagnosticreport-note'
           description %(
 

--- a/lib/modules/uscore_v3.1.1/us_core_documentreference_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_documentreference_sequence.rb
@@ -623,7 +623,7 @@ module Inferno
       test :validate_resources do
         metadata do
           id '12'
-          name 'DocumentReference resources returned conform to the US Core DocumentReference Profile.'
+          name 'DocumentReference resources returned during previous tests conform to the US Core DocumentReference Profile.'
           link 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-documentreference'
           description %(
 

--- a/lib/modules/uscore_v3.1.1/us_core_documentreference_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_documentreference_sequence.rb
@@ -623,7 +623,7 @@ module Inferno
       test :validate_resources do
         metadata do
           id '12'
-          name 'DocumentReference resources returned from previous search conform to the US Core DocumentReference Profile.'
+          name 'DocumentReference resources returned conform to the US Core DocumentReference Profile.'
           link 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-documentreference'
           description %(
 
@@ -762,7 +762,6 @@ module Inferno
           versions :r4
         end
 
-        skip_if_known_not_supported(:DocumentReference, [:search, :read])
         skip_if_not_found(resource_type: 'DocumentReference', delayed: false)
 
         validated_resources = Set.new

--- a/lib/modules/uscore_v3.1.1/us_core_encounter_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_encounter_sequence.rb
@@ -177,7 +177,7 @@ module Inferno
       test :validate_resources do
         metadata do
           id '02'
-          name 'Encounter resources returned from previous search conform to the US Core Encounter Profile.'
+          name 'Encounter resources returned conform to the US Core Encounter Profile.'
           link 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-encounter'
           description %(
 
@@ -300,7 +300,6 @@ module Inferno
           versions :r4
         end
 
-        skip_if_known_not_supported(:Encounter, [:search, :read])
         skip_if_not_found(resource_type: 'Encounter', delayed: true)
 
         validated_resources = Set.new

--- a/lib/modules/uscore_v3.1.1/us_core_encounter_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_encounter_sequence.rb
@@ -177,7 +177,7 @@ module Inferno
       test :validate_resources do
         metadata do
           id '02'
-          name 'Encounter resources returned conform to the US Core Encounter Profile.'
+          name 'Encounter resources returned during previous tests conform to the US Core Encounter Profile.'
           link 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-encounter'
           description %(
 

--- a/lib/modules/uscore_v3.1.1/us_core_goal_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_goal_sequence.rb
@@ -349,7 +349,7 @@ module Inferno
       test :validate_resources do
         metadata do
           id '07'
-          name 'Goal resources returned conform to the US Core Goal Profile.'
+          name 'Goal resources returned during previous tests conform to the US Core Goal Profile.'
           link 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-goal'
           description %(
 

--- a/lib/modules/uscore_v3.1.1/us_core_goal_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_goal_sequence.rb
@@ -349,7 +349,7 @@ module Inferno
       test :validate_resources do
         metadata do
           id '07'
-          name 'Goal resources returned from previous search conform to the US Core Goal Profile.'
+          name 'Goal resources returned conform to the US Core Goal Profile.'
           link 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-goal'
           description %(
 
@@ -469,7 +469,6 @@ module Inferno
           versions :r4
         end
 
-        skip_if_known_not_supported(:Goal, [:search, :read])
         skip_if_not_found(resource_type: 'Goal', delayed: false)
 
         validated_resources = Set.new

--- a/lib/modules/uscore_v3.1.1/us_core_immunization_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_immunization_sequence.rb
@@ -400,7 +400,7 @@ module Inferno
       test :validate_resources do
         metadata do
           id '08'
-          name 'Immunization resources returned conform to the US Core Immunization Profile.'
+          name 'Immunization resources returned during previous tests conform to the US Core Immunization Profile.'
           link 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-immunization'
           description %(
 

--- a/lib/modules/uscore_v3.1.1/us_core_immunization_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_immunization_sequence.rb
@@ -400,7 +400,7 @@ module Inferno
       test :validate_resources do
         metadata do
           id '08'
-          name 'Immunization resources returned from previous search conform to the US Core Immunization Profile.'
+          name 'Immunization resources returned conform to the US Core Immunization Profile.'
           link 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-immunization'
           description %(
 
@@ -512,7 +512,6 @@ module Inferno
           versions :r4
         end
 
-        skip_if_known_not_supported(:Immunization, [:search, :read])
         skip_if_not_found(resource_type: 'Immunization', delayed: false)
 
         validated_resources = Set.new

--- a/lib/modules/uscore_v3.1.1/us_core_implantable_device_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_implantable_device_sequence.rb
@@ -325,7 +325,7 @@ module Inferno
       test :validate_resources do
         metadata do
           id '07'
-          name 'Device resources returned from previous search conform to the US Core Implantable Device Profile.'
+          name 'Device resources returned conform to the US Core Implantable Device Profile.'
           link 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-implantable-device'
           description %(
 
@@ -445,7 +445,6 @@ module Inferno
           versions :r4
         end
 
-        skip_if_known_not_supported(:Device, [:search, :read])
         skip_if_not_found(resource_type: 'Device', delayed: false)
 
         validated_resources = Set.new

--- a/lib/modules/uscore_v3.1.1/us_core_implantable_device_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_implantable_device_sequence.rb
@@ -325,7 +325,7 @@ module Inferno
       test :validate_resources do
         metadata do
           id '07'
-          name 'Device resources returned conform to the US Core Implantable Device Profile.'
+          name 'Device resources returned during previous tests conform to the US Core Implantable Device Profile.'
           link 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-implantable-device'
           description %(
 

--- a/lib/modules/uscore_v3.1.1/us_core_location_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_location_sequence.rb
@@ -128,7 +128,7 @@ module Inferno
       test :validate_resources do
         metadata do
           id '02'
-          name 'Location resources returned from previous search conform to the US Core Location Profile.'
+          name 'Location resources returned conform to the US Core Location Profile.'
           link 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-location'
           description %(
 
@@ -243,7 +243,6 @@ module Inferno
           versions :r4
         end
 
-        skip_if_known_not_supported(:Location, [:search, :read])
         skip_if_not_found(resource_type: 'Location', delayed: true)
 
         validated_resources = Set.new

--- a/lib/modules/uscore_v3.1.1/us_core_location_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_location_sequence.rb
@@ -128,7 +128,7 @@ module Inferno
       test :validate_resources do
         metadata do
           id '02'
-          name 'Location resources returned conform to the US Core Location Profile.'
+          name 'Location resources returned during previous tests conform to the US Core Location Profile.'
           link 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-location'
           description %(
 

--- a/lib/modules/uscore_v3.1.1/us_core_medicationrequest_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_medicationrequest_sequence.rb
@@ -572,7 +572,7 @@ module Inferno
       test :validate_resources do
         metadata do
           id '10'
-          name 'MedicationRequest resources returned from previous search conform to the US Core MedicationRequest Profile.'
+          name 'MedicationRequest resources returned conform to the US Core MedicationRequest Profile.'
           link 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-medicationrequest'
           description %(
 
@@ -790,7 +790,6 @@ module Inferno
           versions :r4
         end
 
-        skip_if_known_not_supported(:MedicationRequest, [:search, :read])
         skip_if_not_found(resource_type: 'MedicationRequest', delayed: false)
 
         validated_resources = Set.new

--- a/lib/modules/uscore_v3.1.1/us_core_medicationrequest_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_medicationrequest_sequence.rb
@@ -572,7 +572,7 @@ module Inferno
       test :validate_resources do
         metadata do
           id '10'
-          name 'MedicationRequest resources returned conform to the US Core MedicationRequest Profile.'
+          name 'MedicationRequest resources returned during previous tests conform to the US Core MedicationRequest Profile.'
           link 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-medicationrequest'
           description %(
 

--- a/lib/modules/uscore_v3.1.1/us_core_observation_lab_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_observation_lab_sequence.rb
@@ -564,7 +564,7 @@ module Inferno
       test :validate_resources do
         metadata do
           id '10'
-          name 'Observation resources returned conform to the US Core Laboratory Result Observation Profile.'
+          name 'Observation resources returned during previous tests conform to the US Core Laboratory Result Observation Profile.'
           link 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-lab'
           description %(
 

--- a/lib/modules/uscore_v3.1.1/us_core_observation_lab_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_observation_lab_sequence.rb
@@ -564,7 +564,7 @@ module Inferno
       test :validate_resources do
         metadata do
           id '10'
-          name 'Observation resources returned from previous search conform to the US Core Laboratory Result Observation Profile.'
+          name 'Observation resources returned conform to the US Core Laboratory Result Observation Profile.'
           link 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-lab'
           description %(
 
@@ -687,7 +687,6 @@ module Inferno
           versions :r4
         end
 
-        skip_if_known_not_supported(:Observation, [:search, :read])
         skip_if_not_found(resource_type: 'Observation', delayed: false)
 
         validated_resources = Set.new

--- a/lib/modules/uscore_v3.1.1/us_core_organization_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_organization_sequence.rb
@@ -110,7 +110,7 @@ module Inferno
       test :validate_resources do
         metadata do
           id '02'
-          name 'Organization resources returned conform to the US Core Organization Profile.'
+          name 'Organization resources returned during previous tests conform to the US Core Organization Profile.'
           link 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-organization'
           description %(
 

--- a/lib/modules/uscore_v3.1.1/us_core_organization_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_organization_sequence.rb
@@ -110,7 +110,7 @@ module Inferno
       test :validate_resources do
         metadata do
           id '02'
-          name 'Organization resources returned from previous search conform to the US Core Organization Profile.'
+          name 'Organization resources returned conform to the US Core Organization Profile.'
           link 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-organization'
           description %(
 
@@ -238,7 +238,6 @@ module Inferno
           versions :r4
         end
 
-        skip_if_known_not_supported(:Organization, [:search, :read])
         skip_if_not_found(resource_type: 'Organization', delayed: true)
 
         validated_resources = Set.new

--- a/lib/modules/uscore_v3.1.1/us_core_patient_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_patient_sequence.rb
@@ -528,7 +528,7 @@ module Inferno
       test :validate_resources do
         metadata do
           id '12'
-          name 'Patient resources returned from previous search conform to the US Core Patient Profile.'
+          name 'Patient resources returned conform to the US Core Patient Profile.'
           link 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient'
           description %(
 
@@ -665,7 +665,6 @@ module Inferno
           versions :r4
         end
 
-        skip_if_known_not_supported(:Patient, [:search, :read])
         skip_if_not_found(resource_type: 'Patient', delayed: false)
 
         validated_resources = Set.new

--- a/lib/modules/uscore_v3.1.1/us_core_patient_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_patient_sequence.rb
@@ -528,7 +528,7 @@ module Inferno
       test :validate_resources do
         metadata do
           id '12'
-          name 'Patient resources returned conform to the US Core Patient Profile.'
+          name 'Patient resources returned during previous tests conform to the US Core Patient Profile.'
           link 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient'
           description %(
 

--- a/lib/modules/uscore_v3.1.1/us_core_practitioner_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_practitioner_sequence.rb
@@ -114,7 +114,7 @@ module Inferno
       test :validate_resources do
         metadata do
           id '02'
-          name 'Practitioner resources returned conform to the US Core Practitioner Profile.'
+          name 'Practitioner resources returned during previous tests conform to the US Core Practitioner Profile.'
           link 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitioner'
           description %(
 

--- a/lib/modules/uscore_v3.1.1/us_core_practitioner_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_practitioner_sequence.rb
@@ -114,7 +114,7 @@ module Inferno
       test :validate_resources do
         metadata do
           id '02'
-          name 'Practitioner resources returned from previous search conform to the US Core Practitioner Profile.'
+          name 'Practitioner resources returned conform to the US Core Practitioner Profile.'
           link 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitioner'
           description %(
 
@@ -235,7 +235,6 @@ module Inferno
           versions :r4
         end
 
-        skip_if_known_not_supported(:Practitioner, [:search, :read])
         skip_if_not_found(resource_type: 'Practitioner', delayed: true)
 
         validated_resources = Set.new

--- a/lib/modules/uscore_v3.1.1/us_core_practitionerrole_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_practitionerrole_sequence.rb
@@ -112,7 +112,7 @@ module Inferno
       test :validate_resources do
         metadata do
           id '02'
-          name 'PractitionerRole resources returned conform to the US Core PractitionerRole Profile.'
+          name 'PractitionerRole resources returned during previous tests conform to the US Core PractitionerRole Profile.'
           link 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitionerrole'
           description %(
 

--- a/lib/modules/uscore_v3.1.1/us_core_practitionerrole_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_practitionerrole_sequence.rb
@@ -112,7 +112,7 @@ module Inferno
       test :validate_resources do
         metadata do
           id '02'
-          name 'PractitionerRole resources returned from previous search conform to the US Core PractitionerRole Profile.'
+          name 'PractitionerRole resources returned conform to the US Core PractitionerRole Profile.'
           link 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitionerrole'
           description %(
 
@@ -227,7 +227,6 @@ module Inferno
           versions :r4
         end
 
-        skip_if_known_not_supported(:PractitionerRole, [:search, :read])
         skip_if_not_found(resource_type: 'PractitionerRole', delayed: true)
 
         validated_resources = Set.new

--- a/lib/modules/uscore_v3.1.1/us_core_procedure_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_procedure_sequence.rb
@@ -470,7 +470,7 @@ module Inferno
       test :validate_resources do
         metadata do
           id '09'
-          name 'Procedure resources returned conform to the US Core Procedure Profile.'
+          name 'Procedure resources returned during previous tests conform to the US Core Procedure Profile.'
           link 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-procedure'
           description %(
 

--- a/lib/modules/uscore_v3.1.1/us_core_procedure_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_procedure_sequence.rb
@@ -470,7 +470,7 @@ module Inferno
       test :validate_resources do
         metadata do
           id '09'
-          name 'Procedure resources returned from previous search conform to the US Core Procedure Profile.'
+          name 'Procedure resources returned conform to the US Core Procedure Profile.'
           link 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-procedure'
           description %(
 
@@ -580,7 +580,6 @@ module Inferno
           versions :r4
         end
 
-        skip_if_known_not_supported(:Procedure, [:search, :read])
         skip_if_not_found(resource_type: 'Procedure', delayed: false)
 
         validated_resources = Set.new

--- a/lib/modules/uscore_v3.1.1/us_core_provenance_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_provenance_sequence.rb
@@ -86,7 +86,7 @@ module Inferno
       test :validate_resources do
         metadata do
           id '02'
-          name 'Provenance resources returned conform to the US Core Provenance Profile.'
+          name 'Provenance resources returned during previous tests conform to the US Core Provenance Profile.'
           link 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-provenance'
           description %(
 

--- a/lib/modules/uscore_v3.1.1/us_core_provenance_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_provenance_sequence.rb
@@ -211,7 +211,7 @@ module Inferno
           versions :r4
         end
 
-        skip_if_known_not_supported(:Provenance, [:search, :read])
+        skip_if_known_not_supported(:Provenance, [:read])
         skip_if_not_found(resource_type: 'Provenance', delayed: true)
 
         validated_resources = Set.new

--- a/lib/modules/uscore_v3.1.1/us_core_provenance_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_provenance_sequence.rb
@@ -86,7 +86,7 @@ module Inferno
       test :validate_resources do
         metadata do
           id '02'
-          name 'Provenance resources returned from previous search conform to the US Core Provenance Profile.'
+          name 'Provenance resources returned conform to the US Core Provenance Profile.'
           link 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-provenance'
           description %(
 
@@ -211,7 +211,6 @@ module Inferno
           versions :r4
         end
 
-        skip_if_known_not_supported(:Provenance, [:read])
         skip_if_not_found(resource_type: 'Provenance', delayed: true)
 
         validated_resources = Set.new

--- a/lib/modules/uscore_v3.1.1/us_core_pulse_oximetry_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_pulse_oximetry_sequence.rb
@@ -564,7 +564,7 @@ module Inferno
       test :validate_resources do
         metadata do
           id '10'
-          name 'Observation resources returned conform to the US Core Pulse Oximetry Profile.'
+          name 'Observation resources returned during previous tests conform to the US Core Pulse Oximetry Profile.'
           link 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-pulse-oximetry'
           description %(
 

--- a/lib/modules/uscore_v3.1.1/us_core_pulse_oximetry_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_pulse_oximetry_sequence.rb
@@ -564,7 +564,7 @@ module Inferno
       test :validate_resources do
         metadata do
           id '10'
-          name 'Observation resources returned from previous search conform to the US Core Pulse Oximetry Profile.'
+          name 'Observation resources returned conform to the US Core Pulse Oximetry Profile.'
           link 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-pulse-oximetry'
           description %(
 
@@ -712,7 +712,6 @@ module Inferno
           versions :r4
         end
 
-        skip_if_known_not_supported(:Observation, [:search, :read])
         skip_if_not_found(resource_type: 'Observation', delayed: false)
 
         validated_resources = Set.new

--- a/lib/modules/uscore_v3.1.1/us_core_smokingstatus_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_smokingstatus_sequence.rb
@@ -367,7 +367,7 @@ module Inferno
       test :validate_resources do
         metadata do
           id '06'
-          name 'Observation resources returned conform to the US Core Smoking Status Observation Profile.'
+          name 'Observation resources returned during previous tests conform to the US Core Smoking Status Observation Profile.'
           link 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-smokingstatus'
           description %(
 

--- a/lib/modules/uscore_v3.1.1/us_core_smokingstatus_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_smokingstatus_sequence.rb
@@ -367,7 +367,7 @@ module Inferno
       test :validate_resources do
         metadata do
           id '06'
-          name 'Observation resources returned from previous search conform to the US Core Smoking Status Observation Profile.'
+          name 'Observation resources returned conform to the US Core Smoking Status Observation Profile.'
           link 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-smokingstatus'
           description %(
 
@@ -487,7 +487,6 @@ module Inferno
           versions :r4
         end
 
-        skip_if_known_not_supported(:Observation, [:search, :read])
         skip_if_not_found(resource_type: 'Observation', delayed: false)
 
         validated_resources = Set.new


### PR DESCRIPTION
# Summary
The inferno-reference-server fails test USCPROV 04 because it requires search to be supported. This fails because reference server's capability statement does not declare for support for Provenance search

## New behavior
The generator was changed to not check for read and support being declared in cabablity statement, as it is checked in previous tests. The the tests were regenerated with this in mind.

## Code changes

## Testing guidance
Run the reference server through this version of inferno and USCPROV-04
