### PR TITLE
FI-1296 Deprecate BDA-03 

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -42,7 +42,7 @@ resource_validator: external
 
 # The url where the external validator can be reached. Ignored when using the
 # internal validator.
-external_resource_validator_url: http://validator_service:4567
+external_resource_validator_url: https://localhost:8888 
 
 # The expected version of the external validator. The app will display a warning if
 # the found version doesn't match the expected version exactly.

--- a/config.yml
+++ b/config.yml
@@ -42,7 +42,7 @@ resource_validator: external
 
 # The url where the external validator can be reached. Ignored when using the
 # internal validator.
-external_resource_validator_url: http://validator_service:4567
+external_resource_validator_url: http://localhost:8888
 
 # The expected version of the external validator. The app will display a warning if
 # the found version doesn't match the expected version exactly.

--- a/config.yml
+++ b/config.yml
@@ -42,7 +42,7 @@ resource_validator: external
 
 # The url where the external validator can be reached. Ignored when using the
 # internal validator.
-external_resource_validator_url: https://localhost:8888 
+external_resource_validator_url: http://validator_service:4567
 
 # The expected version of the external validator. The app will display a warning if
 # the found version doesn't match the expected version exactly.

--- a/config.yml
+++ b/config.yml
@@ -42,7 +42,7 @@ resource_validator: external
 
 # The url where the external validator can be reached. Ignored when using the
 # internal validator.
-external_resource_validator_url: http://localhost:8888
+external_resource_validator_url: http://validator_service:4567
 
 # The expected version of the external validator. The app will display a warning if
 # the found version doesn't match the expected version exactly.

--- a/lib/modules/core/shared_tests.rb
+++ b/lib/modules/core/shared_tests.rb
@@ -15,7 +15,7 @@ module Inferno
               name "#{name} is deprecated"
               link 'http://hl7.org/fhir'
               description %(
-                Test #{name} is deprecated from version #{version}
+                Test #{name} is deprecated after version #{version}
               )
               optional
             end

--- a/lib/modules/onc_program/bulk_data_authorization_sequence.rb
+++ b/lib/modules/onc_program/bulk_data_authorization_sequence.rb
@@ -1,8 +1,12 @@
 # frozen_string_literal: true
 
+require_relative '../core/shared_tests'
+
 module Inferno
   module Sequence
     class BulkDataAuthorizationSequence < SequenceBase
+      include Inferno::Sequence::SharedTests
+
       title 'Bulk Data Authorization'
       description 'Demonstrate SMART Backend Service Authorization for Bulk Data'
 
@@ -131,30 +135,7 @@ module Inferno
         assert_response_bad(response)
       end
 
-      test :require_system_scope do
-        metadata do
-          id '03'
-          name 'Authorization request fails when client supplies invalid scope'
-          link 'http://hl7.org/fhir/uv/bulkdata/authorization/index.html#scopes'
-          description %(
-            The Backend Service Authorization specification defines the required fields for the
-            authorization request, made via HTTP POST to authorization token endpoint.  This
-            request includes the `scope` parameter, where the value must be a system scope.
-            System scopes have the format `system/(:resourceType|*).(read|write|*).
-
-            The OAuth 2.0 Authorization Framework describes the proper response for an
-            invalid request in the client credentials grant flow:
-
-            ```
-            If the request failed client authentication or is invalid, the authorization server returns an
-            error response as described in [Section 5.2](https://tools.ietf.org/html/rfc6749#section-5.2).
-            ```
-          )
-        end
-
-        response = authorize(scope: 'user/*.read')
-        assert_response_bad(response)
-      end
+      test_is_deprecated(index: '03', name: 'Authorization request fails when client supplies invalid scope', version: '1.6.2')
 
       test :require_grant_type do
         metadata do

--- a/lib/modules/onc_program/onc_ehr_launch_sequence.rb
+++ b/lib/modules/onc_program/onc_ehr_launch_sequence.rb
@@ -185,9 +185,9 @@ module Inferno
 
       token_endpoint_tls_test(index: '06')
 
-      test_is_deprecated(index: '07', name: 'OAuth token exchange fails when supplied invalid code', version: '1.7.0')
+      test_is_deprecated(index: '07', name: 'OAuth token exchange fails when supplied invalid code', version: '1.6.1')
 
-      test_is_deprecated(index: '08', name: 'OAuth token exchange fails when supplied invalid client ID', version: '1.7.0')
+      test_is_deprecated(index: '08', name: 'OAuth token exchange fails when supplied invalid client ID', version: '1.6.1')
 
       successful_token_exchange_test(index: '09')
 

--- a/lib/modules/onc_program/onc_standalone_launch_sequence.rb
+++ b/lib/modules/onc_program/onc_standalone_launch_sequence.rb
@@ -189,9 +189,9 @@ module Inferno
 
       token_endpoint_tls_test(index: '04')
 
-      test_is_deprecated(index: '05', name: 'OAuth token exchange fails when supplied invalid code', version: '1.7.0')
+      test_is_deprecated(index: '05', name: 'OAuth token exchange fails when supplied invalid code', version: '1.6.1')
 
-      test_is_deprecated(index: '06', name: 'OAuth token exchange fails when supplied invalid client ID', version: '1.7.0')
+      test_is_deprecated(index: '06', name: 'OAuth token exchange fails when supplied invalid client ID', version: '1.6.1')
 
       successful_token_exchange_test(index: '07')
 

--- a/lib/modules/onc_program/onc_standalone_restricted_launch_sequence.rb
+++ b/lib/modules/onc_program/onc_standalone_restricted_launch_sequence.rb
@@ -156,9 +156,9 @@ module Inferno
 
       token_endpoint_tls_test(index: '04')
 
-      test_is_deprecated(index: '05', name: 'OAuth token exchange fails when supplied invalid code', version: '1.7.0')
+      test_is_deprecated(index: '05', name: 'OAuth token exchange fails when supplied invalid code', version: '1.6.1')
 
-      test_is_deprecated(index: '06', name: 'OAuth token exchange fails when supplied invalid client ID', version: '1.7.0')
+      test_is_deprecated(index: '06', name: 'OAuth token exchange fails when supplied invalid client ID', version: '1.6.1')
 
       successful_token_exchange_test(index: '07')
 

--- a/lib/modules/onc_program/test/bulk_authorization_sequence_test.rb
+++ b/lib/modules/onc_program/test/bulk_authorization_sequence_test.rb
@@ -122,15 +122,6 @@ describe Inferno::Sequence::BulkDataAuthorizationSequence do
     it_tests_required_parameter(request_headers: { content_type: 'application/json' })
   end
 
-  describe 'require system scope' do
-    before do
-      @test = @sequence_class[:require_system_scope]
-      @sequence = @sequence_class.new(@instance, @client)
-    end
-
-    it_tests_required_parameter(request_parameter: { scope: 'user/*.read' })
-  end
-
   describe 'require grant type' do
     before do
       @test = @sequence_class[:require_grant_type]


### PR DESCRIPTION
# Summary
Fix issue raised in #331 
* Deprecate BDA-03 from Inferno Program
* Update test_is_deprecated message from ' ... deprecated _from_ version ... ' to  ' ... deprecated _after_ version ...' because developer may not know the upcoming release number during development
* Remove unit tests for BDA-03

## New behavior
Multi-Patient test does not include BDA-03 "Authorization request fails when client supplies invalid scope" test

## Code changes

## Testing guidance
Open Multi-Patient tab
Verify BDA-03 is not listed
