### PR TITLE
FI-1294 Add Resource.id validation to hl7_validator

### DIFF
--- a/lib/app/utils/hl7_validator.rb
+++ b/lib/app/utils/hl7_validator.rb
@@ -34,7 +34,7 @@ module Inferno
 
       id_errors = validate_resource_id(resource)
 
-      result[:errors].push(*id_errors)
+      result[:errors].concat(id_errors)
 
       result
     end

--- a/lib/app/utils/hl7_validator.rb
+++ b/lib/app/utils/hl7_validator.rb
@@ -28,7 +28,17 @@ module Inferno
       result = RestClient.post "#{@validator_url}/validate", resource.source_contents, params: { profile: profile_url }
       outcome = fhir_models_klass.from_contents(result.body)
 
-      issues_by_severity(outcome.issue)
+      result = issues_by_severity(outcome.issue)
+
+      id_error = validate_resource_id(resource)
+
+      result[:errors] << id_error if id_error.present?
+
+      result
+    end
+
+    def validate_resource_id(resource)
+      resource&.id.nil? || resource.id.match?(/^[A-Za-z0-9\-\.]{1,64}$/) ? nil : "#{resource.resourceType}.id: FHIR id value shall match Regex /^[A-Za-z0-9\-\.]{1,64}$/"
     end
 
     # @return [String] the version of the validator currently being used or nil

--- a/lib/app/utils/hl7_validator.rb
+++ b/lib/app/utils/hl7_validator.rb
@@ -37,6 +37,9 @@ module Inferno
       result
     end
 
+    # FHIR validator does not valid Resource.id /^[A-Za-z0-9\-\.]{1,64}$/
+    # So Inferno has to check Resource.id against this regex.
+    # This should be removed after FHIR validator fix
     def validate_resource_id(resource)
       resource&.id.nil? || resource.id.match?(/^[A-Za-z0-9\-\.]{1,64}$/) ? nil : "#{resource.resourceType}.id: FHIR id value shall match Regex /^[A-Za-z0-9\-\.]{1,64}$/"
     end

--- a/lib/app/utils/hl7_validator.rb
+++ b/lib/app/utils/hl7_validator.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative 'walk'
+
 module Inferno
   # A validator that calls out to the HL7 validator API
   class HL7Validator
@@ -30,9 +32,9 @@ module Inferno
 
       result = issues_by_severity(outcome.issue)
 
-      id_error = validate_resource_id(resource)
+      id_errors = validate_resource_id(resource)
 
-      result[:errors] << id_error if id_error.present?
+      result[:errors].push(*id_errors)
 
       result
     end
@@ -41,7 +43,16 @@ module Inferno
     # So Inferno has to check Resource.id against this regex.
     # This should be removed after FHIR validator fix
     def validate_resource_id(resource)
-      resource&.id.nil? || resource.id.match?(/^[A-Za-z0-9\-\.]{1,64}$/) ? nil : "#{resource.resourceType}.id: FHIR id value shall match Regex /^[A-Za-z0-9\-\.]{1,64}$/"
+      errors = []
+
+      walk_resource(resource) do |value, meta, path|
+        next unless meta['type'] == 'id'
+        next unless value.present?
+
+        errors << "#{resource.resourceType}.#{path}: FHIR id value shall match Regex /^[A-Za-z0-9\-\.]{1,64}$/" unless value.match?(/^[A-Za-z0-9\-\.]{1,64}$/)
+      end
+
+      errors
     end
 
     # @return [String] the version of the validator currently being used or nil

--- a/test/unit/hl7_validator_test.rb
+++ b/test/unit/hl7_validator_test.rb
@@ -47,6 +47,26 @@ describe Inferno::HL7Validator do
       assert_equal 1, result[:warnings].length
       assert_equal 4, result[:information].length
     end
+
+    it 'adds Resource id error' do
+      outcome = load_fixture('hl7_validator_operation_outcome')
+      @resource.id = '1234567890123456789012345678901234567890123456789012345678901234567890'
+
+      stub_request(:post, "#{@validator_url}/validate")
+        .with(
+          query: { 'profile': @profile },
+          body: @resource.source_contents
+        )
+        .to_return(
+          status: 200,
+          body: outcome
+        )
+
+      result = @validator.validate(@resource, FHIR, @profile)
+      assert_equal 3, result[:errors].length
+      assert_equal 1, result[:warnings].length
+      assert_equal 4, result[:information].length
+    end
   end
 
   describe 'Fetching the validator version' do
