### PR TITLE
FI-1292/1293 Add missing index and allow dynamic content in db config

### DIFF
--- a/db/config.postgres.yml
+++ b/db/config.postgres.yml
@@ -1,3 +1,6 @@
+# ERB may be used to add dynamic content to this file.
+# https://docs.ruby-lang.org/en/2.7.0/ERB.html
+
 development:
   adapter: postgresql
   database: inferno_program
@@ -8,11 +11,11 @@ development:
 
 production:
   adapter: postgresql
-  database: inferno_program
-  username: postgres
-  host: db
-  pool: 10
-  idle_timeout: 60
+  database: <%= ENV.fetch('INFERNO_DB_NAME', 'inferno_program') %>
+  username: <%= ENV.fetch('INFERNO_DB_USERNAME', 'postgres') %>
+  host: <%= ENV.fetch('INFERNO_DB_HOST', 'db') %>
+  pool: <%= ENV.fetch('INFERNO_DB_POOL_SIZE', '10') %>
+  idle_timeout: <%= ENV.fetch('INFERNO_DB_IDLE_TIMEOUT', '60') %>
 
 test: &test
   adapter: postgresql

--- a/db/config.postgres.yml
+++ b/db/config.postgres.yml
@@ -13,6 +13,7 @@ production:
   adapter: postgresql
   database: <%= ENV.fetch('INFERNO_DB_NAME', 'inferno_program') %>
   username: <%= ENV.fetch('INFERNO_DB_USERNAME', 'postgres') %>
+  password: <%= ENV.fetch('INFERNO_DB_PASSWORD', '') %>
   host: <%= ENV.fetch('INFERNO_DB_HOST', 'db') %>
   pool: <%= ENV.fetch('INFERNO_DB_POOL_SIZE', '10') %>
   idle_timeout: <%= ENV.fetch('INFERNO_DB_IDLE_TIMEOUT', '60') %>

--- a/db/config.yml
+++ b/db/config.yml
@@ -1,3 +1,6 @@
+# ERB may be used to add dynamic content to this file.
+# https://docs.ruby-lang.org/en/2.7.0/ERB.html
+
 development:
   adapter: sqlite3
   database: data/development_data.db

--- a/db/migrate/20210804135524_add_request_index.rb
+++ b/db/migrate/20210804135524_add_request_index.rb
@@ -1,0 +1,7 @@
+class AddRequestIndex < ActiveRecord::Migration[5.2]
+  def change
+    add_index :inferno_models_request_response_test_results,
+              :test_result_id,
+              name: :index_request_response_test_results_on_test_result_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_04_21_162516) do
+ActiveRecord::Schema.define(version: 2021_08_04_135524) do
 
   create_table "inferno_models_information_messages", id: :string, limit: 500, force: :cascade do |t|
     t.text "message"
@@ -21,6 +21,7 @@ ActiveRecord::Schema.define(version: 2021_04_21_162516) do
   create_table "inferno_models_request_response_test_results", primary_key: ["request_response_id", "test_result_id"], force: :cascade do |t|
     t.string "request_response_id", limit: 500, null: false
     t.string "test_result_id", limit: 500, null: false
+    t.index ["test_result_id"], name: "index_request_response_test_results_on_test_result_id"
   end
 
   create_table "inferno_models_request_responses", primary_key: "request_index", force: :cascade do |t|

--- a/lib/app/utils/database.rb
+++ b/lib/app/utils/database.rb
@@ -7,7 +7,8 @@ module Inferno
     module Database
       def self.establish_db_connection
         path = File.join(__dir__, '..', '..', '..', 'db', 'config.yml')
-        configuration = YAML.load_file(path)[ENV['RACK_ENV']]
+        raw_config = File.read(path)
+        configuration = YAML.safe_load(ERB.new(raw_config).result)[ENV['RACK_ENV']]
         ActiveRecord::Base.establish_connection(configuration)
         ActiveRecord::Base.connection
       end


### PR DESCRIPTION
This branch adds the missing index to join table to fix performance issues as the table size increases.

Also allows erb to be used in the database configuration so that values can be loaded from environment variables.

## Testing guidance
This should work:
```
docker-compose -f docker-compose.postgres.yml build
docker-compose -f docker-compose.postgres.yml up
```
You can validate that the environment variables work by adding something like this to the inferno service in `docker-compose.postgres.yml`, which will cause inferno to fail to connect to the database.
```
    environment:
      INFERNO_DB_USERNAME: xyz
```