### PR TITLE
FI-1156 Fix issues in IE11 and slightly clean up certain alert message styling.

### DIFF
--- a/lib/app/views/layout.erb
+++ b/lib/app/views/layout.erb
@@ -35,10 +35,6 @@
         </div>
       </nav>
     <% end %>
-    <script type="text/javascript">
-      if(/MSIE \d|Trident.*rv:/.test(navigator.userAgent))
-        alert('Inferno does not currently support Internet Explorer.  Please switch to another browser, such as Chrome, Firefox, Safari, or Edge.');
-    </script>
 
     <%= yield %>
 

--- a/lib/app/views/layout.erb
+++ b/lib/app/views/layout.erb
@@ -35,7 +35,32 @@
         </div>
       </nav>
     <% end %>
+    <script type="text/javascript">
 
+      /* Cannot put this in app.js because that may not be parseable by older IEs */
+      /* Show alert for IE10 and below */
+
+      function getIEVersion(){
+          var agent = navigator.userAgent;
+          var reg = /MSIE\s?(\d+)(?:\.(\d+))?/i;
+          var matches = agent.match(reg);
+          if (matches != null) {
+              return { major: matches[1], minor: matches[2] };
+          }
+          return { major: "-1", minor: "-1" };
+      }
+
+      function alertIfUnsupportedBrowser(){
+        var ieVersion =  getIEVersion();
+
+        if(ieVersion.major !== "-1"){
+          alert('Inferno does not currently support Internet Explorer 10 or earlier.  Please switch to another browser, such as Chrome, Firefox, Safari, or Edge.');
+        }
+      }
+
+      alertIfUnsupportedBrowser();
+
+    </script>
     <%= yield %>
 
     <!-- global modals -->

--- a/lib/app/views/missing_valuesets.erb
+++ b/lib/app/views/missing_valuesets.erb
@@ -3,7 +3,7 @@
     <div class="col">
       <div class="container row row-no-padding align-items-center" style="margin:auto;" >
         <div class="col-12" style="color: #063d75; text-align: center;">
-          <div class="alert alert-danger" role="alert">
+          <div class="alert alert-danger" role="alert" style="margin-top: 1rem; margin-bottom: 0;">
             <% if @missing_validators.count > 5 %>
               Inferno is missing files needed to validate codes in FHIR Resources. 
             <% else %>

--- a/lib/app/views/onc_program.erb
+++ b/lib/app/views/onc_program.erb
@@ -410,7 +410,7 @@
                   <label style="margin-bottom: 0;" class="form-check-label" for="<%=field[:field]%>_off_active">No</label>
                 </div>
               </div>
-              <div class="form-group" data-requiredby="<%=field[:required_by] || 'ONCVisualInspectionSequence' %>"" data-definedby="" data-prerequisite="<%=field[:notes_field]%>" style="margin-bottom: 2rem;">
+              <div class="form-group" data-requiredby="<%=field[:required_by] || 'ONCVisualInspectionSequence' %>" data-definedby="" data-prerequisite="<%=field[:notes_field]%>" style="margin-bottom: 2rem;">
                 <label for="<%=field[:notes_field]%>">
                   <small>Notes, if applicable:</small>
                 </label>

--- a/lib/app/views/resource_validator_version.erb
+++ b/lib/app/views/resource_validator_version.erb
@@ -3,7 +3,7 @@
     <div class="col">
       <div class="container row row-no-padding align-items-center" style="margin:auto;" >
         <div class="col-12" style="color: #063d75; text-align: center;">
-          <div class="alert alert-danger" role="alert">
+          <div class="alert alert-danger" role="alert" style="margin-top: 1rem; margin-bottom: 0;">
             Inferno expects FHIR Validator Service to be version <code><%= Inferno::RESOURCE_VALIDATOR.expected_version %></code>, 
             but the available instance is version <code><%= Inferno::RESOURCE_VALIDATOR.version || 'unknown' %></code>. For instructions on how to update the validator, please review <a href="https://github.com/onc-healthit/inferno-program#validator-service">the Inferno README</a>.
           </div>

--- a/lib/app/views/state_status.erb
+++ b/lib/app/views/state_status.erb
@@ -11,7 +11,7 @@
       <div class="form-group row">
         <label class="col-sm-2 col-form-label" for="state_fhir_version">FHIR Version</label>
         <div class="col-sm-10">