@@ -61,6 +81,39 @@ describe Inferno::HL7Validator do
       stub_request(:get, "#{@validator_url}/version")
         .to_return(status: 404)
       assert_nil @validator.version
+    end
+  end
+
+  describe 'Validating Resource ID' do
+    before do
+      @resource = FHIR::Patient.new
+    end
+
+    it 'catches Resource id longer than 64 characters' do
+      @resource.id = '1234567890123456789012345678901234567890123456789012345678901234567890'
+      result = @validator.validate_resource_id(@resource)
+
+      assert result.present?
+    end
+
+    it 'catches Resource id with invalid character' do
+      @resource.id = '1234567890$'
+      result = @validator.validate_resource_id(@resource)
+
+      assert result.present?
+    end
+
+    it 'passes Resource without id' do
+      result = @validator.validate_resource_id(@resource)
+
+      assert_nil result
+    end
+
+    it 'passes Resource with valid id' do
+      @resource.id = 'A-123.b'
+      result = @validator.validate_resource_id(@resource)
+
+      assert_nil result
     end
   end
 end

--- a/test/unit/hl7_validator_test.rb
+++ b/test/unit/hl7_validator_test.rb
@@ -63,9 +63,7 @@ describe Inferno::HL7Validator do
         )
 
       result = @validator.validate(@resource, FHIR, @profile)
-      assert_equal 3, result[:errors].length
-      assert_equal 1, result[:warnings].length
-      assert_equal 4, result[:information].length
+      assert(result[:errors].any? { |err| err.match?(/FHIR id value shall match Regex/) })
     end
   end
 
@@ -94,6 +92,7 @@ describe Inferno::HL7Validator do
       result = @validator.validate_resource_id(@resource)
 
       assert result.present?
+      assert result.match?(/FHIR id value shall match Regex/)
     end
 
     it 'catches Resource id with invalid character' do
@@ -101,6 +100,7 @@ describe Inferno::HL7Validator do
       result = @validator.validate_resource_id(@resource)
 
       assert result.present?
+      assert result.match?(/FHIR id value shall match Regex/)
     end
 
     it 'passes Resource without id' do

--- a/test/unit/hl7_validator_test.rb
+++ b/test/unit/hl7_validator_test.rb
@@ -91,29 +91,38 @@ describe Inferno::HL7Validator do
       @resource.id = '1234567890123456789012345678901234567890123456789012345678901234567890'
       result = @validator.validate_resource_id(@resource)
 
-      assert result.present?
-      assert result.match?(/FHIR id value shall match Regex/)
+      refute result.empty?
+      assert result.first.match?(/^Patient\.id: FHIR id value shall match Regex/)
     end
 
     it 'catches Resource id with invalid character' do
       @resource.id = '1234567890$'
       result = @validator.validate_resource_id(@resource)
 
-      assert result.present?
-      assert result.match?(/FHIR id value shall match Regex/)
+      refute result.empty?
+      assert result.first.match?(/^Patient\.id: FHIR id value shall match Regex/)
+    end
+
+    it 'catches Resource id in internal resource' do
+      @resource.id = '1234567890123456789012345678901234567890123456789012345678901234567890'
+      bundle = wrap_resources_in_bundle(@resource)
+      bundle.id = '1234567890$'
+      result = @validator.validate_resource_id(bundle)
+
+      assert result.size == 2
     end
 
     it 'passes Resource without id' do
       result = @validator.validate_resource_id(@resource)
 
-      assert_nil result
+      assert result.empty?
     end
 
     it 'passes Resource with valid id' do
       @resource.id = 'A-123.b'
       result = @validator.validate_resource_id(@resource)
 
-      assert_nil result
+      assert result.empty?
     end
   end
 end


### PR DESCRIPTION
# Summary
FHIR validator does not valid Resource.id 
So Inferno has to check Resource.id against this regex /^[A-Za-z0-9\-\.]{1,64}$/.

This PR addresses Issue #332 
 
## New behavior
Inferno will report "FHIR id value shall match Regex /^[A-Za-z0-9\-\.]{1,64}$/" error if the Resource.id does not match the regex

## Code changes

## Testing guidance
