### PR TITLE
FI-1287 Save bearer and refresh tokens to separate state variable in 1st launch

### DIFF
--- a/lib/app/views/onc_program.erb
+++ b/lib/app/views/onc_program.erb
@@ -493,11 +493,11 @@
               value: instance.onc_sl_refresh_token,
               })%> 
 
-        <%= erb(:prerequisite_field,{},{prerequisite: :patient_id,
+        <%= erb(:prerequisite_field,{},{prerequisite: :onc_sl_patient_id,
               label: 'Patient ID',
-              description: 'Patient ID provided as context in the patient standalone launch.',
+              description: 'Patient ID associated with revoked tokens provided as context in the patient standalone launch. This will be used to verify access is no longer granted using the revoked token.',
               instance: instance,
-              value: instance.patient_id,
+              value: instance.onc_sl_patient_id,
               })%>
 
         <%= erb(:prerequisite_field,{},{prerequisite: :dynamic_registration_token,
@@ -654,7 +654,12 @@
               instance: instance,
               value: instance.bulk_token_endpoint,
               })%>       
-
+        <%= erb(:prerequisite_field,{},{prerequisite: :bulk_access_token,
+              label: 'Bulk Data Access Token',
+              description: 'Bearer token to be used for Bulk Data API.  Note that this field is only intended to support development for systems that have not yet implemented authorization and must not be available as input for certification.',
+              instance: instance,
+              value: instance.bulk_access_token,
+              })%> 
         <%= erb(:prerequisite_field,{},{prerequisite: :bulk_client_id,
               label: 'Bulk Data Client ID',
               description: 'Client ID provided at registration to the Inferno application.',

--- a/lib/modules/onc_program/onc_standalone_launch_sequence.rb
+++ b/lib/modules/onc_program/onc_standalone_launch_sequence.rb
@@ -24,7 +24,8 @@ module Inferno
                :initiate_login_uri,
                :redirect_uris
 
-      defines :token, :id_token, :refresh_token, :patient_id, :onc_sl_token, :onc_sl_refresh_token
+      defines :token, :id_token, :refresh_token, :patient_id, :onc_sl_token,
+              :onc_sl_refresh_token, :onc_sl_patient_id
 
       show_uris
 
@@ -131,10 +132,13 @@ module Inferno
         # this method.
 
         @instance.onc_sl_token = token
+        @instance.save!
+      end
 
-        # save a copy so patient_id and oauth_token_endpoint are not overwritten
-        @instance.onc_sl_patient_id = @instance.patient_id
-
+      def after_save_patient_id(patient_id)
+        # See `after_save_refresh_token` method for explanation of purpose of
+        # this method.
+        @instance.onc_sl_patient_id = patient_id
         @instance.save!
       end
 

--- a/lib/modules/onc_program/onc_standalone_smart_discovery_sequence.rb
+++ b/lib/modules/onc_program/onc_standalone_smart_discovery_sequence.rb
@@ -12,7 +12,9 @@ module Inferno
       test_id_prefix 'SA-OSD'
 
       requires :onc_sl_url
-      defines :oauth_authorize_endpoint, :oauth_token_endpoint, :oauth_register_endpoint
+      defines :oauth_authorize_endpoint, :oauth_token_endpoint,
+              :oauth_register_endpoint, :onc_sl_oauth_token_endpoint,
+              :onc_sl_oauth_authorize_endpoint
 
       description "Retrieve server's SMART on FHIR configuration"
 
@@ -44,6 +46,10 @@ module Inferno
       end
 
       def after_save_oauth_endpoints(oauth_token_endpoint, oauth_authorize_endpoint)
+        # Save the endpoints for use in the Token Revocation test at the end of
+        # the ONC Test Method, because we want that to use the endpoints for the
+        # Single Patient API set of tests, in case there are different ones for
+        # the EHR launch.
         @instance.onc_sl_oauth_token_endpoint = oauth_token_endpoint
         @instance.onc_sl_oauth_authorize_endpoint = oauth_authorize_endpoint
         @instance.save!

--- a/lib/modules/onc_program/onc_standalone_token_refresh_sequence.rb
+++ b/lib/modules/onc_program/onc_standalone_token_refresh_sequence.rb
@@ -16,7 +16,7 @@ module Inferno
       test_id_prefix 'TR'
 
       requires :onc_sl_url, :onc_sl_client_id, :onc_sl_confidential_client, :onc_sl_client_secret, :refresh_token, :oauth_token_endpoint
-      defines :token, :refresh_token, :onc_sl_token, :onc_sl_refresh_token, :onc_sl_patient_id, :onc_sl_oauth_token_endpoint
+      defines :token, :refresh_token, :onc_sl_token, :onc_sl_refresh_token
 
       def url_property
         'onc_sl_url'
@@ -43,23 +43,19 @@ module Inferno
       end
 
       def after_save_refresh_token(refresh_token)
-        # This method is used to save off the refresh token for standalone launch to be used for token
-        # revocation later.  We must do this because we are overwriting our standalone refresh/access token
-        # with the one used in the ehr launch.
+        # This method is used to save off the refresh token for standalone
+        # launch to be used for token revocation later.  We must do this because
+        # we are overwriting our standalone refresh/access token with
+        # the one used in other launches, but we specifically want to use this
+        # for revocation.
 
         @instance.onc_sl_refresh_token = refresh_token
         @instance.save!
       end
 
       def after_save_access_token(token)
-        # This method is used to save off the access token for standalone launch to be used for token
-        # revocation later.  We must do this because we are overwriting our standalone refresh/access token
-        # with the one used in the ehr launch.
+        # See `after_save_refresh_token` for explanation of this method/hook.
         @instance.onc_sl_token = token
-
-        # save a copy so patient_id and oauth_token_endpoint are not overwritten
-        @instance.onc_sl_patient_id = @instance.patient_id
-
         @instance.save!
       end
     end


### PR DESCRIPTION
# Summary

Inferno's sequences often overwrite certain shared state variables, which can be problematic if you want to have a later sequence use output from a specific instance of sequence prior (instead of just the last one that was run).  To work around this, in certain cases we save some of these variables under a separate name in a derived sequence, in the case where we do NOT want them overwritten.  For example, we save the bearer/refresh token that comes out of the 'Standalone Patient App' into a separate variables, because we want to revoke those specific tokens at the very end of the procedure (Other > Token Revocation) and don't want the other launches to overwrite those values.  

This fixes an issue that prevented the refresh token from being saved in a separate variable in a certain case, which caused it to not show up as a default input in the variable. See #324

It also fixed an issue where the onc_sl_patient_id wasn't being displayed as an input in the Token Revocation test, because we misnamed the input field in the .erb file.  We just silently grabbed the patient_id provided in the first Single Patient API tests without reporting it to the user.

This PR also just cleans up the code slightly here to make it a little more logical.  The end result is the same, but the values are saved and reported to the user in more logical spots.

Finally, and this tangential to the scope of this ticket, but it adds a (almost always invisible) input field for a Bearer Token for Bulk API that will show up in the developer knows how to disable authorization testing in the module file.  This was done because I was already editing the input parameter fields.

## New behavior

'Standalone Patient App > Standalone Launch WIth Patient Scope > Outputs' now includes "Onc Sl Token', 'Onc Sl Refresh Token', and 'Onc Sl Patient Id' outputs.  Before it does not include those values, because it relied on the 'Token Refresh' test to do this, which we shouldn't do.

'Standalone Patient App > Discovery' now is explicit that is saving the "onc_sl_*" for the auth endpoints.  It was doing this before, but we didn't report it as 'output'.

The Token Revocation sequence now has an input for patient_id, which should be prefilled from the context provided in the first launch (as is the bearer and refresh tokens).

## Code changes

Updated the Standalone Launch with Patient Scopes to save that data to those other variables for safekeeping.  Note that this is basically just copying a few lines from our ONC Standalone Launch Refresh Token sequence.  I also slightly reorganized the code to be more clean.

## Testing guidance

To truly test this fixes a real life issue, you'd have to alter our reference implementation token to not providing a 'refresh_token' parameter when a token is refreshed.  I don't think that is necessary for here though, just check that 'Standalone Patient App > Standalone Launch WIth Patient Scope > Outputs' now includes "Onc Sl Token' and 'Onc Sl Refresh Token' outputs.  Also verify that if you the 'Single Patient API' launch, followed by different tests that involve launches (e.g. Limited App Launch, EHR Launch, or Other > Public Client launch), that the Token Revocation only shows the Bearer/Refresh Tokens/Patient IDs from the 'Single Patient API' launch and was not overwritten.