-          <input type="text" class="form-control" id="state_fhir_version"value="<%=instance.fhir_version.upcase %>" disabled>
+          <input type="text" class="form-control" id="state_fhir_version" value="<%=instance.fhir_version.upcase %>" disabled>
         </div>
       </div>
     <% end %>

--- a/lib/app/views/test_case.erb
+++ b/lib/app/views/test_case.erb
@@ -113,7 +113,7 @@
                 Run Again
               </button>
             <% else %>
-              <button type="submit" class="sequence-button btn btn-<% if sequence_results[test_case.id] %>outline-<%end%>info btn-sm "">
+              <button type="submit" class="sequence-button btn btn-<% if sequence_results[test_case.id] %>outline-<%end%>info btn-sm">
                 <span class="oi oi-media-play"></span>
                 Run
               </button>

--- a/lib/version.rb
+++ b/lib/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Inferno
-  VERSION = '1.6.2'
+  VERSION = '1.6.3-pre'
 end

--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -1048,10 +1048,11 @@ body {
   width: 28px;
   height: 28px;
   background:white; 
-  ht: 0px;
   z-index: 5;
+  -ms-transform: rotate(45deg);
   -moz-transform: rotate(45deg);
   -webkit-transform: rotate(45deg);
+  transform: rotate(45deg);
   right: -14px;
   top: 6px;
   border-radius: 4px;
@@ -1252,12 +1253,6 @@ body {
   display:inherit;
 }
 
-.input-instructions {
-
-
-}
-
-
 #group-report .print-button {
 
   position:absolute;
@@ -1340,4 +1335,8 @@ body {
 .onc-index-page .btn-secondary {
   background-color: #f88b30;
   border-color: #f87e30;
+}
+
+.onc-index-page .alert {
+  margin-bottom: 1rem !important;
 }

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -5,16 +5,8 @@
 // providing IE11 support makes it clear that the certification criteria does
 // not specifically disallow IE 11.
 
-// Start of legacy browser alerts/polyfills
-function alertIfUnsupportedBrowser(){
-  var isIE = /MSIE \d|Trident.*rv:/.test(navigator.userAgent);
-  var isIE11 = !!window.MSInputMethodContext && !!document.documentMode;
-  if(isIE && !isIE11){
-    alert('Inferno does not currently support Internet Explorer 10 or earlier.  Please switch to another browser, such as Chrome, Firefox, Safari, or Edge.');
-  }
-}
-
-alertIfUnsupportedBrowser();
+// Start of IE11 browser alerts/polyfills
+// May remove once IE11 is no longer supported anywhere
 
 // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/includes
 if (!String.prototype.includes) {

--- a/public/js/app.js
+++ b/public/js/app.js
@@ -1,4 +1,87 @@
+// IE11 is not technically end-of-life yet and may be used for embedded apps
+// within EHRs until it is.  You have always been able to work around this using
+// a modern browser to start the launch test, launching within the embedded IE11
+// browser, then switching back to the modern browser & refreshing.  But by
+// providing IE11 support makes it clear that the certification criteria does
+// not specifically disallow IE 11.
 
+// Start of legacy browser alerts/polyfills
+function alertIfUnsupportedBrowser(){
+  var isIE = /MSIE \d|Trident.*rv:/.test(navigator.userAgent);
+  var isIE11 = !!window.MSInputMethodContext && !!document.documentMode;
+  if(isIE && !isIE11){
+    alert('Inferno does not currently support Internet Explorer 10 or earlier.  Please switch to another browser, such as Chrome, Firefox, Safari, or Edge.');
+  }
+}
+
+alertIfUnsupportedBrowser();
+
+// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/includes
+if (!String.prototype.includes) {
+  String.prototype.includes = function(search, start) {
+    'use strict';
+
+    if (search instanceof RegExp) {
+      throw TypeError('first argument must not be a RegExp');
+    }
+    if (start === undefined) { start = 0; }
+    return this.indexOf(search, start) !== -1;
+  };
+}
+
+// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/startsWith
+if (!String.prototype.startsWith) {
+    Object.defineProperty(String.prototype, 'startsWith', {
+        value: function(search, rawPos) {
+            var pos = rawPos > 0 ? rawPos|0 : 0;
+            return this.substring(pos, pos + search.length) === search;
+        }
+    });
+}
+
+// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/includes
+if (!Array.prototype.includes) {
+  Object.defineProperty(Array.prototype, 'includes', {
+    value: function(searchElement, fromIndex) {
+      // 1. Let O be ? ToObject(this value).
+      if (this == null) {
+        throw new TypeError('"this" is null or not defined');
+      }
+      var o = Object(this);
+      // 2. Let len be ? ToLength(? Get(O, "length")).
+      var len = o.length >>> 0;
+      // 3. If len is 0, return false.
+      if (len === 0) {
+        return false;
+      }
+      // 4. Let n be ? ToInteger(fromIndex).
+      //    (If fromIndex is undefined, this step produces the value 0.)
+      var n = fromIndex | 0;
+      // 5. If n ≥ 0, then
+      //  a. Let k be n.
+      // 6. Else n < 0,
+      //  a. Let k be len + n.
+      //  b. If k < 0, let k be 0.
+      var k = Math.max(n >= 0 ? n : len - Math.abs(n), 0);
+      function sameValueZero(x, y) {
+        return x === y || (typeof x === 'number' && typeof y === 'number' && isNaN(x) && isNaN(y));
+      }
+      // 7. Repeat, while k < len
+      while (k < len) {
+        // a. Let elementK be the result of ? Get(O, ! ToString(k)).
+        // b. If SameValueZero(searchElement, elementK) is true, return true.
+        // c. Increase k by 1. 
+        if (sameValueZero(o[k], searchElement)) {
+          return true;
+        }
+        k++;
+      }
+      // 8. Return false
+      return false;
+    }
+  });
+}
+// End of legacy browser alerts/polyfills
 
 $(function(){
   jQuery.extend({
@@ -379,8 +462,9 @@ $(function(){
   // Then register the handler
   $(window).on('scroll', handleScroll)
 
-  function handlePresetChange(e, preset_id = ""){
-    preset_id = preset_id == "" ? $('#preset-select option:selected').data('selected') : preset_id;
+  function handlePresetChange(e, preset_id){
+
+    preset_id = (!preset_id || preset_id.length === 0) ? $('#preset-select option:selected').data('selected') : preset_id;
     var all = $('#preset-select option:selected').data('all');
     var modules = $('#preset-select option:selected').data('module_names').split(",");
     var preset = all[preset_id] == undefined ? "" : all[preset_id];


### PR DESCRIPTION
# Summary
IE11 is not technically end-of-life yet and may be used for embedded apps within EHRs until it is.  You have always been able to work around this using a modern browser to start the launch test, launching within the embedded IE11 browser, then switching back to the modern browser & refreshing (see #235).  This update fixes javascript/styling to allow IE11 to use Inferno, which makes it clear that the certification criteria does not specifically disallow IE 11.

## New behavior

IE11 no longer has an alert message stating it is not supported.  IE10 and before should still have this alert message.  IE11 should look exactly the same as chrome/firefox/safari.

I also slightly cleaned up the alert message when you do not have terminology installed, or are pointing to the wrong version of the validator service.

## Code changes
I fixed the javascript (adding polyfills when needed) and CSS so that IE11 functions properly. I also updated the browser checking to allow IE11, but it should still pop an alert if you are using < IE11.

Also, I had to bump the inferno version to "1.6.3-pre" to bust caches on javascript/css.  Since we haven't yet merged any breaking changed into `main`, I didn't bump it to 1.7.0-pre, though it does look like we might end up including updates requiring us to go to 1.7.0.
## Testing guidance

Walk through the majority of the tests in chrome or firefox to make sure I didn't inadvertently break anything in those browsers.

I already did this (see comment below), but to be more thorough, download an IE11 VM from MS (or hop on a windows machine that has it) and try running through the tests (NOTE: our reference server's OAuth screens are not compatible with IE11, so you have to work around that a bit, but that is outside the scope of this ticket).

I also already did this (see comment below), but to be most thorough, also download IE10 in a VM to ensure that the error message still shows up.

![Capture](https://user-images.githubusercontent.com/412901/128384460-cf492194-ec0f-478f-a8ad-3a8fe2c348dc.PNG)

