### PR TITLE
FI-1302: Catch error from invalid headers

### DIFF
--- a/lib/app/models/request_response.rb
+++ b/lib/app/models/request_response.rb
@@ -22,14 +22,20 @@ module Inferno
         direction: direction || req&.direction,
         request_method: request[:method],
         request_url: request[:url],
-        request_headers: request[:headers].to_json,
+        request_headers: stringify_headers(request[:headers]),
         request_payload: request[:payload],
         response_code: response[:code],
-        response_headers: response[:headers].to_json,
+        response_headers: stringify_headers(response[:headers]),
         response_body: escaped_body,
         instance_id: instance_id,
         timestamp: response[:timestamp]
       )
+    end
+
+    def self.stringify_headers(headers)
+      headers.to_json
+    rescue StandardError => e
+      { 'ERROR' => "#{e.class}: #{e.message}" }.to_json
     end
 
     # This is needed to escape HTML when the html tags are unicode escape sequences

--- a/test/unit/request_response_test.rb
+++ b/test/unit/request_response_test.rb
@@ -13,6 +13,7 @@ describe Inferno::RequestResponse do
     @result = Inferno::TestResult.new(sequence_result: @sequence_result)
     @result.save!
   end
+
   it 'returns the request and responses in the correct order' do
     10.times do |index|
       @result.request_responses << Inferno::RequestResponse.create(
@@ -26,5 +27,19 @@ describe Inferno::RequestResponse do
     result.request_responses.each_with_index do |request_response, index|
       assert_equal request_response.request_url, "http://#{index}"
     end
+  end
+
+  it "doesn't raise an error when invalid headers are received" do
+    bad_header = { 'abc' => (0..255).map(&:chr).join }
+
+    request = Inferno::RequestResponse.from_request(
+      OpenStruct.new(
+        request: { headers: bad_header },
+        response: {}
+      ),
+      'abc'
+    )
+
+    assert(request.request_headers.match?(/"ERROR":/))
   end
 end


### PR DESCRIPTION
Fixes #326 where receiving an invalid header can crash Inferno. If you get rid of the `rescue` in `RequestResponse.stringify_headers`, an exception will cause the unit test to fail.