### PR TITLE
FI-1268 Update uscore_generator to prevent get searching value from different…

### DIFF
--- a/generator/uscore/uscore_generator.rb
+++ b/generator/uscore/uscore_generator.rb
@@ -451,9 +451,7 @@ module Inferno
                   #{
                     if search_param[:names].length > 2
                       %(
-                        #{sequence[:resource].underscore}_ary = Array.wrap(@#{sequence[:resource].underscore}_ary[patient])
-
-                        #{sequence[:resource].underscore}_ary.each do |#{sequence[:resource].underscore}|
+                        Array.wrap(@#{sequence[:resource].underscore}_ary[patient]).each do |#{sequence[:resource].underscore}|
                           #{reply_code.gsub("@#{sequence[:resource].underscore}_ary[patient]", sequence[:resource].underscore.to_s)}
                           break if resolved_one
                         end
@@ -920,8 +918,7 @@ module Inferno
               #{
                 if multiple_or_search[:names].length > 2
                   %(
-                    #{sequence[:resource].underscore}_ary = Array.wrap(@#{sequence[:resource].underscore}_ary[patient])
-                    #{sequence[:resource].underscore}_ary.each do |#{sequence[:resource].underscore}|
+                    Array.wrap(@#{sequence[:resource].underscore}_ary[patient]).each do |#{sequence[:resource].underscore}|
                       #{search_params.gsub("@#{sequence[:resource].underscore}_ary[patient]", sequence[:resource].underscore.to_s)}
                       #{reply_code}
                       break if resolved_one

--- a/generator/uscore/uscore_generator.rb
+++ b/generator/uscore/uscore_generator.rb
@@ -443,10 +443,25 @@ module Inferno
               #{comparator_search_code}
               #{token_system_search_code}
             )
+
             unless sequence[:delayed_sequence]
               reply_code = %(
                 patient_ids.each do |patient|
-                  #{reply_code}
+                  #{"next unless @#{sequence[:resource].underscore}_ary[patient].present?" if search_param[:names].include?('patient')}
+                  #{
+                    if search_param[:names].length > 2
+                      %(
+                        #{sequence[:resource].underscore}_ary = Array.wrap(@#{sequence[:resource].underscore}_ary[patient])
+
+                        #{sequence[:resource].underscore}_ary.each do |#{sequence[:resource].underscore}|
+                          #{reply_code.gsub("@#{sequence[:resource].underscore}_ary[patient]", sequence[:resource].underscore.to_s)}
+                          break if resolved_one
+                        end
+                      )
+                    else
+                      reply_code
+                    end
+                  }
                 end
               )
             end
@@ -882,22 +897,43 @@ module Inferno
               resolved_one = false
             )
           end
+
+          reply_code = %(
+            #{second_val_var} = #{resolve_el_str}
+            next if #{second_val_var}.nil?
+            found_second_val = true
+            #{param_value_name(param)} += ',' + get_value_for_search_param(#{second_val_var})
+            reply = get_resource_by_params(versioned_resource_class('#{sequence[:resource]}'), search_params)
+            validate_search_reply(versioned_resource_class('#{sequence[:resource]}'), reply, search_params)
+            assert_response_ok(reply)
+            resources_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
+            missing_values = #{param_value_name(param)}.split(',').reject do |val|
+              resolve_element_from_path(resources_returned, '#{param}') { |val_found| val_found == val }
+            end
+            assert missing_values.blank?, "Could not find \#{missing_values.join(',')} values from #{param} in any of the resources returned"
+          )
+
           test[:test_code] += %(
             found_second_val = false
             patient_ids.each do |patient|
-              #{search_params}
-              #{second_val_var} = #{resolve_el_str}
-              next if #{second_val_var}.nil?
-              found_second_val = true
-              #{param_value_name(param)} += ',' + get_value_for_search_param(#{second_val_var})
-              reply = get_resource_by_params(versioned_resource_class('#{sequence[:resource]}'), search_params)
-              validate_search_reply(versioned_resource_class('#{sequence[:resource]}'), reply, search_params)
-              assert_response_ok(reply)
-              resources_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
-              missing_values = #{param_value_name(param)}.split(',').reject do |val|
-                resolve_element_from_path(resources_returned, '#{param}') { |val_found| val_found == val }
-              end
-              assert missing_values.blank?, "Could not find \#{missing_values.join(',')} values from #{param} in any of the resources returned"
+              #{"next unless @#{sequence[:resource].underscore}_ary[patient].present?" if multiple_or_search[:names].include?('patient')}
+              #{
+                if multiple_or_search[:names].length > 2
+                  %(
+                    #{sequence[:resource].underscore}_ary = Array.wrap(@#{sequence[:resource].underscore}_ary[patient])
+                    #{sequence[:resource].underscore}_ary.each do |#{sequence[:resource].underscore}|
+                      #{search_params.gsub("@#{sequence[:resource].underscore}_ary[patient]", sequence[:resource].underscore.to_s)}
+                      #{reply_code}
+                      break if resolved_one
+                    end
+                  )
+                else
+                  %(
+                    #{search_params}
+                    #{reply_code}
+                  )
+                end
+              }
             end
             skip 'Cannot find second value for #{param} to perform a multipleOr search' unless found_second_val
           )
@@ -1210,13 +1246,6 @@ module Inferno
             #{search_params.map { |param, value| search_param_to_string(param, value) }.join(",\n")}
           }
         )
-
-        if search_parameters != find_first_search(sequence)[:names] && search_parameters.include?('patient') # skip if patient does not have this resource type.
-          search_param_string = %(
-            next unless @#{sequence[:resource].underscore}_ary[patient].present?
-            #{search_param_string}
-          )
-        end
 
         if search_param_string.include? 'get_value_for_search_param'
           search_param_value_check = if sequence[:delayed_sequence]

--- a/lib/modules/uscore_v3.1.1/bodyheight_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/bodyheight_sequence.rb
@@ -286,33 +286,39 @@ module Inferno
         patient_ids.each do |patient|
           next unless @observation_ary[patient].present?
 
-          search_params = {
-            'patient': patient,
-            'category': get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category') { |el| get_value_for_search_param(el).present? }),
-            'date': get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'effective') { |el| get_value_for_search_param(el).present? })
-          }
+          observation_ary = Array.wrap(@observation_ary[patient])
 
-          next if search_params.any? { |_param, value| value.nil? }
+          observation_ary.each do |observation|
+            search_params = {
+              'patient': patient,
+              'category': get_value_for_search_param(resolve_element_from_path(observation, 'category') { |el| get_value_for_search_param(el).present? }),
+              'date': get_value_for_search_param(resolve_element_from_path(observation, 'effective') { |el| get_value_for_search_param(el).present? })
+            }
 
-          resolved_one = true
+            next if search_params.any? { |_param, value| value.nil? }
 
-          reply = get_resource_by_params(versioned_resource_class('Observation'), search_params)
+            resolved_one = true
 
-          reply = perform_search_with_status(reply, search_params, search_method: :get) if reply.code == 400
+            reply = get_resource_by_params(versioned_resource_class('Observation'), search_params)
 
-          validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
+            reply = perform_search_with_status(reply, search_params, search_method: :get) if reply.code == 400
 
-          ['gt', 'ge', 'lt', 'le'].each do |comparator|
-            comparator_val = date_comparator_value(comparator, resolve_element_from_path(@observation_ary[patient], 'effective') { |el| get_value_for_search_param(el).present? })
-            comparator_search_params = search_params.merge('date': comparator_val)
-            reply = get_resource_by_params(versioned_resource_class('Observation'), comparator_search_params)
-            validate_search_reply(versioned_resource_class('Observation'), reply, comparator_search_params)
+            validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
+
+            ['gt', 'ge', 'lt', 'le'].each do |comparator|
+              comparator_val = date_comparator_value(comparator, resolve_element_from_path(observation, 'effective') { |el| get_value_for_search_param(el).present? })
+              comparator_search_params = search_params.merge('date': comparator_val)
+              reply = get_resource_by_params(versioned_resource_class('Observation'), comparator_search_params)
+              validate_search_reply(versioned_resource_class('Observation'), reply, comparator_search_params)
+            end
+
+            value_with_system = get_value_for_search_param(resolve_element_from_path(observation, 'category') { |el| get_value_for_search_param(el).present? }, true)
+            token_with_system_search_params = search_params.merge('category': value_with_system)
+            reply = get_resource_by_params(versioned_resource_class('Observation'), token_with_system_search_params)
+            validate_search_reply(versioned_resource_class('Observation'), reply, token_with_system_search_params)
+
+            break if resolved_one
           end
-
-          value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category') { |el| get_value_for_search_param(el).present? }, true)
-          token_with_system_search_params = search_params.merge('category': value_with_system)
-          reply = get_resource_by_params(versioned_resource_class('Observation'), token_with_system_search_params)
-          validate_search_reply(versioned_resource_class('Observation'), reply, token_with_system_search_params)
         end
 
         skip 'Could not resolve all parameters (patient, category, date) in any resource.' unless resolved_one
@@ -387,24 +393,30 @@ module Inferno
         patient_ids.each do |patient|
           next unless @observation_ary[patient].present?
 
-          search_params = {
-            'patient': patient,
-            'category': get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category') { |el| get_value_for_search_param(el).present? }),
-            'status': get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'status') { |el| get_value_for_search_param(el).present? })
-          }
+          observation_ary = Array.wrap(@observation_ary[patient])
 
-          next if search_params.any? { |_param, value| value.nil? }
+          observation_ary.each do |observation|
+            search_params = {
+              'patient': patient,
+              'category': get_value_for_search_param(resolve_element_from_path(observation, 'category') { |el| get_value_for_search_param(el).present? }),
+              'status': get_value_for_search_param(resolve_element_from_path(observation, 'status') { |el| get_value_for_search_param(el).present? })
+            }
 
-          resolved_one = true
+            next if search_params.any? { |_param, value| value.nil? }
 
-          reply = get_resource_by_params(versioned_resource_class('Observation'), search_params)
+            resolved_one = true
 
-          validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
+            reply = get_resource_by_params(versioned_resource_class('Observation'), search_params)
 
-          value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category') { |el| get_value_for_search_param(el).present? }, true)
-          token_with_system_search_params = search_params.merge('category': value_with_system)
-          reply = get_resource_by_params(versioned_resource_class('Observation'), token_with_system_search_params)
-          validate_search_reply(versioned_resource_class('Observation'), reply, token_with_system_search_params)
+            validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
+
+            value_with_system = get_value_for_search_param(resolve_element_from_path(observation, 'category') { |el| get_value_for_search_param(el).present? }, true)
+            token_with_system_search_params = search_params.merge('category': value_with_system)
+            reply = get_resource_by_params(versioned_resource_class('Observation'), token_with_system_search_params)
+            validate_search_reply(versioned_resource_class('Observation'), reply, token_with_system_search_params)
+
+            break if resolved_one
+          end
         end
 
         skip 'Could not resolve all parameters (patient, category, status) in any resource.' unless resolved_one
@@ -437,33 +449,39 @@ module Inferno
         patient_ids.each do |patient|
           next unless @observation_ary[patient].present?
 
-          search_params = {
-            'patient': patient,
-            'code': get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'code') { |el| get_value_for_search_param(el).present? }),
-            'date': get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'effective') { |el| get_value_for_search_param(el).present? })
-          }
+          observation_ary = Array.wrap(@observation_ary[patient])
 
-          next if search_params.any? { |_param, value| value.nil? }
+          observation_ary.each do |observation|
+            search_params = {
+              'patient': patient,
+              'code': get_value_for_search_param(resolve_element_from_path(observation, 'code') { |el| get_value_for_search_param(el).present? }),
+              'date': get_value_for_search_param(resolve_element_from_path(observation, 'effective') { |el| get_value_for_search_param(el).present? })
+            }
 
-          resolved_one = true
+            next if search_params.any? { |_param, value| value.nil? }
 
-          reply = get_resource_by_params(versioned_resource_class('Observation'), search_params)
+            resolved_one = true
 
-          reply = perform_search_with_status(reply, search_params, search_method: :get) if reply.code == 400
+            reply = get_resource_by_params(versioned_resource_class('Observation'), search_params)
 
-          validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
+            reply = perform_search_with_status(reply, search_params, search_method: :get) if reply.code == 400
 
-          ['gt', 'ge', 'lt', 'le'].each do |comparator|
-            comparator_val = date_comparator_value(comparator, resolve_element_from_path(@observation_ary[patient], 'effective') { |el| get_value_for_search_param(el).present? })
-            comparator_search_params = search_params.merge('date': comparator_val)
-            reply = get_resource_by_params(versioned_resource_class('Observation'), comparator_search_params)
-            validate_search_reply(versioned_resource_class('Observation'), reply, comparator_search_params)
+            validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
+
+            ['gt', 'ge', 'lt', 'le'].each do |comparator|
+              comparator_val = date_comparator_value(comparator, resolve_element_from_path(observation, 'effective') { |el| get_value_for_search_param(el).present? })
+              comparator_search_params = search_params.merge('date': comparator_val)
+              reply = get_resource_by_params(versioned_resource_class('Observation'), comparator_search_params)
+              validate_search_reply(versioned_resource_class('Observation'), reply, comparator_search_params)
+            end
+
+            value_with_system = get_value_for_search_param(resolve_element_from_path(observation, 'code') { |el| get_value_for_search_param(el).present? }, true)
+            token_with_system_search_params = search_params.merge('code': value_with_system)
+            reply = get_resource_by_params(versioned_resource_class('Observation'), token_with_system_search_params)
+            validate_search_reply(versioned_resource_class('Observation'), reply, token_with_system_search_params)
+
+            break if resolved_one
           end
-
-          value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'code') { |el| get_value_for_search_param(el).present? }, true)
-          token_with_system_search_params = search_params.merge('code': value_with_system)
-          reply = get_resource_by_params(versioned_resource_class('Observation'), token_with_system_search_params)
-          validate_search_reply(versioned_resource_class('Observation'), reply, token_with_system_search_params)
         end
 
         skip 'Could not resolve all parameters (patient, code, date) in any resource.' unless resolved_one

--- a/lib/modules/uscore_v3.1.1/bodyheight_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/bodyheight_sequence.rb
@@ -286,9 +286,7 @@ module Inferno
         patient_ids.each do |patient|
           next unless @observation_ary[patient].present?
 
-          observation_ary = Array.wrap(@observation_ary[patient])
-
-          observation_ary.each do |observation|
+          Array.wrap(@observation_ary[patient]).each do |observation|
             search_params = {
               'patient': patient,
               'category': get_value_for_search_param(resolve_element_from_path(observation, 'category') { |el| get_value_for_search_param(el).present? }),
@@ -393,9 +391,7 @@ module Inferno
         patient_ids.each do |patient|
           next unless @observation_ary[patient].present?
 
-          observation_ary = Array.wrap(@observation_ary[patient])
-
-          observation_ary.each do |observation|
+          Array.wrap(@observation_ary[patient]).each do |observation|
             search_params = {
               'patient': patient,
               'category': get_value_for_search_param(resolve_element_from_path(observation, 'category') { |el| get_value_for_search_param(el).present? }),
@@ -449,9 +445,7 @@ module Inferno
         patient_ids.each do |patient|
           next unless @observation_ary[patient].present?
 
-          observation_ary = Array.wrap(@observation_ary[patient])
-
-          observation_ary.each do |observation|
+          Array.wrap(@observation_ary[patient]).each do |observation|
             search_params = {
               'patient': patient,
               'code': get_value_for_search_param(resolve_element_from_path(observation, 'code') { |el| get_value_for_search_param(el).present? }),

--- a/lib/modules/uscore_v3.1.1/bodytemp_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/bodytemp_sequence.rb
@@ -286,33 +286,39 @@ module Inferno
         patient_ids.each do |patient|
           next unless @observation_ary[patient].present?
 
-          search_params = {
-            'patient': patient,
-            'category': get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category') { |el| get_value_for_search_param(el).present? }),
-            'date': get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'effective') { |el| get_value_for_search_param(el).present? })
-          }
+          observation_ary = Array.wrap(@observation_ary[patient])
 
-          next if search_params.any? { |_param, value| value.nil? }
+          observation_ary.each do |observation|
+            search_params = {
+              'patient': patient,
+              'category': get_value_for_search_param(resolve_element_from_path(observation, 'category') { |el| get_value_for_search_param(el).present? }),
+              'date': get_value_for_search_param(resolve_element_from_path(observation, 'effective') { |el| get_value_for_search_param(el).present? })
+            }
 
-          resolved_one = true
+            next if search_params.any? { |_param, value| value.nil? }
 
-          reply = get_resource_by_params(versioned_resource_class('Observation'), search_params)
+            resolved_one = true
 
-          reply = perform_search_with_status(reply, search_params, search_method: :get) if reply.code == 400
+            reply = get_resource_by_params(versioned_resource_class('Observation'), search_params)
 
-          validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
+            reply = perform_search_with_status(reply, search_params, search_method: :get) if reply.code == 400
 
-          ['gt', 'ge', 'lt', 'le'].each do |comparator|
-            comparator_val = date_comparator_value(comparator, resolve_element_from_path(@observation_ary[patient], 'effective') { |el| get_value_for_search_param(el).present? })
-            comparator_search_params = search_params.merge('date': comparator_val)
-            reply = get_resource_by_params(versioned_resource_class('Observation'), comparator_search_params)
-            validate_search_reply(versioned_resource_class('Observation'), reply, comparator_search_params)
+            validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
+
+            ['gt', 'ge', 'lt', 'le'].each do |comparator|
+              comparator_val = date_comparator_value(comparator, resolve_element_from_path(observation, 'effective') { |el| get_value_for_search_param(el).present? })
+              comparator_search_params = search_params.merge('date': comparator_val)
+              reply = get_resource_by_params(versioned_resource_class('Observation'), comparator_search_params)
+              validate_search_reply(versioned_resource_class('Observation'), reply, comparator_search_params)
+            end
+
+            value_with_system = get_value_for_search_param(resolve_element_from_path(observation, 'category') { |el| get_value_for_search_param(el).present? }, true)
+            token_with_system_search_params = search_params.merge('category': value_with_system)
+            reply = get_resource_by_params(versioned_resource_class('Observation'), token_with_system_search_params)
+            validate_search_reply(versioned_resource_class('Observation'), reply, token_with_system_search_params)
+
+            break if resolved_one
           end
-
-          value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category') { |el| get_value_for_search_param(el).present? }, true)
-          token_with_system_search_params = search_params.merge('category': value_with_system)
-          reply = get_resource_by_params(versioned_resource_class('Observation'), token_with_system_search_params)
-          validate_search_reply(versioned_resource_class('Observation'), reply, token_with_system_search_params)
         end
 
         skip 'Could not resolve all parameters (patient, category, date) in any resource.' unless resolved_one
@@ -387,24 +393,30 @@ module Inferno
         patient_ids.each do |patient|
           next unless @observation_ary[patient].present?
 
-          search_params = {
-            'patient': patient,
-            'category': get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category') { |el| get_value_for_search_param(el).present? }),
-            'status': get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'status') { |el| get_value_for_search_param(el).present? })
-          }
+          observation_ary = Array.wrap(@observation_ary[patient])
 
-          next if search_params.any? { |_param, value| value.nil? }
+          observation_ary.each do |observation|
+            search_params = {
+              'patient': patient,
+              'category': get_value_for_search_param(resolve_element_from_path(observation, 'category') { |el| get_value_for_search_param(el).present? }),
+              'status': get_value_for_search_param(resolve_element_from_path(observation, 'status') { |el| get_value_for_search_param(el).present? })
+            }
 
-          resolved_one = true
+            next if search_params.any? { |_param, value| value.nil? }
 
-          reply = get_resource_by_params(versioned_resource_class('Observation'), search_params)
+            resolved_one = true
 
-          validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
+            reply = get_resource_by_params(versioned_resource_class('Observation'), search_params)
 
-          value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category') { |el| get_value_for_search_param(el).present? }, true)
-          token_with_system_search_params = search_params.merge('category': value_with_system)
-          reply = get_resource_by_params(versioned_resource_class('Observation'), token_with_system_search_params)
-          validate_search_reply(versioned_resource_class('Observation'), reply, token_with_system_search_params)
+            validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
+
+            value_with_system = get_value_for_search_param(resolve_element_from_path(observation, 'category') { |el| get_value_for_search_param(el).present? }, true)
+            token_with_system_search_params = search_params.merge('category': value_with_system)
+            reply = get_resource_by_params(versioned_resource_class('Observation'), token_with_system_search_params)
+            validate_search_reply(versioned_resource_class('Observation'), reply, token_with_system_search_params)
+
+            break if resolved_one
+          end
         end
 
         skip 'Could not resolve all parameters (patient, category, status) in any resource.' unless resolved_one
@@ -437,33 +449,39 @@ module Inferno
         patient_ids.each do |patient|
           next unless @observation_ary[patient].present?
 
-          search_params = {
-            'patient': patient,
-            'code': get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'code') { |el| get_value_for_search_param(el).present? }),
-            'date': get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'effective') { |el| get_value_for_search_param(el).present? })
-          }
+          observation_ary = Array.wrap(@observation_ary[patient])
 
-          next if search_params.any? { |_param, value| value.nil? }
+          observation_ary.each do |observation|
+            search_params = {
+              'patient': patient,
+              'code': get_value_for_search_param(resolve_element_from_path(observation, 'code') { |el| get_value_for_search_param(el).present? }),
+              'date': get_value_for_search_param(resolve_element_from_path(observation, 'effective') { |el| get_value_for_search_param(el).present? })
+            }
 
-          resolved_one = true
+            next if search_params.any? { |_param, value| value.nil? }
 
-          reply = get_resource_by_params(versioned_resource_class('Observation'), search_params)
+            resolved_one = true
 
-          reply = perform_search_with_status(reply, search_params, search_method: :get) if reply.code == 400
+            reply = get_resource_by_params(versioned_resource_class('Observation'), search_params)
 
-          validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
+            reply = perform_search_with_status(reply, search_params, search_method: :get) if reply.code == 400
 
-          ['gt', 'ge', 'lt', 'le'].each do |comparator|
-            comparator_val = date_comparator_value(comparator, resolve_element_from_path(@observation_ary[patient], 'effective') { |el| get_value_for_search_param(el).present? })
-            comparator_search_params = search_params.merge('date': comparator_val)
-            reply = get_resource_by_params(versioned_resource_class('Observation'), comparator_search_params)
-            validate_search_reply(versioned_resource_class('Observation'), reply, comparator_search_params)
+            validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
+
+            ['gt', 'ge', 'lt', 'le'].each do |comparator|
+              comparator_val = date_comparator_value(comparator, resolve_element_from_path(observation, 'effective') { |el| get_value_for_search_param(el).present? })
+              comparator_search_params = search_params.merge('date': comparator_val)
+              reply = get_resource_by_params(versioned_resource_class('Observation'), comparator_search_params)
+              validate_search_reply(versioned_resource_class('Observation'), reply, comparator_search_params)
+            end
+
+            value_with_system = get_value_for_search_param(resolve_element_from_path(observation, 'code') { |el| get_value_for_search_param(el).present? }, true)
+            token_with_system_search_params = search_params.merge('code': value_with_system)
+            reply = get_resource_by_params(versioned_resource_class('Observation'), token_with_system_search_params)
+            validate_search_reply(versioned_resource_class('Observation'), reply, token_with_system_search_params)
+
+            break if resolved_one
           end
-
-          value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'code') { |el| get_value_for_search_param(el).present? }, true)
-          token_with_system_search_params = search_params.merge('code': value_with_system)
-          reply = get_resource_by_params(versioned_resource_class('Observation'), token_with_system_search_params)
-          validate_search_reply(versioned_resource_class('Observation'), reply, token_with_system_search_params)
         end
 
         skip 'Could not resolve all parameters (patient, code, date) in any resource.' unless resolved_one

--- a/lib/modules/uscore_v3.1.1/bodytemp_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/bodytemp_sequence.rb
@@ -286,9 +286,7 @@ module Inferno
         patient_ids.each do |patient|
           next unless @observation_ary[patient].present?
 
-          observation_ary = Array.wrap(@observation_ary[patient])
-
-          observation_ary.each do |observation|
+          Array.wrap(@observation_ary[patient]).each do |observation|
             search_params = {
               'patient': patient,
               'category': get_value_for_search_param(resolve_element_from_path(observation, 'category') { |el| get_value_for_search_param(el).present? }),
@@ -393,9 +391,7 @@ module Inferno
         patient_ids.each do |patient|
           next unless @observation_ary[patient].present?
 
-          observation_ary = Array.wrap(@observation_ary[patient])
-
-          observation_ary.each do |observation|
+          Array.wrap(@observation_ary[patient]).each do |observation|
             search_params = {
               'patient': patient,
               'category': get_value_for_search_param(resolve_element_from_path(observation, 'category') { |el| get_value_for_search_param(el).present? }),
@@ -449,9 +445,7 @@ module Inferno
         patient_ids.each do |patient|
           next unless @observation_ary[patient].present?
 
-          observation_ary = Array.wrap(@observation_ary[patient])
-
-          observation_ary.each do |observation|
+          Array.wrap(@observation_ary[patient]).each do |observation|
             search_params = {
               'patient': patient,
               'code': get_value_for_search_param(resolve_element_from_path(observation, 'code') { |el| get_value_for_search_param(el).present? }),

--- a/lib/modules/uscore_v3.1.1/bodyweight_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/bodyweight_sequence.rb
@@ -286,33 +286,39 @@ module Inferno
         patient_ids.each do |patient|
           next unless @observation_ary[patient].present?
 
-          search_params = {
-            'patient': patient,
-            'category': get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category') { |el| get_value_for_search_param(el).present? }),
-            'date': get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'effective') { |el| get_value_for_search_param(el).present? })
-          }
+          observation_ary = Array.wrap(@observation_ary[patient])
 
-          next if search_params.any? { |_param, value| value.nil? }
+          observation_ary.each do |observation|
+            search_params = {
+              'patient': patient,
+              'category': get_value_for_search_param(resolve_element_from_path(observation, 'category') { |el| get_value_for_search_param(el).present? }),
+              'date': get_value_for_search_param(resolve_element_from_path(observation, 'effective') { |el| get_value_for_search_param(el).present? })
+            }
 
-          resolved_one = true
+            next if search_params.any? { |_param, value| value.nil? }
 
-          reply = get_resource_by_params(versioned_resource_class('Observation'), search_params)
+            resolved_one = true
 
-          reply = perform_search_with_status(reply, search_params, search_method: :get) if reply.code == 400
+            reply = get_resource_by_params(versioned_resource_class('Observation'), search_params)
 
-          validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
+            reply = perform_search_with_status(reply, search_params, search_method: :get) if reply.code == 400
 
-          ['gt', 'ge', 'lt', 'le'].each do |comparator|
-            comparator_val = date_comparator_value(comparator, resolve_element_from_path(@observation_ary[patient], 'effective') { |el| get_value_for_search_param(el).present? })
-            comparator_search_params = search_params.merge('date': comparator_val)
-            reply = get_resource_by_params(versioned_resource_class('Observation'), comparator_search_params)
-            validate_search_reply(versioned_resource_class('Observation'), reply, comparator_search_params)
+            validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
+
+            ['gt', 'ge', 'lt', 'le'].each do |comparator|
+              comparator_val = date_comparator_value(comparator, resolve_element_from_path(observation, 'effective') { |el| get_value_for_search_param(el).present? })
+              comparator_search_params = search_params.merge('date': comparator_val)
+              reply = get_resource_by_params(versioned_resource_class('Observation'), comparator_search_params)
+              validate_search_reply(versioned_resource_class('Observation'), reply, comparator_search_params)
+            end
+
+            value_with_system = get_value_for_search_param(resolve_element_from_path(observation, 'category') { |el| get_value_for_search_param(el).present? }, true)
+            token_with_system_search_params = search_params.merge('category': value_with_system)
+            reply = get_resource_by_params(versioned_resource_class('Observation'), token_with_system_search_params)
+            validate_search_reply(versioned_resource_class('Observation'), reply, token_with_system_search_params)
+
+            break if resolved_one
           end
-
-          value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category') { |el| get_value_for_search_param(el).present? }, true)
-          token_with_system_search_params = search_params.merge('category': value_with_system)
-          reply = get_resource_by_params(versioned_resource_class('Observation'), token_with_system_search_params)
-          validate_search_reply(versioned_resource_class('Observation'), reply, token_with_system_search_params)
         end
 
         skip 'Could not resolve all parameters (patient, category, date) in any resource.' unless resolved_one
@@ -387,24 +393,30 @@ module Inferno
         patient_ids.each do |patient|
           next unless @observation_ary[patient].present?
 
-          search_params = {
-            'patient': patient,
-            'category': get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category') { |el| get_value_for_search_param(el).present? }),
-            'status': get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'status') { |el| get_value_for_search_param(el).present? })
-          }
+          observation_ary = Array.wrap(@observation_ary[patient])
 
-          next if search_params.any? { |_param, value| value.nil? }
+          observation_ary.each do |observation|
+            search_params = {
+              'patient': patient,
+              'category': get_value_for_search_param(resolve_element_from_path(observation, 'category') { |el| get_value_for_search_param(el).present? }),
+              'status': get_value_for_search_param(resolve_element_from_path(observation, 'status') { |el| get_value_for_search_param(el).present? })
+            }
 
-          resolved_one = true
+            next if search_params.any? { |_param, value| value.nil? }
 
-          reply = get_resource_by_params(versioned_resource_class('Observation'), search_params)
+            resolved_one = true
 
-          validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
+            reply = get_resource_by_params(versioned_resource_class('Observation'), search_params)
 
-          value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category') { |el| get_value_for_search_param(el).present? }, true)
-          token_with_system_search_params = search_params.merge('category': value_with_system)
-          reply = get_resource_by_params(versioned_resource_class('Observation'), token_with_system_search_params)
-          validate_search_reply(versioned_resource_class('Observation'), reply, token_with_system_search_params)
+            validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
+
+            value_with_system = get_value_for_search_param(resolve_element_from_path(observation, 'category') { |el| get_value_for_search_param(el).present? }, true)
+            token_with_system_search_params = search_params.merge('category': value_with_system)
+            reply = get_resource_by_params(versioned_resource_class('Observation'), token_with_system_search_params)
+            validate_search_reply(versioned_resource_class('Observation'), reply, token_with_system_search_params)
+
+            break if resolved_one
+          end
         end
 
         skip 'Could not resolve all parameters (patient, category, status) in any resource.' unless resolved_one
@@ -437,33 +449,39 @@ module Inferno
         patient_ids.each do |patient|
           next unless @observation_ary[patient].present?
 
-          search_params = {
-            'patient': patient,
-            'code': get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'code') { |el| get_value_for_search_param(el).present? }),
-            'date': get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'effective') { |el| get_value_for_search_param(el).present? })
-          }
+          observation_ary = Array.wrap(@observation_ary[patient])
 
-          next if search_params.any? { |_param, value| value.nil? }
+          observation_ary.each do |observation|
+            search_params = {
+              'patient': patient,
+              'code': get_value_for_search_param(resolve_element_from_path(observation, 'code') { |el| get_value_for_search_param(el).present? }),
+              'date': get_value_for_search_param(resolve_element_from_path(observation, 'effective') { |el| get_value_for_search_param(el).present? })
+            }
 
-          resolved_one = true
+            next if search_params.any? { |_param, value| value.nil? }
 
-          reply = get_resource_by_params(versioned_resource_class('Observation'), search_params)
+            resolved_one = true
 
-          reply = perform_search_with_status(reply, search_params, search_method: :get) if reply.code == 400
+            reply = get_resource_by_params(versioned_resource_class('Observation'), search_params)
 
-          validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
+            reply = perform_search_with_status(reply, search_params, search_method: :get) if reply.code == 400
 
-          ['gt', 'ge', 'lt', 'le'].each do |comparator|
-            comparator_val = date_comparator_value(comparator, resolve_element_from_path(@observation_ary[patient], 'effective') { |el| get_value_for_search_param(el).present? })
-            comparator_search_params = search_params.merge('date': comparator_val)
-            reply = get_resource_by_params(versioned_resource_class('Observation'), comparator_search_params)
-            validate_search_reply(versioned_resource_class('Observation'), reply, comparator_search_params)
+            validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
+
+            ['gt', 'ge', 'lt', 'le'].each do |comparator|
+              comparator_val = date_comparator_value(comparator, resolve_element_from_path(observation, 'effective') { |el| get_value_for_search_param(el).present? })
+              comparator_search_params = search_params.merge('date': comparator_val)
+              reply = get_resource_by_params(versioned_resource_class('Observation'), comparator_search_params)
+              validate_search_reply(versioned_resource_class('Observation'), reply, comparator_search_params)
+            end
+
+            value_with_system = get_value_for_search_param(resolve_element_from_path(observation, 'code') { |el| get_value_for_search_param(el).present? }, true)
+            token_with_system_search_params = search_params.merge('code': value_with_system)
+            reply = get_resource_by_params(versioned_resource_class('Observation'), token_with_system_search_params)
+            validate_search_reply(versioned_resource_class('Observation'), reply, token_with_system_search_params)
+
+            break if resolved_one
           end
-
-          value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'code') { |el| get_value_for_search_param(el).present? }, true)
-          token_with_system_search_params = search_params.merge('code': value_with_system)
-          reply = get_resource_by_params(versioned_resource_class('Observation'), token_with_system_search_params)
-          validate_search_reply(versioned_resource_class('Observation'), reply, token_with_system_search_params)
         end
 
         skip 'Could not resolve all parameters (patient, code, date) in any resource.' unless resolved_one

--- a/lib/modules/uscore_v3.1.1/bodyweight_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/bodyweight_sequence.rb
@@ -286,9 +286,7 @@ module Inferno
         patient_ids.each do |patient|
           next unless @observation_ary[patient].present?
 
-          observation_ary = Array.wrap(@observation_ary[patient])
-
-          observation_ary.each do |observation|
+          Array.wrap(@observation_ary[patient]).each do |observation|
             search_params = {
               'patient': patient,
               'category': get_value_for_search_param(resolve_element_from_path(observation, 'category') { |el| get_value_for_search_param(el).present? }),
@@ -393,9 +391,7 @@ module Inferno
         patient_ids.each do |patient|
           next unless @observation_ary[patient].present?
 
-          observation_ary = Array.wrap(@observation_ary[patient])
-
-          observation_ary.each do |observation|
+          Array.wrap(@observation_ary[patient]).each do |observation|
             search_params = {
               'patient': patient,
               'category': get_value_for_search_param(resolve_element_from_path(observation, 'category') { |el| get_value_for_search_param(el).present? }),
@@ -449,9 +445,7 @@ module Inferno
         patient_ids.each do |patient|
           next unless @observation_ary[patient].present?
 
-          observation_ary = Array.wrap(@observation_ary[patient])
-
-          observation_ary.each do |observation|
+          Array.wrap(@observation_ary[patient]).each do |observation|
             search_params = {
               'patient': patient,
               'code': get_value_for_search_param(resolve_element_from_path(observation, 'code') { |el| get_value_for_search_param(el).present? }),

--- a/lib/modules/uscore_v3.1.1/bp_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/bp_sequence.rb
@@ -286,33 +286,39 @@ module Inferno
         patient_ids.each do |patient|
           next unless @observation_ary[patient].present?
 
-          search_params = {
-            'patient': patient,
-            'category': get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category') { |el| get_value_for_search_param(el).present? }),
-            'date': get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'effective') { |el| get_value_for_search_param(el).present? })
-          }
+          observation_ary = Array.wrap(@observation_ary[patient])
 
-          next if search_params.any? { |_param, value| value.nil? }
+          observation_ary.each do |observation|
+            search_params = {
+              'patient': patient,
+              'category': get_value_for_search_param(resolve_element_from_path(observation, 'category') { |el| get_value_for_search_param(el).present? }),
+              'date': get_value_for_search_param(resolve_element_from_path(observation, 'effective') { |el| get_value_for_search_param(el).present? })
+            }
 
-          resolved_one = true
+            next if search_params.any? { |_param, value| value.nil? }
 
-          reply = get_resource_by_params(versioned_resource_class('Observation'), search_params)
+            resolved_one = true
 
-          reply = perform_search_with_status(reply, search_params, search_method: :get) if reply.code == 400
+            reply = get_resource_by_params(versioned_resource_class('Observation'), search_params)
 
-          validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
+            reply = perform_search_with_status(reply, search_params, search_method: :get) if reply.code == 400
 
-          ['gt', 'ge', 'lt', 'le'].each do |comparator|
-            comparator_val = date_comparator_value(comparator, resolve_element_from_path(@observation_ary[patient], 'effective') { |el| get_value_for_search_param(el).present? })
-            comparator_search_params = search_params.merge('date': comparator_val)
-            reply = get_resource_by_params(versioned_resource_class('Observation'), comparator_search_params)
-            validate_search_reply(versioned_resource_class('Observation'), reply, comparator_search_params)
+            validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
+
+            ['gt', 'ge', 'lt', 'le'].each do |comparator|
+              comparator_val = date_comparator_value(comparator, resolve_element_from_path(observation, 'effective') { |el| get_value_for_search_param(el).present? })
+              comparator_search_params = search_params.merge('date': comparator_val)
+              reply = get_resource_by_params(versioned_resource_class('Observation'), comparator_search_params)
+              validate_search_reply(versioned_resource_class('Observation'), reply, comparator_search_params)
+            end
+
+            value_with_system = get_value_for_search_param(resolve_element_from_path(observation, 'category') { |el| get_value_for_search_param(el).present? }, true)
+            token_with_system_search_params = search_params.merge('category': value_with_system)
+            reply = get_resource_by_params(versioned_resource_class('Observation'), token_with_system_search_params)
+            validate_search_reply(versioned_resource_class('Observation'), reply, token_with_system_search_params)
+
+            break if resolved_one
           end
-
-          value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category') { |el| get_value_for_search_param(el).present? }, true)
-          token_with_system_search_params = search_params.merge('category': value_with_system)
-          reply = get_resource_by_params(versioned_resource_class('Observation'), token_with_system_search_params)
-          validate_search_reply(versioned_resource_class('Observation'), reply, token_with_system_search_params)
         end
 
         skip 'Could not resolve all parameters (patient, category, date) in any resource.' unless resolved_one
@@ -387,24 +393,30 @@ module Inferno
         patient_ids.each do |patient|
           next unless @observation_ary[patient].present?
 
-          search_params = {
-            'patient': patient,
-            'category': get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category') { |el| get_value_for_search_param(el).present? }),
-            'status': get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'status') { |el| get_value_for_search_param(el).present? })
-          }
+          observation_ary = Array.wrap(@observation_ary[patient])
 
-          next if search_params.any? { |_param, value| value.nil? }
+          observation_ary.each do |observation|
+            search_params = {
+              'patient': patient,
+              'category': get_value_for_search_param(resolve_element_from_path(observation, 'category') { |el| get_value_for_search_param(el).present? }),
+              'status': get_value_for_search_param(resolve_element_from_path(observation, 'status') { |el| get_value_for_search_param(el).present? })
+            }
 
-          resolved_one = true
+            next if search_params.any? { |_param, value| value.nil? }
 
-          reply = get_resource_by_params(versioned_resource_class('Observation'), search_params)
+            resolved_one = true
 
-          validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
+            reply = get_resource_by_params(versioned_resource_class('Observation'), search_params)
 
-          value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category') { |el| get_value_for_search_param(el).present? }, true)
-          token_with_system_search_params = search_params.merge('category': value_with_system)
-          reply = get_resource_by_params(versioned_resource_class('Observation'), token_with_system_search_params)
-          validate_search_reply(versioned_resource_class('Observation'), reply, token_with_system_search_params)
+            validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
+
+            value_with_system = get_value_for_search_param(resolve_element_from_path(observation, 'category') { |el| get_value_for_search_param(el).present? }, true)
+            token_with_system_search_params = search_params.merge('category': value_with_system)
+            reply = get_resource_by_params(versioned_resource_class('Observation'), token_with_system_search_params)
+            validate_search_reply(versioned_resource_class('Observation'), reply, token_with_system_search_params)
+
+            break if resolved_one
+          end
         end
 
         skip 'Could not resolve all parameters (patient, category, status) in any resource.' unless resolved_one
@@ -437,33 +449,39 @@ module Inferno
         patient_ids.each do |patient|
           next unless @observation_ary[patient].present?
 
-          search_params = {
-            'patient': patient,
-            'code': get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'code') { |el| get_value_for_search_param(el).present? }),
-            'date': get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'effective') { |el| get_value_for_search_param(el).present? })
-          }
+          observation_ary = Array.wrap(@observation_ary[patient])
 
-          next if search_params.any? { |_param, value| value.nil? }
+          observation_ary.each do |observation|
+            search_params = {
+              'patient': patient,
+              'code': get_value_for_search_param(resolve_element_from_path(observation, 'code') { |el| get_value_for_search_param(el).present? }),
+              'date': get_value_for_search_param(resolve_element_from_path(observation, 'effective') { |el| get_value_for_search_param(el).present? })
+            }
 
-          resolved_one = true
+            next if search_params.any? { |_param, value| value.nil? }
 
-          reply = get_resource_by_params(versioned_resource_class('Observation'), search_params)
+            resolved_one = true
 
-          reply = perform_search_with_status(reply, search_params, search_method: :get) if reply.code == 400
+            reply = get_resource_by_params(versioned_resource_class('Observation'), search_params)
 
-          validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
+            reply = perform_search_with_status(reply, search_params, search_method: :get) if reply.code == 400
 
-          ['gt', 'ge', 'lt', 'le'].each do |comparator|
-            comparator_val = date_comparator_value(comparator, resolve_element_from_path(@observation_ary[patient], 'effective') { |el| get_value_for_search_param(el).present? })
-            comparator_search_params = search_params.merge('date': comparator_val)
-            reply = get_resource_by_params(versioned_resource_class('Observation'), comparator_search_params)
-            validate_search_reply(versioned_resource_class('Observation'), reply, comparator_search_params)
+            validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
+
+            ['gt', 'ge', 'lt', 'le'].each do |comparator|
+              comparator_val = date_comparator_value(comparator, resolve_element_from_path(observation, 'effective') { |el| get_value_for_search_param(el).present? })
+              comparator_search_params = search_params.merge('date': comparator_val)
+              reply = get_resource_by_params(versioned_resource_class('Observation'), comparator_search_params)
+              validate_search_reply(versioned_resource_class('Observation'), reply, comparator_search_params)
+            end
+
+            value_with_system = get_value_for_search_param(resolve_element_from_path(observation, 'code') { |el| get_value_for_search_param(el).present? }, true)
+            token_with_system_search_params = search_params.merge('code': value_with_system)
+            reply = get_resource_by_params(versioned_resource_class('Observation'), token_with_system_search_params)
+            validate_search_reply(versioned_resource_class('Observation'), reply, token_with_system_search_params)
+
+            break if resolved_one
           end
-
-          value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'code') { |el| get_value_for_search_param(el).present? }, true)
-          token_with_system_search_params = search_params.merge('code': value_with_system)
-          reply = get_resource_by_params(versioned_resource_class('Observation'), token_with_system_search_params)
-          validate_search_reply(versioned_resource_class('Observation'), reply, token_with_system_search_params)
         end
 
         skip 'Could not resolve all parameters (patient, code, date) in any resource.' unless resolved_one

--- a/lib/modules/uscore_v3.1.1/bp_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/bp_sequence.rb
@@ -286,9 +286,7 @@ module Inferno
         patient_ids.each do |patient|
           next unless @observation_ary[patient].present?
 
-          observation_ary = Array.wrap(@observation_ary[patient])
-
-          observation_ary.each do |observation|
+          Array.wrap(@observation_ary[patient]).each do |observation|
             search_params = {
               'patient': patient,
               'category': get_value_for_search_param(resolve_element_from_path(observation, 'category') { |el| get_value_for_search_param(el).present? }),
@@ -393,9 +391,7 @@ module Inferno
         patient_ids.each do |patient|
           next unless @observation_ary[patient].present?
 
-          observation_ary = Array.wrap(@observation_ary[patient])
-
-          observation_ary.each do |observation|
+          Array.wrap(@observation_ary[patient]).each do |observation|
             search_params = {
               'patient': patient,
               'category': get_value_for_search_param(resolve_element_from_path(observation, 'category') { |el| get_value_for_search_param(el).present? }),
@@ -449,9 +445,7 @@ module Inferno
         patient_ids.each do |patient|
           next unless @observation_ary[patient].present?
 
-          observation_ary = Array.wrap(@observation_ary[patient])
-
-          observation_ary.each do |observation|
+          Array.wrap(@observation_ary[patient]).each do |observation|
             search_params = {
               'patient': patient,
               'code': get_value_for_search_param(resolve_element_from_path(observation, 'code') { |el| get_value_for_search_param(el).present? }),

--- a/lib/modules/uscore_v3.1.1/head_occipital_frontal_circumference_percentile_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/head_occipital_frontal_circumference_percentile_sequence.rb
@@ -286,33 +286,39 @@ module Inferno
         patient_ids.each do |patient|
           next unless @observation_ary[patient].present?
 
-          search_params = {
-            'patient': patient,
-            'category': get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category') { |el| get_value_for_search_param(el).present? }),
-            'date': get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'effective') { |el| get_value_for_search_param(el).present? })
-          }
+          observation_ary = Array.wrap(@observation_ary[patient])
 
-          next if search_params.any? { |_param, value| value.nil? }
+          observation_ary.each do |observation|
+            search_params = {
+              'patient': patient,
+              'category': get_value_for_search_param(resolve_element_from_path(observation, 'category') { |el| get_value_for_search_param(el).present? }),
+              'date': get_value_for_search_param(resolve_element_from_path(observation, 'effective') { |el| get_value_for_search_param(el).present? })
+            }
 
-          resolved_one = true
+            next if search_params.any? { |_param, value| value.nil? }
 
-          reply = get_resource_by_params(versioned_resource_class('Observation'), search_params)
+            resolved_one = true
 
-          reply = perform_search_with_status(reply, search_params, search_method: :get) if reply.code == 400
+            reply = get_resource_by_params(versioned_resource_class('Observation'), search_params)
 
-          validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
+            reply = perform_search_with_status(reply, search_params, search_method: :get) if reply.code == 400
 
-          ['gt', 'ge', 'lt', 'le'].each do |comparator|
-            comparator_val = date_comparator_value(comparator, resolve_element_from_path(@observation_ary[patient], 'effective') { |el| get_value_for_search_param(el).present? })
-            comparator_search_params = search_params.merge('date': comparator_val)
-            reply = get_resource_by_params(versioned_resource_class('Observation'), comparator_search_params)
-            validate_search_reply(versioned_resource_class('Observation'), reply, comparator_search_params)
+            validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
+
+            ['gt', 'ge', 'lt', 'le'].each do |comparator|
+              comparator_val = date_comparator_value(comparator, resolve_element_from_path(observation, 'effective') { |el| get_value_for_search_param(el).present? })
+              comparator_search_params = search_params.merge('date': comparator_val)
+              reply = get_resource_by_params(versioned_resource_class('Observation'), comparator_search_params)
+              validate_search_reply(versioned_resource_class('Observation'), reply, comparator_search_params)
+            end
+
+            value_with_system = get_value_for_search_param(resolve_element_from_path(observation, 'category') { |el| get_value_for_search_param(el).present? }, true)
+            token_with_system_search_params = search_params.merge('category': value_with_system)
+            reply = get_resource_by_params(versioned_resource_class('Observation'), token_with_system_search_params)
+            validate_search_reply(versioned_resource_class('Observation'), reply, token_with_system_search_params)
+
+            break if resolved_one
           end
-
-          value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category') { |el| get_value_for_search_param(el).present? }, true)
-          token_with_system_search_params = search_params.merge('category': value_with_system)
-          reply = get_resource_by_params(versioned_resource_class('Observation'), token_with_system_search_params)
-          validate_search_reply(versioned_resource_class('Observation'), reply, token_with_system_search_params)
         end
 
         skip 'Could not resolve all parameters (patient, category, date) in any resource.' unless resolved_one
@@ -387,24 +393,30 @@ module Inferno
         patient_ids.each do |patient|
           next unless @observation_ary[patient].present?
 
-          search_params = {
-            'patient': patient,
-            'category': get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category') { |el| get_value_for_search_param(el).present? }),
-            'status': get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'status') { |el| get_value_for_search_param(el).present? })
-          }
+          observation_ary = Array.wrap(@observation_ary[patient])
 
-          next if search_params.any? { |_param, value| value.nil? }
+          observation_ary.each do |observation|
+            search_params = {
+              'patient': patient,
+              'category': get_value_for_search_param(resolve_element_from_path(observation, 'category') { |el| get_value_for_search_param(el).present? }),
+              'status': get_value_for_search_param(resolve_element_from_path(observation, 'status') { |el| get_value_for_search_param(el).present? })
+            }
 
-          resolved_one = true
+            next if search_params.any? { |_param, value| value.nil? }
 
-          reply = get_resource_by_params(versioned_resource_class('Observation'), search_params)
+            resolved_one = true
 
-          validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
+            reply = get_resource_by_params(versioned_resource_class('Observation'), search_params)
 
-          value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category') { |el| get_value_for_search_param(el).present? }, true)
-          token_with_system_search_params = search_params.merge('category': value_with_system)
-          reply = get_resource_by_params(versioned_resource_class('Observation'), token_with_system_search_params)
-          validate_search_reply(versioned_resource_class('Observation'), reply, token_with_system_search_params)
+            validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
+
+            value_with_system = get_value_for_search_param(resolve_element_from_path(observation, 'category') { |el| get_value_for_search_param(el).present? }, true)
+            token_with_system_search_params = search_params.merge('category': value_with_system)
+            reply = get_resource_by_params(versioned_resource_class('Observation'), token_with_system_search_params)
+            validate_search_reply(versioned_resource_class('Observation'), reply, token_with_system_search_params)
+
+            break if resolved_one
+          end
         end
 
         skip 'Could not resolve all parameters (patient, category, status) in any resource.' unless resolved_one
@@ -437,33 +449,39 @@ module Inferno
         patient_ids.each do |patient|
           next unless @observation_ary[patient].present?
 
-          search_params = {
-            'patient': patient,
-            'code': get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'code') { |el| get_value_for_search_param(el).present? }),
-            'date': get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'effective') { |el| get_value_for_search_param(el).present? })
-          }
+          observation_ary = Array.wrap(@observation_ary[patient])
 
-          next if search_params.any? { |_param, value| value.nil? }
+          observation_ary.each do |observation|
+            search_params = {
+              'patient': patient,
+              'code': get_value_for_search_param(resolve_element_from_path(observation, 'code') { |el| get_value_for_search_param(el).present? }),
+              'date': get_value_for_search_param(resolve_element_from_path(observation, 'effective') { |el| get_value_for_search_param(el).present? })
+            }
 
-          resolved_one = true
+            next if search_params.any? { |_param, value| value.nil? }
 
-          reply = get_resource_by_params(versioned_resource_class('Observation'), search_params)
+            resolved_one = true
 
-          reply = perform_search_with_status(reply, search_params, search_method: :get) if reply.code == 400
+            reply = get_resource_by_params(versioned_resource_class('Observation'), search_params)
 
-          validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
+            reply = perform_search_with_status(reply, search_params, search_method: :get) if reply.code == 400
 
-          ['gt', 'ge', 'lt', 'le'].each do |comparator|
-            comparator_val = date_comparator_value(comparator, resolve_element_from_path(@observation_ary[patient], 'effective') { |el| get_value_for_search_param(el).present? })
-            comparator_search_params = search_params.merge('date': comparator_val)
-            reply = get_resource_by_params(versioned_resource_class('Observation'), comparator_search_params)
-            validate_search_reply(versioned_resource_class('Observation'), reply, comparator_search_params)
+            validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
+
+            ['gt', 'ge', 'lt', 'le'].each do |comparator|
+              comparator_val = date_comparator_value(comparator, resolve_element_from_path(observation, 'effective') { |el| get_value_for_search_param(el).present? })
+              comparator_search_params = search_params.merge('date': comparator_val)
+              reply = get_resource_by_params(versioned_resource_class('Observation'), comparator_search_params)
+              validate_search_reply(versioned_resource_class('Observation'), reply, comparator_search_params)
+            end
+
+            value_with_system = get_value_for_search_param(resolve_element_from_path(observation, 'code') { |el| get_value_for_search_param(el).present? }, true)
+            token_with_system_search_params = search_params.merge('code': value_with_system)
+            reply = get_resource_by_params(versioned_resource_class('Observation'), token_with_system_search_params)
+            validate_search_reply(versioned_resource_class('Observation'), reply, token_with_system_search_params)
+
+            break if resolved_one
           end
-
-          value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'code') { |el| get_value_for_search_param(el).present? }, true)
-          token_with_system_search_params = search_params.merge('code': value_with_system)
-          reply = get_resource_by_params(versioned_resource_class('Observation'), token_with_system_search_params)
-          validate_search_reply(versioned_resource_class('Observation'), reply, token_with_system_search_params)
         end
 
         skip 'Could not resolve all parameters (patient, code, date) in any resource.' unless resolved_one

--- a/lib/modules/uscore_v3.1.1/head_occipital_frontal_circumference_percentile_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/head_occipital_frontal_circumference_percentile_sequence.rb
@@ -286,9 +286,7 @@ module Inferno
         patient_ids.each do |patient|
           next unless @observation_ary[patient].present?
 
-          observation_ary = Array.wrap(@observation_ary[patient])
-
-          observation_ary.each do |observation|
+          Array.wrap(@observation_ary[patient]).each do |observation|
             search_params = {
               'patient': patient,
               'category': get_value_for_search_param(resolve_element_from_path(observation, 'category') { |el| get_value_for_search_param(el).present? }),
@@ -393,9 +391,7 @@ module Inferno
         patient_ids.each do |patient|
           next unless @observation_ary[patient].present?
 
-          observation_ary = Array.wrap(@observation_ary[patient])
-
-          observation_ary.each do |observation|
+          Array.wrap(@observation_ary[patient]).each do |observation|
             search_params = {
               'patient': patient,
               'category': get_value_for_search_param(resolve_element_from_path(observation, 'category') { |el| get_value_for_search_param(el).present? }),
@@ -449,9 +445,7 @@ module Inferno
         patient_ids.each do |patient|
           next unless @observation_ary[patient].present?
 
-          observation_ary = Array.wrap(@observation_ary[patient])
-
-          observation_ary.each do |observation|
+          Array.wrap(@observation_ary[patient]).each do |observation|
             search_params = {
               'patient': patient,
               'code': get_value_for_search_param(resolve_element_from_path(observation, 'code') { |el| get_value_for_search_param(el).present? }),

--- a/lib/modules/uscore_v3.1.1/heartrate_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/heartrate_sequence.rb
@@ -286,33 +286,39 @@ module Inferno
         patient_ids.each do |patient|
           next unless @observation_ary[patient].present?
 
-          search_params = {
-            'patient': patient,
-            'category': get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category') { |el| get_value_for_search_param(el).present? }),
-            'date': get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'effective') { |el| get_value_for_search_param(el).present? })
-          }
+          observation_ary = Array.wrap(@observation_ary[patient])
 
-          next if search_params.any? { |_param, value| value.nil? }
+          observation_ary.each do |observation|
+            search_params = {
+              'patient': patient,
+              'category': get_value_for_search_param(resolve_element_from_path(observation, 'category') { |el| get_value_for_search_param(el).present? }),
+              'date': get_value_for_search_param(resolve_element_from_path(observation, 'effective') { |el| get_value_for_search_param(el).present? })
+            }
 
-          resolved_one = true
+            next if search_params.any? { |_param, value| value.nil? }
 
-          reply = get_resource_by_params(versioned_resource_class('Observation'), search_params)
+            resolved_one = true
 
-          reply = perform_search_with_status(reply, search_params, search_method: :get) if reply.code == 400
+            reply = get_resource_by_params(versioned_resource_class('Observation'), search_params)
 
-          validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
+            reply = perform_search_with_status(reply, search_params, search_method: :get) if reply.code == 400
 
-          ['gt', 'ge', 'lt', 'le'].each do |comparator|
-            comparator_val = date_comparator_value(comparator, resolve_element_from_path(@observation_ary[patient], 'effective') { |el| get_value_for_search_param(el).present? })
-            comparator_search_params = search_params.merge('date': comparator_val)
-            reply = get_resource_by_params(versioned_resource_class('Observation'), comparator_search_params)
-            validate_search_reply(versioned_resource_class('Observation'), reply, comparator_search_params)
+            validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
+
+            ['gt', 'ge', 'lt', 'le'].each do |comparator|
+              comparator_val = date_comparator_value(comparator, resolve_element_from_path(observation, 'effective') { |el| get_value_for_search_param(el).present? })
+              comparator_search_params = search_params.merge('date': comparator_val)
+              reply = get_resource_by_params(versioned_resource_class('Observation'), comparator_search_params)
+              validate_search_reply(versioned_resource_class('Observation'), reply, comparator_search_params)
+            end
+
+            value_with_system = get_value_for_search_param(resolve_element_from_path(observation, 'category') { |el| get_value_for_search_param(el).present? }, true)
+            token_with_system_search_params = search_params.merge('category': value_with_system)
+            reply = get_resource_by_params(versioned_resource_class('Observation'), token_with_system_search_params)
+            validate_search_reply(versioned_resource_class('Observation'), reply, token_with_system_search_params)
+
+            break if resolved_one
           end
-
-          value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category') { |el| get_value_for_search_param(el).present? }, true)
-          token_with_system_search_params = search_params.merge('category': value_with_system)
-          reply = get_resource_by_params(versioned_resource_class('Observation'), token_with_system_search_params)
-          validate_search_reply(versioned_resource_class('Observation'), reply, token_with_system_search_params)
         end
 
         skip 'Could not resolve all parameters (patient, category, date) in any resource.' unless resolved_one
@@ -387,24 +393,30 @@ module Inferno
         patient_ids.each do |patient|
           next unless @observation_ary[patient].present?
 
-          search_params = {
-            'patient': patient,
-            'category': get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category') { |el| get_value_for_search_param(el).present? }),
-            'status': get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'status') { |el| get_value_for_search_param(el).present? })
-          }
+          observation_ary = Array.wrap(@observation_ary[patient])
 
-          next if search_params.any? { |_param, value| value.nil? }
+          observation_ary.each do |observation|
+            search_params = {
+              'patient': patient,
+              'category': get_value_for_search_param(resolve_element_from_path(observation, 'category') { |el| get_value_for_search_param(el).present? }),
+              'status': get_value_for_search_param(resolve_element_from_path(observation, 'status') { |el| get_value_for_search_param(el).present? })
+            }
 
-          resolved_one = true
+            next if search_params.any? { |_param, value| value.nil? }
 
-          reply = get_resource_by_params(versioned_resource_class('Observation'), search_params)
+            resolved_one = true
 
-          validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
+            reply = get_resource_by_params(versioned_resource_class('Observation'), search_params)
 
-          value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category') { |el| get_value_for_search_param(el).present? }, true)
-          token_with_system_search_params = search_params.merge('category': value_with_system)
-          reply = get_resource_by_params(versioned_resource_class('Observation'), token_with_system_search_params)
-          validate_search_reply(versioned_resource_class('Observation'), reply, token_with_system_search_params)
+            validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
+
+            value_with_system = get_value_for_search_param(resolve_element_from_path(observation, 'category') { |el| get_value_for_search_param(el).present? }, true)
+            token_with_system_search_params = search_params.merge('category': value_with_system)
+            reply = get_resource_by_params(versioned_resource_class('Observation'), token_with_system_search_params)
+            validate_search_reply(versioned_resource_class('Observation'), reply, token_with_system_search_params)
+
+            break if resolved_one
+          end
         end
 
         skip 'Could not resolve all parameters (patient, category, status) in any resource.' unless resolved_one
@@ -437,33 +449,39 @@ module Inferno
         patient_ids.each do |patient|
           next unless @observation_ary[patient].present?
 
-          search_params = {
-            'patient': patient,
-            'code': get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'code') { |el| get_value_for_search_param(el).present? }),
-            'date': get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'effective') { |el| get_value_for_search_param(el).present? })
-          }
+          observation_ary = Array.wrap(@observation_ary[patient])
 
-          next if search_params.any? { |_param, value| value.nil? }
+          observation_ary.each do |observation|
+            search_params = {
+              'patient': patient,
+              'code': get_value_for_search_param(resolve_element_from_path(observation, 'code') { |el| get_value_for_search_param(el).present? }),
+              'date': get_value_for_search_param(resolve_element_from_path(observation, 'effective') { |el| get_value_for_search_param(el).present? })
+            }
 
-          resolved_one = true
+            next if search_params.any? { |_param, value| value.nil? }
 
-          reply = get_resource_by_params(versioned_resource_class('Observation'), search_params)
+            resolved_one = true
 
-          reply = perform_search_with_status(reply, search_params, search_method: :get) if reply.code == 400
+            reply = get_resource_by_params(versioned_resource_class('Observation'), search_params)
 
-          validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
+            reply = perform_search_with_status(reply, search_params, search_method: :get) if reply.code == 400
 
-          ['gt', 'ge', 'lt', 'le'].each do |comparator|
-            comparator_val = date_comparator_value(comparator, resolve_element_from_path(@observation_ary[patient], 'effective') { |el| get_value_for_search_param(el).present? })
-            comparator_search_params = search_params.merge('date': comparator_val)
-            reply = get_resource_by_params(versioned_resource_class('Observation'), comparator_search_params)
-            validate_search_reply(versioned_resource_class('Observation'), reply, comparator_search_params)
+            validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
+
+            ['gt', 'ge', 'lt', 'le'].each do |comparator|
+              comparator_val = date_comparator_value(comparator, resolve_element_from_path(observation, 'effective') { |el| get_value_for_search_param(el).present? })
+              comparator_search_params = search_params.merge('date': comparator_val)
+              reply = get_resource_by_params(versioned_resource_class('Observation'), comparator_search_params)
+              validate_search_reply(versioned_resource_class('Observation'), reply, comparator_search_params)
+            end
+
+            value_with_system = get_value_for_search_param(resolve_element_from_path(observation, 'code') { |el| get_value_for_search_param(el).present? }, true)
+            token_with_system_search_params = search_params.merge('code': value_with_system)
+            reply = get_resource_by_params(versioned_resource_class('Observation'), token_with_system_search_params)
+            validate_search_reply(versioned_resource_class('Observation'), reply, token_with_system_search_params)
+
+            break if resolved_one
           end
-
-          value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'code') { |el| get_value_for_search_param(el).present? }, true)
-          token_with_system_search_params = search_params.merge('code': value_with_system)
-          reply = get_resource_by_params(versioned_resource_class('Observation'), token_with_system_search_params)
-          validate_search_reply(versioned_resource_class('Observation'), reply, token_with_system_search_params)
         end
 
         skip 'Could not resolve all parameters (patient, code, date) in any resource.' unless resolved_one

--- a/lib/modules/uscore_v3.1.1/heartrate_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/heartrate_sequence.rb
@@ -286,9 +286,7 @@ module Inferno
         patient_ids.each do |patient|
           next unless @observation_ary[patient].present?
 
-          observation_ary = Array.wrap(@observation_ary[patient])
-
-          observation_ary.each do |observation|
+          Array.wrap(@observation_ary[patient]).each do |observation|
             search_params = {
               'patient': patient,
               'category': get_value_for_search_param(resolve_element_from_path(observation, 'category') { |el| get_value_for_search_param(el).present? }),
@@ -393,9 +391,7 @@ module Inferno
         patient_ids.each do |patient|
           next unless @observation_ary[patient].present?
 
-          observation_ary = Array.wrap(@observation_ary[patient])
-
-          observation_ary.each do |observation|
+          Array.wrap(@observation_ary[patient]).each do |observation|
             search_params = {
               'patient': patient,
               'category': get_value_for_search_param(resolve_element_from_path(observation, 'category') { |el| get_value_for_search_param(el).present? }),
@@ -449,9 +445,7 @@ module Inferno
         patient_ids.each do |patient|
           next unless @observation_ary[patient].present?
 
-          observation_ary = Array.wrap(@observation_ary[patient])
-
-          observation_ary.each do |observation|
+          Array.wrap(@observation_ary[patient]).each do |observation|
             search_params = {
               'patient': patient,
               'code': get_value_for_search_param(resolve_element_from_path(observation, 'code') { |el| get_value_for_search_param(el).present? }),

--- a/lib/modules/uscore_v3.1.1/pediatric_bmi_for_age_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/pediatric_bmi_for_age_sequence.rb
@@ -286,33 +286,39 @@ module Inferno
         patient_ids.each do |patient|
           next unless @observation_ary[patient].present?
 
-          search_params = {
-            'patient': patient,
-            'category': get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category') { |el| get_value_for_search_param(el).present? }),
-            'date': get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'effective') { |el| get_value_for_search_param(el).present? })
-          }
+          observation_ary = Array.wrap(@observation_ary[patient])
 
-          next if search_params.any? { |_param, value| value.nil? }
+          observation_ary.each do |observation|
+            search_params = {
+              'patient': patient,
+              'category': get_value_for_search_param(resolve_element_from_path(observation, 'category') { |el| get_value_for_search_param(el).present? }),
+              'date': get_value_for_search_param(resolve_element_from_path(observation, 'effective') { |el| get_value_for_search_param(el).present? })
+            }
 
-          resolved_one = true
+            next if search_params.any? { |_param, value| value.nil? }
 
-          reply = get_resource_by_params(versioned_resource_class('Observation'), search_params)
+            resolved_one = true
 
-          reply = perform_search_with_status(reply, search_params, search_method: :get) if reply.code == 400
+            reply = get_resource_by_params(versioned_resource_class('Observation'), search_params)
 
-          validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
+            reply = perform_search_with_status(reply, search_params, search_method: :get) if reply.code == 400
 
-          ['gt', 'ge', 'lt', 'le'].each do |comparator|
-            comparator_val = date_comparator_value(comparator, resolve_element_from_path(@observation_ary[patient], 'effective') { |el| get_value_for_search_param(el).present? })
-            comparator_search_params = search_params.merge('date': comparator_val)
-            reply = get_resource_by_params(versioned_resource_class('Observation'), comparator_search_params)
-            validate_search_reply(versioned_resource_class('Observation'), reply, comparator_search_params)
+            validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
+
+            ['gt', 'ge', 'lt', 'le'].each do |comparator|
+              comparator_val = date_comparator_value(comparator, resolve_element_from_path(observation, 'effective') { |el| get_value_for_search_param(el).present? })
+              comparator_search_params = search_params.merge('date': comparator_val)
+              reply = get_resource_by_params(versioned_resource_class('Observation'), comparator_search_params)
+              validate_search_reply(versioned_resource_class('Observation'), reply, comparator_search_params)
+            end
+
+            value_with_system = get_value_for_search_param(resolve_element_from_path(observation, 'category') { |el| get_value_for_search_param(el).present? }, true)
+            token_with_system_search_params = search_params.merge('category': value_with_system)
+            reply = get_resource_by_params(versioned_resource_class('Observation'), token_with_system_search_params)
+            validate_search_reply(versioned_resource_class('Observation'), reply, token_with_system_search_params)
+
+            break if resolved_one
           end
-
-          value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category') { |el| get_value_for_search_param(el).present? }, true)
-          token_with_system_search_params = search_params.merge('category': value_with_system)
-          reply = get_resource_by_params(versioned_resource_class('Observation'), token_with_system_search_params)
-          validate_search_reply(versioned_resource_class('Observation'), reply, token_with_system_search_params)
         end
 
         skip 'Could not resolve all parameters (patient, category, date) in any resource.' unless resolved_one
@@ -387,24 +393,30 @@ module Inferno
         patient_ids.each do |patient|
           next unless @observation_ary[patient].present?
 
-          search_params = {
-            'patient': patient,
-            'category': get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category') { |el| get_value_for_search_param(el).present? }),
-            'status': get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'status') { |el| get_value_for_search_param(el).present? })
-          }
+          observation_ary = Array.wrap(@observation_ary[patient])
 
-          next if search_params.any? { |_param, value| value.nil? }
+          observation_ary.each do |observation|
+            search_params = {
+              'patient': patient,
+              'category': get_value_for_search_param(resolve_element_from_path(observation, 'category') { |el| get_value_for_search_param(el).present? }),
+              'status': get_value_for_search_param(resolve_element_from_path(observation, 'status') { |el| get_value_for_search_param(el).present? })
+            }
 
-          resolved_one = true
+            next if search_params.any? { |_param, value| value.nil? }
 
-          reply = get_resource_by_params(versioned_resource_class('Observation'), search_params)
+            resolved_one = true
 
-          validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
+            reply = get_resource_by_params(versioned_resource_class('Observation'), search_params)
 
-          value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category') { |el| get_value_for_search_param(el).present? }, true)
-          token_with_system_search_params = search_params.merge('category': value_with_system)
-          reply = get_resource_by_params(versioned_resource_class('Observation'), token_with_system_search_params)
-          validate_search_reply(versioned_resource_class('Observation'), reply, token_with_system_search_params)
+            validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
+
+            value_with_system = get_value_for_search_param(resolve_element_from_path(observation, 'category') { |el| get_value_for_search_param(el).present? }, true)
+            token_with_system_search_params = search_params.merge('category': value_with_system)
+            reply = get_resource_by_params(versioned_resource_class('Observation'), token_with_system_search_params)
+            validate_search_reply(versioned_resource_class('Observation'), reply, token_with_system_search_params)
+
+            break if resolved_one
+          end
         end
 
         skip 'Could not resolve all parameters (patient, category, status) in any resource.' unless resolved_one
@@ -437,33 +449,39 @@ module Inferno
         patient_ids.each do |patient|
           next unless @observation_ary[patient].present?
 
-          search_params = {
-            'patient': patient,
-            'code': get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'code') { |el| get_value_for_search_param(el).present? }),
-            'date': get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'effective') { |el| get_value_for_search_param(el).present? })
-          }
+          observation_ary = Array.wrap(@observation_ary[patient])
 
-          next if search_params.any? { |_param, value| value.nil? }
+          observation_ary.each do |observation|
+            search_params = {
+              'patient': patient,
+              'code': get_value_for_search_param(resolve_element_from_path(observation, 'code') { |el| get_value_for_search_param(el).present? }),
+              'date': get_value_for_search_param(resolve_element_from_path(observation, 'effective') { |el| get_value_for_search_param(el).present? })
+            }
 
-          resolved_one = true
+            next if search_params.any? { |_param, value| value.nil? }
 
-          reply = get_resource_by_params(versioned_resource_class('Observation'), search_params)
+            resolved_one = true
 
-          reply = perform_search_with_status(reply, search_params, search_method: :get) if reply.code == 400
+            reply = get_resource_by_params(versioned_resource_class('Observation'), search_params)
 
-          validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
+            reply = perform_search_with_status(reply, search_params, search_method: :get) if reply.code == 400
 
-          ['gt', 'ge', 'lt', 'le'].each do |comparator|
-            comparator_val = date_comparator_value(comparator, resolve_element_from_path(@observation_ary[patient], 'effective') { |el| get_value_for_search_param(el).present? })
-            comparator_search_params = search_params.merge('date': comparator_val)
-            reply = get_resource_by_params(versioned_resource_class('Observation'), comparator_search_params)
-            validate_search_reply(versioned_resource_class('Observation'), reply, comparator_search_params)
+            validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
+
+            ['gt', 'ge', 'lt', 'le'].each do |comparator|
+              comparator_val = date_comparator_value(comparator, resolve_element_from_path(observation, 'effective') { |el| get_value_for_search_param(el).present? })
+              comparator_search_params = search_params.merge('date': comparator_val)
+              reply = get_resource_by_params(versioned_resource_class('Observation'), comparator_search_params)
+              validate_search_reply(versioned_resource_class('Observation'), reply, comparator_search_params)
+            end
+
+            value_with_system = get_value_for_search_param(resolve_element_from_path(observation, 'code') { |el| get_value_for_search_param(el).present? }, true)
+            token_with_system_search_params = search_params.merge('code': value_with_system)
+            reply = get_resource_by_params(versioned_resource_class('Observation'), token_with_system_search_params)
+            validate_search_reply(versioned_resource_class('Observation'), reply, token_with_system_search_params)
+
+            break if resolved_one
           end
-
-          value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'code') { |el| get_value_for_search_param(el).present? }, true)
-          token_with_system_search_params = search_params.merge('code': value_with_system)
-          reply = get_resource_by_params(versioned_resource_class('Observation'), token_with_system_search_params)
-          validate_search_reply(versioned_resource_class('Observation'), reply, token_with_system_search_params)
         end
 
         skip 'Could not resolve all parameters (patient, code, date) in any resource.' unless resolved_one

--- a/lib/modules/uscore_v3.1.1/pediatric_bmi_for_age_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/pediatric_bmi_for_age_sequence.rb
@@ -286,9 +286,7 @@ module Inferno
         patient_ids.each do |patient|
           next unless @observation_ary[patient].present?
 
-          observation_ary = Array.wrap(@observation_ary[patient])
-
-          observation_ary.each do |observation|
+          Array.wrap(@observation_ary[patient]).each do |observation|
             search_params = {
               'patient': patient,
               'category': get_value_for_search_param(resolve_element_from_path(observation, 'category') { |el| get_value_for_search_param(el).present? }),
@@ -393,9 +391,7 @@ module Inferno
         patient_ids.each do |patient|
           next unless @observation_ary[patient].present?
 
-          observation_ary = Array.wrap(@observation_ary[patient])
-
-          observation_ary.each do |observation|
+          Array.wrap(@observation_ary[patient]).each do |observation|
             search_params = {
               'patient': patient,
               'category': get_value_for_search_param(resolve_element_from_path(observation, 'category') { |el| get_value_for_search_param(el).present? }),
@@ -449,9 +445,7 @@ module Inferno
         patient_ids.each do |patient|
           next unless @observation_ary[patient].present?
 
-          observation_ary = Array.wrap(@observation_ary[patient])
-
-          observation_ary.each do |observation|
+          Array.wrap(@observation_ary[patient]).each do |observation|
             search_params = {
               'patient': patient,
               'code': get_value_for_search_param(resolve_element_from_path(observation, 'code') { |el| get_value_for_search_param(el).present? }),

--- a/lib/modules/uscore_v3.1.1/pediatric_weight_for_height_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/pediatric_weight_for_height_sequence.rb
@@ -286,33 +286,39 @@ module Inferno
         patient_ids.each do |patient|
           next unless @observation_ary[patient].present?
 
-          search_params = {
-            'patient': patient,
-            'category': get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category') { |el| get_value_for_search_param(el).present? }),
-            'date': get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'effective') { |el| get_value_for_search_param(el).present? })
-          }
+          observation_ary = Array.wrap(@observation_ary[patient])
 
-          next if search_params.any? { |_param, value| value.nil? }
+          observation_ary.each do |observation|
+            search_params = {
+              'patient': patient,
+              'category': get_value_for_search_param(resolve_element_from_path(observation, 'category') { |el| get_value_for_search_param(el).present? }),
+              'date': get_value_for_search_param(resolve_element_from_path(observation, 'effective') { |el| get_value_for_search_param(el).present? })
+            }
 
-          resolved_one = true
+            next if search_params.any? { |_param, value| value.nil? }
 
-          reply = get_resource_by_params(versioned_resource_class('Observation'), search_params)
+            resolved_one = true
 
-          reply = perform_search_with_status(reply, search_params, search_method: :get) if reply.code == 400
+            reply = get_resource_by_params(versioned_resource_class('Observation'), search_params)
 
-          validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
+            reply = perform_search_with_status(reply, search_params, search_method: :get) if reply.code == 400
 
-          ['gt', 'ge', 'lt', 'le'].each do |comparator|
-            comparator_val = date_comparator_value(comparator, resolve_element_from_path(@observation_ary[patient], 'effective') { |el| get_value_for_search_param(el).present? })
-            comparator_search_params = search_params.merge('date': comparator_val)
-            reply = get_resource_by_params(versioned_resource_class('Observation'), comparator_search_params)
-            validate_search_reply(versioned_resource_class('Observation'), reply, comparator_search_params)
+            validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
+
+            ['gt', 'ge', 'lt', 'le'].each do |comparator|
+              comparator_val = date_comparator_value(comparator, resolve_element_from_path(observation, 'effective') { |el| get_value_for_search_param(el).present? })
+              comparator_search_params = search_params.merge('date': comparator_val)
+              reply = get_resource_by_params(versioned_resource_class('Observation'), comparator_search_params)
+              validate_search_reply(versioned_resource_class('Observation'), reply, comparator_search_params)
+            end
+
+            value_with_system = get_value_for_search_param(resolve_element_from_path(observation, 'category') { |el| get_value_for_search_param(el).present? }, true)
+            token_with_system_search_params = search_params.merge('category': value_with_system)
+            reply = get_resource_by_params(versioned_resource_class('Observation'), token_with_system_search_params)
+            validate_search_reply(versioned_resource_class('Observation'), reply, token_with_system_search_params)
+
+            break if resolved_one
           end
-
-          value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category') { |el| get_value_for_search_param(el).present? }, true)
-          token_with_system_search_params = search_params.merge('category': value_with_system)
-          reply = get_resource_by_params(versioned_resource_class('Observation'), token_with_system_search_params)
-          validate_search_reply(versioned_resource_class('Observation'), reply, token_with_system_search_params)
         end
 
         skip 'Could not resolve all parameters (patient, category, date) in any resource.' unless resolved_one
@@ -387,24 +393,30 @@ module Inferno
         patient_ids.each do |patient|
           next unless @observation_ary[patient].present?
 
-          search_params = {
-            'patient': patient,
-            'category': get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category') { |el| get_value_for_search_param(el).present? }),
-            'status': get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'status') { |el| get_value_for_search_param(el).present? })
-          }
+          observation_ary = Array.wrap(@observation_ary[patient])
 
-          next if search_params.any? { |_param, value| value.nil? }
+          observation_ary.each do |observation|
+            search_params = {
+              'patient': patient,
+              'category': get_value_for_search_param(resolve_element_from_path(observation, 'category') { |el| get_value_for_search_param(el).present? }),
+              'status': get_value_for_search_param(resolve_element_from_path(observation, 'status') { |el| get_value_for_search_param(el).present? })
+            }
 
-          resolved_one = true
+            next if search_params.any? { |_param, value| value.nil? }
 
-          reply = get_resource_by_params(versioned_resource_class('Observation'), search_params)
+            resolved_one = true
 
-          validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
+            reply = get_resource_by_params(versioned_resource_class('Observation'), search_params)
 
-          value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category') { |el| get_value_for_search_param(el).present? }, true)
-          token_with_system_search_params = search_params.merge('category': value_with_system)
-          reply = get_resource_by_params(versioned_resource_class('Observation'), token_with_system_search_params)
-          validate_search_reply(versioned_resource_class('Observation'), reply, token_with_system_search_params)
+            validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
+
+            value_with_system = get_value_for_search_param(resolve_element_from_path(observation, 'category') { |el| get_value_for_search_param(el).present? }, true)
+            token_with_system_search_params = search_params.merge('category': value_with_system)
+            reply = get_resource_by_params(versioned_resource_class('Observation'), token_with_system_search_params)
+            validate_search_reply(versioned_resource_class('Observation'), reply, token_with_system_search_params)
+
+            break if resolved_one
+          end
         end
 
         skip 'Could not resolve all parameters (patient, category, status) in any resource.' unless resolved_one
@@ -437,33 +449,39 @@ module Inferno
         patient_ids.each do |patient|
           next unless @observation_ary[patient].present?
 
-          search_params = {
-            'patient': patient,
-            'code': get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'code') { |el| get_value_for_search_param(el).present? }),
-            'date': get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'effective') { |el| get_value_for_search_param(el).present? })
-          }
+          observation_ary = Array.wrap(@observation_ary[patient])
 
-          next if search_params.any? { |_param, value| value.nil? }
+          observation_ary.each do |observation|
+            search_params = {
+              'patient': patient,
+              'code': get_value_for_search_param(resolve_element_from_path(observation, 'code') { |el| get_value_for_search_param(el).present? }),
+              'date': get_value_for_search_param(resolve_element_from_path(observation, 'effective') { |el| get_value_for_search_param(el).present? })
+            }
 
-          resolved_one = true
+            next if search_params.any? { |_param, value| value.nil? }
 
-          reply = get_resource_by_params(versioned_resource_class('Observation'), search_params)
+            resolved_one = true
 
-          reply = perform_search_with_status(reply, search_params, search_method: :get) if reply.code == 400
+            reply = get_resource_by_params(versioned_resource_class('Observation'), search_params)
 
-          validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
+            reply = perform_search_with_status(reply, search_params, search_method: :get) if reply.code == 400
 
-          ['gt', 'ge', 'lt', 'le'].each do |comparator|
-            comparator_val = date_comparator_value(comparator, resolve_element_from_path(@observation_ary[patient], 'effective') { |el| get_value_for_search_param(el).present? })
-            comparator_search_params = search_params.merge('date': comparator_val)
-            reply = get_resource_by_params(versioned_resource_class('Observation'), comparator_search_params)
-            validate_search_reply(versioned_resource_class('Observation'), reply, comparator_search_params)
+            validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
+
+            ['gt', 'ge', 'lt', 'le'].each do |comparator|
+              comparator_val = date_comparator_value(comparator, resolve_element_from_path(observation, 'effective') { |el| get_value_for_search_param(el).present? })
+              comparator_search_params = search_params.merge('date': comparator_val)
+              reply = get_resource_by_params(versioned_resource_class('Observation'), comparator_search_params)
+              validate_search_reply(versioned_resource_class('Observation'), reply, comparator_search_params)
+            end
+
+            value_with_system = get_value_for_search_param(resolve_element_from_path(observation, 'code') { |el| get_value_for_search_param(el).present? }, true)
+            token_with_system_search_params = search_params.merge('code': value_with_system)
+            reply = get_resource_by_params(versioned_resource_class('Observation'), token_with_system_search_params)
+            validate_search_reply(versioned_resource_class('Observation'), reply, token_with_system_search_params)
+
+            break if resolved_one
           end
-
-          value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'code') { |el| get_value_for_search_param(el).present? }, true)
-          token_with_system_search_params = search_params.merge('code': value_with_system)
-          reply = get_resource_by_params(versioned_resource_class('Observation'), token_with_system_search_params)
-          validate_search_reply(versioned_resource_class('Observation'), reply, token_with_system_search_params)
         end
 
         skip 'Could not resolve all parameters (patient, code, date) in any resource.' unless resolved_one

--- a/lib/modules/uscore_v3.1.1/pediatric_weight_for_height_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/pediatric_weight_for_height_sequence.rb
@@ -286,9 +286,7 @@ module Inferno
         patient_ids.each do |patient|
           next unless @observation_ary[patient].present?
 
-          observation_ary = Array.wrap(@observation_ary[patient])
-
-          observation_ary.each do |observation|
+          Array.wrap(@observation_ary[patient]).each do |observation|
             search_params = {
               'patient': patient,
               'category': get_value_for_search_param(resolve_element_from_path(observation, 'category') { |el| get_value_for_search_param(el).present? }),
@@ -393,9 +391,7 @@ module Inferno
         patient_ids.each do |patient|
           next unless @observation_ary[patient].present?
 
-          observation_ary = Array.wrap(@observation_ary[patient])
-
-          observation_ary.each do |observation|
+          Array.wrap(@observation_ary[patient]).each do |observation|
             search_params = {
               'patient': patient,
               'category': get_value_for_search_param(resolve_element_from_path(observation, 'category') { |el| get_value_for_search_param(el).present? }),
@@ -449,9 +445,7 @@ module Inferno
         patient_ids.each do |patient|
           next unless @observation_ary[patient].present?
 
-          observation_ary = Array.wrap(@observation_ary[patient])
-
-          observation_ary.each do |observation|
+          Array.wrap(@observation_ary[patient]).each do |observation|
             search_params = {
               'patient': patient,
               'code': get_value_for_search_param(resolve_element_from_path(observation, 'code') { |el| get_value_for_search_param(el).present? }),

--- a/lib/modules/uscore_v3.1.1/resprate_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/resprate_sequence.rb
@@ -286,33 +286,39 @@ module Inferno
         patient_ids.each do |patient|
           next unless @observation_ary[patient].present?
 
-          search_params = {
-            'patient': patient,
-            'category': get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category') { |el| get_value_for_search_param(el).present? }),
-            'date': get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'effective') { |el| get_value_for_search_param(el).present? })
-          }
+          observation_ary = Array.wrap(@observation_ary[patient])
 
-          next if search_params.any? { |_param, value| value.nil? }
+          observation_ary.each do |observation|
+            search_params = {
+              'patient': patient,
+              'category': get_value_for_search_param(resolve_element_from_path(observation, 'category') { |el| get_value_for_search_param(el).present? }),
+              'date': get_value_for_search_param(resolve_element_from_path(observation, 'effective') { |el| get_value_for_search_param(el).present? })
+            }
 
-          resolved_one = true
+            next if search_params.any? { |_param, value| value.nil? }
 
-          reply = get_resource_by_params(versioned_resource_class('Observation'), search_params)
+            resolved_one = true
 
-          reply = perform_search_with_status(reply, search_params, search_method: :get) if reply.code == 400
+            reply = get_resource_by_params(versioned_resource_class('Observation'), search_params)
 
-          validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
+            reply = perform_search_with_status(reply, search_params, search_method: :get) if reply.code == 400
 
-          ['gt', 'ge', 'lt', 'le'].each do |comparator|
-            comparator_val = date_comparator_value(comparator, resolve_element_from_path(@observation_ary[patient], 'effective') { |el| get_value_for_search_param(el).present? })
-            comparator_search_params = search_params.merge('date': comparator_val)
-            reply = get_resource_by_params(versioned_resource_class('Observation'), comparator_search_params)
-            validate_search_reply(versioned_resource_class('Observation'), reply, comparator_search_params)
+            validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
+
+            ['gt', 'ge', 'lt', 'le'].each do |comparator|
+              comparator_val = date_comparator_value(comparator, resolve_element_from_path(observation, 'effective') { |el| get_value_for_search_param(el).present? })
+              comparator_search_params = search_params.merge('date': comparator_val)
+              reply = get_resource_by_params(versioned_resource_class('Observation'), comparator_search_params)
+              validate_search_reply(versioned_resource_class('Observation'), reply, comparator_search_params)
+            end
+
+            value_with_system = get_value_for_search_param(resolve_element_from_path(observation, 'category') { |el| get_value_for_search_param(el).present? }, true)
+            token_with_system_search_params = search_params.merge('category': value_with_system)
+            reply = get_resource_by_params(versioned_resource_class('Observation'), token_with_system_search_params)
+            validate_search_reply(versioned_resource_class('Observation'), reply, token_with_system_search_params)
+
+            break if resolved_one
           end
-
-          value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category') { |el| get_value_for_search_param(el).present? }, true)
-          token_with_system_search_params = search_params.merge('category': value_with_system)
-          reply = get_resource_by_params(versioned_resource_class('Observation'), token_with_system_search_params)
-          validate_search_reply(versioned_resource_class('Observation'), reply, token_with_system_search_params)
         end
 
         skip 'Could not resolve all parameters (patient, category, date) in any resource.' unless resolved_one
@@ -387,24 +393,30 @@ module Inferno
         patient_ids.each do |patient|
           next unless @observation_ary[patient].present?
 
-          search_params = {
-            'patient': patient,
-            'category': get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category') { |el| get_value_for_search_param(el).present? }),
-            'status': get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'status') { |el| get_value_for_search_param(el).present? })
-          }
+          observation_ary = Array.wrap(@observation_ary[patient])
 
-          next if search_params.any? { |_param, value| value.nil? }
+          observation_ary.each do |observation|
+            search_params = {
+              'patient': patient,
+              'category': get_value_for_search_param(resolve_element_from_path(observation, 'category') { |el| get_value_for_search_param(el).present? }),
+              'status': get_value_for_search_param(resolve_element_from_path(observation, 'status') { |el| get_value_for_search_param(el).present? })
+            }
 
-          resolved_one = true
+            next if search_params.any? { |_param, value| value.nil? }
 
-          reply = get_resource_by_params(versioned_resource_class('Observation'), search_params)
+            resolved_one = true
 
-          validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
+            reply = get_resource_by_params(versioned_resource_class('Observation'), search_params)
 
-          value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category') { |el| get_value_for_search_param(el).present? }, true)
-          token_with_system_search_params = search_params.merge('category': value_with_system)
-          reply = get_resource_by_params(versioned_resource_class('Observation'), token_with_system_search_params)
-          validate_search_reply(versioned_resource_class('Observation'), reply, token_with_system_search_params)
+            validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
+
+            value_with_system = get_value_for_search_param(resolve_element_from_path(observation, 'category') { |el| get_value_for_search_param(el).present? }, true)
+            token_with_system_search_params = search_params.merge('category': value_with_system)
+            reply = get_resource_by_params(versioned_resource_class('Observation'), token_with_system_search_params)
+            validate_search_reply(versioned_resource_class('Observation'), reply, token_with_system_search_params)
+
+            break if resolved_one
+          end
         end
 
         skip 'Could not resolve all parameters (patient, category, status) in any resource.' unless resolved_one
@@ -437,33 +449,39 @@ module Inferno
         patient_ids.each do |patient|
           next unless @observation_ary[patient].present?
 
-          search_params = {
-            'patient': patient,
-            'code': get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'code') { |el| get_value_for_search_param(el).present? }),
-            'date': get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'effective') { |el| get_value_for_search_param(el).present? })
-          }
+          observation_ary = Array.wrap(@observation_ary[patient])
 
-          next if search_params.any? { |_param, value| value.nil? }
+          observation_ary.each do |observation|
+            search_params = {
+              'patient': patient,
+              'code': get_value_for_search_param(resolve_element_from_path(observation, 'code') { |el| get_value_for_search_param(el).present? }),
+              'date': get_value_for_search_param(resolve_element_from_path(observation, 'effective') { |el| get_value_for_search_param(el).present? })
+            }
 
-          resolved_one = true
+            next if search_params.any? { |_param, value| value.nil? }
 
-          reply = get_resource_by_params(versioned_resource_class('Observation'), search_params)
+            resolved_one = true
 
-          reply = perform_search_with_status(reply, search_params, search_method: :get) if reply.code == 400
+            reply = get_resource_by_params(versioned_resource_class('Observation'), search_params)
 
-          validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
+            reply = perform_search_with_status(reply, search_params, search_method: :get) if reply.code == 400
 
-          ['gt', 'ge', 'lt', 'le'].each do |comparator|
-            comparator_val = date_comparator_value(comparator, resolve_element_from_path(@observation_ary[patient], 'effective') { |el| get_value_for_search_param(el).present? })
-            comparator_search_params = search_params.merge('date': comparator_val)
-            reply = get_resource_by_params(versioned_resource_class('Observation'), comparator_search_params)
-            validate_search_reply(versioned_resource_class('Observation'), reply, comparator_search_params)
+            validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
+
+            ['gt', 'ge', 'lt', 'le'].each do |comparator|
+              comparator_val = date_comparator_value(comparator, resolve_element_from_path(observation, 'effective') { |el| get_value_for_search_param(el).present? })
+              comparator_search_params = search_params.merge('date': comparator_val)
+              reply = get_resource_by_params(versioned_resource_class('Observation'), comparator_search_params)
+              validate_search_reply(versioned_resource_class('Observation'), reply, comparator_search_params)
+            end
+
+            value_with_system = get_value_for_search_param(resolve_element_from_path(observation, 'code') { |el| get_value_for_search_param(el).present? }, true)
+            token_with_system_search_params = search_params.merge('code': value_with_system)
+            reply = get_resource_by_params(versioned_resource_class('Observation'), token_with_system_search_params)
+            validate_search_reply(versioned_resource_class('Observation'), reply, token_with_system_search_params)
+
+            break if resolved_one
           end
-
-          value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'code') { |el| get_value_for_search_param(el).present? }, true)
-          token_with_system_search_params = search_params.merge('code': value_with_system)
-          reply = get_resource_by_params(versioned_resource_class('Observation'), token_with_system_search_params)
-          validate_search_reply(versioned_resource_class('Observation'), reply, token_with_system_search_params)
         end
 
         skip 'Could not resolve all parameters (patient, code, date) in any resource.' unless resolved_one

--- a/lib/modules/uscore_v3.1.1/resprate_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/resprate_sequence.rb
@@ -286,9 +286,7 @@ module Inferno
         patient_ids.each do |patient|
           next unless @observation_ary[patient].present?
 
-          observation_ary = Array.wrap(@observation_ary[patient])
-
-          observation_ary.each do |observation|
+          Array.wrap(@observation_ary[patient]).each do |observation|
             search_params = {
               'patient': patient,
               'category': get_value_for_search_param(resolve_element_from_path(observation, 'category') { |el| get_value_for_search_param(el).present? }),
@@ -393,9 +391,7 @@ module Inferno
         patient_ids.each do |patient|
           next unless @observation_ary[patient].present?
 
-          observation_ary = Array.wrap(@observation_ary[patient])
-
-          observation_ary.each do |observation|
+          Array.wrap(@observation_ary[patient]).each do |observation|
             search_params = {
               'patient': patient,
               'category': get_value_for_search_param(resolve_element_from_path(observation, 'category') { |el| get_value_for_search_param(el).present? }),
@@ -449,9 +445,7 @@ module Inferno
         patient_ids.each do |patient|
           next unless @observation_ary[patient].present?
 
-          observation_ary = Array.wrap(@observation_ary[patient])
-
-          observation_ary.each do |observation|
+          Array.wrap(@observation_ary[patient]).each do |observation|
             search_params = {
               'patient': patient,
               'code': get_value_for_search_param(resolve_element_from_path(observation, 'code') { |el| get_value_for_search_param(el).present? }),

--- a/lib/modules/uscore_v3.1.1/us_core_careplan_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_careplan_sequence.rb
@@ -268,24 +268,30 @@ module Inferno
         patient_ids.each do |patient|
           next unless @care_plan_ary[patient].present?
 
-          search_params = {
-            'patient': patient,
-            'category': get_value_for_search_param(resolve_element_from_path(@care_plan_ary[patient], 'category') { |el| get_value_for_search_param(el).present? }),
-            'status': get_value_for_search_param(resolve_element_from_path(@care_plan_ary[patient], 'status') { |el| get_value_for_search_param(el).present? })
-          }
+          care_plan_ary = Array.wrap(@care_plan_ary[patient])
 
-          next if search_params.any? { |_param, value| value.nil? }
+          care_plan_ary.each do |care_plan|
+            search_params = {
+              'patient': patient,
+              'category': get_value_for_search_param(resolve_element_from_path(care_plan, 'category') { |el| get_value_for_search_param(el).present? }),
+              'status': get_value_for_search_param(resolve_element_from_path(care_plan, 'status') { |el| get_value_for_search_param(el).present? })
+            }
 
-          resolved_one = true
+            next if search_params.any? { |_param, value| value.nil? }
 
-          reply = get_resource_by_params(versioned_resource_class('CarePlan'), search_params)
+            resolved_one = true
 
-          validate_search_reply(versioned_resource_class('CarePlan'), reply, search_params)
+            reply = get_resource_by_params(versioned_resource_class('CarePlan'), search_params)
 
-          value_with_system = get_value_for_search_param(resolve_element_from_path(@care_plan_ary[patient], 'category') { |el| get_value_for_search_param(el).present? }, true)
-          token_with_system_search_params = search_params.merge('category': value_with_system)
-          reply = get_resource_by_params(versioned_resource_class('CarePlan'), token_with_system_search_params)
-          validate_search_reply(versioned_resource_class('CarePlan'), reply, token_with_system_search_params)
+            validate_search_reply(versioned_resource_class('CarePlan'), reply, search_params)
+
+            value_with_system = get_value_for_search_param(resolve_element_from_path(care_plan, 'category') { |el| get_value_for_search_param(el).present? }, true)
+            token_with_system_search_params = search_params.merge('category': value_with_system)
+            reply = get_resource_by_params(versioned_resource_class('CarePlan'), token_with_system_search_params)
+            validate_search_reply(versioned_resource_class('CarePlan'), reply, token_with_system_search_params)
+
+            break if resolved_one
+          end
         end
 
         skip 'Could not resolve all parameters (patient, category, status) in any resource.' unless resolved_one

--- a/lib/modules/uscore_v3.1.1/us_core_careplan_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_careplan_sequence.rb
@@ -268,9 +268,7 @@ module Inferno
         patient_ids.each do |patient|
           next unless @care_plan_ary[patient].present?
 
-          care_plan_ary = Array.wrap(@care_plan_ary[patient])
-
-          care_plan_ary.each do |care_plan|
+          Array.wrap(@care_plan_ary[patient]).each do |care_plan|
             search_params = {
               'patient': patient,
               'category': get_value_for_search_param(resolve_element_from_path(care_plan, 'category') { |el| get_value_for_search_param(el).present? }),

--- a/lib/modules/uscore_v3.1.1/us_core_careteam_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_careteam_sequence.rb
@@ -438,6 +438,8 @@ module Inferno
 
         found_second_val = false
         patient_ids.each do |patient|
+          next unless @care_team_ary[patient].present?
+
           search_params = {
             'patient': patient,
             'status': get_value_for_search_param(resolve_element_from_path(@care_team_ary[patient], 'status') { |el| get_value_for_search_param(el).present? })

--- a/lib/modules/uscore_v3.1.1/us_core_diagnosticreport_lab_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_diagnosticreport_lab_sequence.rb
@@ -321,9 +321,7 @@ module Inferno
         patient_ids.each do |patient|
           next unless @diagnostic_report_ary[patient].present?
 
-          diagnostic_report_ary = Array.wrap(@diagnostic_report_ary[patient])
-
-          diagnostic_report_ary.each do |diagnostic_report|
+          Array.wrap(@diagnostic_report_ary[patient]).each do |diagnostic_report|
             search_params = {
               'patient': patient,
               'category': get_value_for_search_param(resolve_element_from_path(diagnostic_report, 'category') { |el| get_value_for_search_param(el).present? }),
@@ -472,9 +470,7 @@ module Inferno
         patient_ids.each do |patient|
           next unless @diagnostic_report_ary[patient].present?
 
-          diagnostic_report_ary = Array.wrap(@diagnostic_report_ary[patient])
-
-          diagnostic_report_ary.each do |diagnostic_report|
+          Array.wrap(@diagnostic_report_ary[patient]).each do |diagnostic_report|
             search_params = {
               'patient': patient,
               'code': get_value_for_search_param(resolve_element_from_path(diagnostic_report, 'code') { |el| get_value_for_search_param(el).present? }),

--- a/lib/modules/uscore_v3.1.1/us_core_diagnosticreport_lab_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_diagnosticreport_lab_sequence.rb
@@ -321,33 +321,39 @@ module Inferno
         patient_ids.each do |patient|
           next unless @diagnostic_report_ary[patient].present?
 
-          search_params = {
-            'patient': patient,
-            'category': get_value_for_search_param(resolve_element_from_path(@diagnostic_report_ary[patient], 'category') { |el| get_value_for_search_param(el).present? }),
-            'date': get_value_for_search_param(resolve_element_from_path(@diagnostic_report_ary[patient], 'effective') { |el| get_value_for_search_param(el).present? })
-          }
+          diagnostic_report_ary = Array.wrap(@diagnostic_report_ary[patient])
 
-          next if search_params.any? { |_param, value| value.nil? }
+          diagnostic_report_ary.each do |diagnostic_report|
+            search_params = {
+              'patient': patient,
+              'category': get_value_for_search_param(resolve_element_from_path(diagnostic_report, 'category') { |el| get_value_for_search_param(el).present? }),
+              'date': get_value_for_search_param(resolve_element_from_path(diagnostic_report, 'effective') { |el| get_value_for_search_param(el).present? })
+            }
 
-          resolved_one = true
+            next if search_params.any? { |_param, value| value.nil? }
 
-          reply = get_resource_by_params(versioned_resource_class('DiagnosticReport'), search_params)
+            resolved_one = true
 
-          reply = perform_search_with_status(reply, search_params, search_method: :get) if reply.code == 400
+            reply = get_resource_by_params(versioned_resource_class('DiagnosticReport'), search_params)
 
-          validate_search_reply(versioned_resource_class('DiagnosticReport'), reply, search_params)
+            reply = perform_search_with_status(reply, search_params, search_method: :get) if reply.code == 400
 
-          ['gt', 'ge', 'lt', 'le'].each do |comparator|
-            comparator_val = date_comparator_value(comparator, resolve_element_from_path(@diagnostic_report_ary[patient], 'effective') { |el| get_value_for_search_param(el).present? })
-            comparator_search_params = search_params.merge('date': comparator_val)
-            reply = get_resource_by_params(versioned_resource_class('DiagnosticReport'), comparator_search_params)
-            validate_search_reply(versioned_resource_class('DiagnosticReport'), reply, comparator_search_params)
+            validate_search_reply(versioned_resource_class('DiagnosticReport'), reply, search_params)
+
+            ['gt', 'ge', 'lt', 'le'].each do |comparator|
+              comparator_val = date_comparator_value(comparator, resolve_element_from_path(diagnostic_report, 'effective') { |el| get_value_for_search_param(el).present? })
+              comparator_search_params = search_params.merge('date': comparator_val)
+              reply = get_resource_by_params(versioned_resource_class('DiagnosticReport'), comparator_search_params)
+              validate_search_reply(versioned_resource_class('DiagnosticReport'), reply, comparator_search_params)
+            end
+
+            value_with_system = get_value_for_search_param(resolve_element_from_path(diagnostic_report, 'category') { |el| get_value_for_search_param(el).present? }, true)
+            token_with_system_search_params = search_params.merge('category': value_with_system)
+            reply = get_resource_by_params(versioned_resource_class('DiagnosticReport'), token_with_system_search_params)
+            validate_search_reply(versioned_resource_class('DiagnosticReport'), reply, token_with_system_search_params)
+
+            break if resolved_one
           end
-
-          value_with_system = get_value_for_search_param(resolve_element_from_path(@diagnostic_report_ary[patient], 'category') { |el| get_value_for_search_param(el).present? }, true)
-          token_with_system_search_params = search_params.merge('category': value_with_system)
-          reply = get_resource_by_params(versioned_resource_class('DiagnosticReport'), token_with_system_search_params)
-          validate_search_reply(versioned_resource_class('DiagnosticReport'), reply, token_with_system_search_params)
         end
 
         skip 'Could not resolve all parameters (patient, category, date) in any resource.' unless resolved_one
@@ -466,33 +472,39 @@ module Inferno
         patient_ids.each do |patient|
           next unless @diagnostic_report_ary[patient].present?
 
-          search_params = {
-            'patient': patient,
-            'code': get_value_for_search_param(resolve_element_from_path(@diagnostic_report_ary[patient], 'code') { |el| get_value_for_search_param(el).present? }),
-            'date': get_value_for_search_param(resolve_element_from_path(@diagnostic_report_ary[patient], 'effective') { |el| get_value_for_search_param(el).present? })
-          }
+          diagnostic_report_ary = Array.wrap(@diagnostic_report_ary[patient])
 
-          next if search_params.any? { |_param, value| value.nil? }
+          diagnostic_report_ary.each do |diagnostic_report|
+            search_params = {
+              'patient': patient,
+              'code': get_value_for_search_param(resolve_element_from_path(diagnostic_report, 'code') { |el| get_value_for_search_param(el).present? }),
+              'date': get_value_for_search_param(resolve_element_from_path(diagnostic_report, 'effective') { |el| get_value_for_search_param(el).present? })
+            }
 
-          resolved_one = true
+            next if search_params.any? { |_param, value| value.nil? }
 
-          reply = get_resource_by_params(versioned_resource_class('DiagnosticReport'), search_params)
+            resolved_one = true
 
-          reply = perform_search_with_status(reply, search_params, search_method: :get) if reply.code == 400
+            reply = get_resource_by_params(versioned_resource_class('DiagnosticReport'), search_params)
 
-          validate_search_reply(versioned_resource_class('DiagnosticReport'), reply, search_params)
+            reply = perform_search_with_status(reply, search_params, search_method: :get) if reply.code == 400
 
-          ['gt', 'ge', 'lt', 'le'].each do |comparator|
-            comparator_val = date_comparator_value(comparator, resolve_element_from_path(@diagnostic_report_ary[patient], 'effective') { |el| get_value_for_search_param(el).present? })
-            comparator_search_params = search_params.merge('date': comparator_val)
-            reply = get_resource_by_params(versioned_resource_class('DiagnosticReport'), comparator_search_params)
-            validate_search_reply(versioned_resource_class('DiagnosticReport'), reply, comparator_search_params)
+            validate_search_reply(versioned_resource_class('DiagnosticReport'), reply, search_params)
+
+            ['gt', 'ge', 'lt', 'le'].each do |comparator|
+              comparator_val = date_comparator_value(comparator, resolve_element_from_path(diagnostic_report, 'effective') { |el| get_value_for_search_param(el).present? })
+              comparator_search_params = search_params.merge('date': comparator_val)
+              reply = get_resource_by_params(versioned_resource_class('DiagnosticReport'), comparator_search_params)
+              validate_search_reply(versioned_resource_class('DiagnosticReport'), reply, comparator_search_params)
+            end
+
+            value_with_system = get_value_for_search_param(resolve_element_from_path(diagnostic_report, 'code') { |el| get_value_for_search_param(el).present? }, true)
+            token_with_system_search_params = search_params.merge('code': value_with_system)
+            reply = get_resource_by_params(versioned_resource_class('DiagnosticReport'), token_with_system_search_params)
+            validate_search_reply(versioned_resource_class('DiagnosticReport'), reply, token_with_system_search_params)
+
+            break if resolved_one
           end
-
-          value_with_system = get_value_for_search_param(resolve_element_from_path(@diagnostic_report_ary[patient], 'code') { |el| get_value_for_search_param(el).present? }, true)
-          token_with_system_search_params = search_params.merge('code': value_with_system)
-          reply = get_resource_by_params(versioned_resource_class('DiagnosticReport'), token_with_system_search_params)
-          validate_search_reply(versioned_resource_class('DiagnosticReport'), reply, token_with_system_search_params)
         end
 
         skip 'Could not resolve all parameters (patient, code, date) in any resource.' unless resolved_one

--- a/lib/modules/uscore_v3.1.1/us_core_diagnosticreport_note_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_diagnosticreport_note_sequence.rb
@@ -321,9 +321,7 @@ module Inferno
         patient_ids.each do |patient|
           next unless @diagnostic_report_ary[patient].present?
 
-          diagnostic_report_ary = Array.wrap(@diagnostic_report_ary[patient])
-
-          diagnostic_report_ary.each do |diagnostic_report|
+          Array.wrap(@diagnostic_report_ary[patient]).each do |diagnostic_report|
             search_params = {
               'patient': patient,
               'category': get_value_for_search_param(resolve_element_from_path(diagnostic_report, 'category') { |el| get_value_for_search_param(el).present? }),
@@ -472,9 +470,7 @@ module Inferno
         patient_ids.each do |patient|
           next unless @diagnostic_report_ary[patient].present?
 
-          diagnostic_report_ary = Array.wrap(@diagnostic_report_ary[patient])
-
-          diagnostic_report_ary.each do |diagnostic_report|
+          Array.wrap(@diagnostic_report_ary[patient]).each do |diagnostic_report|
             search_params = {
               'patient': patient,
               'code': get_value_for_search_param(resolve_element_from_path(diagnostic_report, 'code') { |el| get_value_for_search_param(el).present? }),

--- a/lib/modules/uscore_v3.1.1/us_core_diagnosticreport_note_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_diagnosticreport_note_sequence.rb
@@ -321,33 +321,39 @@ module Inferno
         patient_ids.each do |patient|
           next unless @diagnostic_report_ary[patient].present?
 
-          search_params = {
-            'patient': patient,
-            'category': get_value_for_search_param(resolve_element_from_path(@diagnostic_report_ary[patient], 'category') { |el| get_value_for_search_param(el).present? }),
-            'date': get_value_for_search_param(resolve_element_from_path(@diagnostic_report_ary[patient], 'effective') { |el| get_value_for_search_param(el).present? })
-          }
+          diagnostic_report_ary = Array.wrap(@diagnostic_report_ary[patient])
 
-          next if search_params.any? { |_param, value| value.nil? }
+          diagnostic_report_ary.each do |diagnostic_report|
+            search_params = {
+              'patient': patient,
+              'category': get_value_for_search_param(resolve_element_from_path(diagnostic_report, 'category') { |el| get_value_for_search_param(el).present? }),
+              'date': get_value_for_search_param(resolve_element_from_path(diagnostic_report, 'effective') { |el| get_value_for_search_param(el).present? })
+            }
 
-          resolved_one = true
+            next if search_params.any? { |_param, value| value.nil? }
 
-          reply = get_resource_by_params(versioned_resource_class('DiagnosticReport'), search_params)
+            resolved_one = true
 
-          reply = perform_search_with_status(reply, search_params, search_method: :get) if reply.code == 400
+            reply = get_resource_by_params(versioned_resource_class('DiagnosticReport'), search_params)
 
-          validate_search_reply(versioned_resource_class('DiagnosticReport'), reply, search_params)
+            reply = perform_search_with_status(reply, search_params, search_method: :get) if reply.code == 400
 
-          ['gt', 'ge', 'lt', 'le'].each do |comparator|
-            comparator_val = date_comparator_value(comparator, resolve_element_from_path(@diagnostic_report_ary[patient], 'effective') { |el| get_value_for_search_param(el).present? })
-            comparator_search_params = search_params.merge('date': comparator_val)
-            reply = get_resource_by_params(versioned_resource_class('DiagnosticReport'), comparator_search_params)
-            validate_search_reply(versioned_resource_class('DiagnosticReport'), reply, comparator_search_params)
+            validate_search_reply(versioned_resource_class('DiagnosticReport'), reply, search_params)
+
+            ['gt', 'ge', 'lt', 'le'].each do |comparator|
+              comparator_val = date_comparator_value(comparator, resolve_element_from_path(diagnostic_report, 'effective') { |el| get_value_for_search_param(el).present? })
+              comparator_search_params = search_params.merge('date': comparator_val)
+              reply = get_resource_by_params(versioned_resource_class('DiagnosticReport'), comparator_search_params)
+              validate_search_reply(versioned_resource_class('DiagnosticReport'), reply, comparator_search_params)
+            end
+
+            value_with_system = get_value_for_search_param(resolve_element_from_path(diagnostic_report, 'category') { |el| get_value_for_search_param(el).present? }, true)
+            token_with_system_search_params = search_params.merge('category': value_with_system)
+            reply = get_resource_by_params(versioned_resource_class('DiagnosticReport'), token_with_system_search_params)
+            validate_search_reply(versioned_resource_class('DiagnosticReport'), reply, token_with_system_search_params)
+
+            break if resolved_one
           end
-
-          value_with_system = get_value_for_search_param(resolve_element_from_path(@diagnostic_report_ary[patient], 'category') { |el| get_value_for_search_param(el).present? }, true)
-          token_with_system_search_params = search_params.merge('category': value_with_system)
-          reply = get_resource_by_params(versioned_resource_class('DiagnosticReport'), token_with_system_search_params)
-          validate_search_reply(versioned_resource_class('DiagnosticReport'), reply, token_with_system_search_params)
         end
 
         skip 'Could not resolve all parameters (patient, category, date) in any resource.' unless resolved_one
@@ -466,33 +472,39 @@ module Inferno
         patient_ids.each do |patient|
           next unless @diagnostic_report_ary[patient].present?
 
-          search_params = {
-            'patient': patient,
-            'code': get_value_for_search_param(resolve_element_from_path(@diagnostic_report_ary[patient], 'code') { |el| get_value_for_search_param(el).present? }),
-            'date': get_value_for_search_param(resolve_element_from_path(@diagnostic_report_ary[patient], 'effective') { |el| get_value_for_search_param(el).present? })
-          }
+          diagnostic_report_ary = Array.wrap(@diagnostic_report_ary[patient])
 
-          next if search_params.any? { |_param, value| value.nil? }
+          diagnostic_report_ary.each do |diagnostic_report|
+            search_params = {
+              'patient': patient,
+              'code': get_value_for_search_param(resolve_element_from_path(diagnostic_report, 'code') { |el| get_value_for_search_param(el).present? }),
+              'date': get_value_for_search_param(resolve_element_from_path(diagnostic_report, 'effective') { |el| get_value_for_search_param(el).present? })
+            }
 
-          resolved_one = true
+            next if search_params.any? { |_param, value| value.nil? }
 
-          reply = get_resource_by_params(versioned_resource_class('DiagnosticReport'), search_params)
+            resolved_one = true
 
-          reply = perform_search_with_status(reply, search_params, search_method: :get) if reply.code == 400
+            reply = get_resource_by_params(versioned_resource_class('DiagnosticReport'), search_params)
 
-          validate_search_reply(versioned_resource_class('DiagnosticReport'), reply, search_params)
+            reply = perform_search_with_status(reply, search_params, search_method: :get) if reply.code == 400
 
-          ['gt', 'ge', 'lt', 'le'].each do |comparator|
-            comparator_val = date_comparator_value(comparator, resolve_element_from_path(@diagnostic_report_ary[patient], 'effective') { |el| get_value_for_search_param(el).present? })
-            comparator_search_params = search_params.merge('date': comparator_val)
-            reply = get_resource_by_params(versioned_resource_class('DiagnosticReport'), comparator_search_params)
-            validate_search_reply(versioned_resource_class('DiagnosticReport'), reply, comparator_search_params)
+            validate_search_reply(versioned_resource_class('DiagnosticReport'), reply, search_params)
+
+            ['gt', 'ge', 'lt', 'le'].each do |comparator|
+              comparator_val = date_comparator_value(comparator, resolve_element_from_path(diagnostic_report, 'effective') { |el| get_value_for_search_param(el).present? })
+              comparator_search_params = search_params.merge('date': comparator_val)
+              reply = get_resource_by_params(versioned_resource_class('DiagnosticReport'), comparator_search_params)
+              validate_search_reply(versioned_resource_class('DiagnosticReport'), reply, comparator_search_params)
+            end
+
+            value_with_system = get_value_for_search_param(resolve_element_from_path(diagnostic_report, 'code') { |el| get_value_for_search_param(el).present? }, true)
+            token_with_system_search_params = search_params.merge('code': value_with_system)
+            reply = get_resource_by_params(versioned_resource_class('DiagnosticReport'), token_with_system_search_params)
+            validate_search_reply(versioned_resource_class('DiagnosticReport'), reply, token_with_system_search_params)
+
+            break if resolved_one
           end
-
-          value_with_system = get_value_for_search_param(resolve_element_from_path(@diagnostic_report_ary[patient], 'code') { |el| get_value_for_search_param(el).present? }, true)
-          token_with_system_search_params = search_params.merge('code': value_with_system)
-          reply = get_resource_by_params(versioned_resource_class('DiagnosticReport'), token_with_system_search_params)
-          validate_search_reply(versioned_resource_class('DiagnosticReport'), reply, token_with_system_search_params)
         end
 
         skip 'Could not resolve all parameters (patient, code, date) in any resource.' unless resolved_one

--- a/lib/modules/uscore_v3.1.1/us_core_documentreference_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_documentreference_sequence.rb
@@ -367,26 +367,32 @@ module Inferno
         patient_ids.each do |patient|
           next unless @document_reference_ary[patient].present?
 
-          search_params = {
-            'patient': patient,
-            'category': get_value_for_search_param(resolve_element_from_path(@document_reference_ary[patient], 'category') { |el| get_value_for_search_param(el).present? }),
-            'date': get_value_for_search_param(resolve_element_from_path(@document_reference_ary[patient], 'date') { |el| get_value_for_search_param(el).present? })
-          }
+          document_reference_ary = Array.wrap(@document_reference_ary[patient])
 
-          next if search_params.any? { |_param, value| value.nil? }
+          document_reference_ary.each do |document_reference|
+            search_params = {
+              'patient': patient,
+              'category': get_value_for_search_param(resolve_element_from_path(document_reference, 'category') { |el| get_value_for_search_param(el).present? }),
+              'date': get_value_for_search_param(resolve_element_from_path(document_reference, 'date') { |el| get_value_for_search_param(el).present? })
+            }
 
-          resolved_one = true
+            next if search_params.any? { |_param, value| value.nil? }
 
-          reply = get_resource_by_params(versioned_resource_class('DocumentReference'), search_params)
+            resolved_one = true
 
-          reply = perform_search_with_status(reply, search_params, search_method: :get) if reply.code == 400
+            reply = get_resource_by_params(versioned_resource_class('DocumentReference'), search_params)
 
-          validate_search_reply(versioned_resource_class('DocumentReference'), reply, search_params)
+            reply = perform_search_with_status(reply, search_params, search_method: :get) if reply.code == 400
 
-          value_with_system = get_value_for_search_param(resolve_element_from_path(@document_reference_ary[patient], 'category') { |el| get_value_for_search_param(el).present? }, true)
-          token_with_system_search_params = search_params.merge('category': value_with_system)
-          reply = get_resource_by_params(versioned_resource_class('DocumentReference'), token_with_system_search_params)
-          validate_search_reply(versioned_resource_class('DocumentReference'), reply, token_with_system_search_params)
+            validate_search_reply(versioned_resource_class('DocumentReference'), reply, search_params)
+
+            value_with_system = get_value_for_search_param(resolve_element_from_path(document_reference, 'category') { |el| get_value_for_search_param(el).present? }, true)
+            token_with_system_search_params = search_params.merge('category': value_with_system)
+            reply = get_resource_by_params(versioned_resource_class('DocumentReference'), token_with_system_search_params)
+            validate_search_reply(versioned_resource_class('DocumentReference'), reply, token_with_system_search_params)
+
+            break if resolved_one
+          end
         end
 
         skip 'Could not resolve all parameters (patient, category, date) in any resource.' unless resolved_one
@@ -465,33 +471,39 @@ module Inferno
         patient_ids.each do |patient|
           next unless @document_reference_ary[patient].present?
 
-          search_params = {
-            'patient': patient,
-            'type': get_value_for_search_param(resolve_element_from_path(@document_reference_ary[patient], 'type') { |el| get_value_for_search_param(el).present? }),
-            'period': get_value_for_search_param(resolve_element_from_path(@document_reference_ary[patient], 'context.period') { |el| get_value_for_search_param(el).present? })
-          }
+          document_reference_ary = Array.wrap(@document_reference_ary[patient])
 
-          next if search_params.any? { |_param, value| value.nil? }
+          document_reference_ary.each do |document_reference|
+            search_params = {
+              'patient': patient,
+              'type': get_value_for_search_param(resolve_element_from_path(document_reference, 'type') { |el| get_value_for_search_param(el).present? }),
+              'period': get_value_for_search_param(resolve_element_from_path(document_reference, 'context.period') { |el| get_value_for_search_param(el).present? })
+            }
 
-          resolved_one = true
+            next if search_params.any? { |_param, value| value.nil? }
 
-          reply = get_resource_by_params(versioned_resource_class('DocumentReference'), search_params)
+            resolved_one = true
 
-          reply = perform_search_with_status(reply, search_params, search_method: :get) if reply.code == 400
+            reply = get_resource_by_params(versioned_resource_class('DocumentReference'), search_params)
 
-          validate_search_reply(versioned_resource_class('DocumentReference'), reply, search_params)
+            reply = perform_search_with_status(reply, search_params, search_method: :get) if reply.code == 400
 
-          ['gt', 'ge', 'lt', 'le'].each do |comparator|
-            comparator_val = date_comparator_value(comparator, resolve_element_from_path(@document_reference_ary[patient], 'context.period') { |el| get_value_for_search_param(el).present? })
-            comparator_search_params = search_params.merge('period': comparator_val)
-            reply = get_resource_by_params(versioned_resource_class('DocumentReference'), comparator_search_params)
-            validate_search_reply(versioned_resource_class('DocumentReference'), reply, comparator_search_params)
+            validate_search_reply(versioned_resource_class('DocumentReference'), reply, search_params)
+
+            ['gt', 'ge', 'lt', 'le'].each do |comparator|
+              comparator_val = date_comparator_value(comparator, resolve_element_from_path(document_reference, 'context.period') { |el| get_value_for_search_param(el).present? })
+              comparator_search_params = search_params.merge('period': comparator_val)
+              reply = get_resource_by_params(versioned_resource_class('DocumentReference'), comparator_search_params)
+              validate_search_reply(versioned_resource_class('DocumentReference'), reply, comparator_search_params)
+            end
+
+            value_with_system = get_value_for_search_param(resolve_element_from_path(document_reference, 'type') { |el| get_value_for_search_param(el).present? }, true)
+            token_with_system_search_params = search_params.merge('type': value_with_system)
+            reply = get_resource_by_params(versioned_resource_class('DocumentReference'), token_with_system_search_params)
+            validate_search_reply(versioned_resource_class('DocumentReference'), reply, token_with_system_search_params)
+
+            break if resolved_one
           end
-
-          value_with_system = get_value_for_search_param(resolve_element_from_path(@document_reference_ary[patient], 'type') { |el| get_value_for_search_param(el).present? }, true)
-          token_with_system_search_params = search_params.merge('type': value_with_system)
-          reply = get_resource_by_params(versioned_resource_class('DocumentReference'), token_with_system_search_params)
-          validate_search_reply(versioned_resource_class('DocumentReference'), reply, token_with_system_search_params)
         end
 
         skip 'Could not resolve all parameters (patient, type, period) in any resource.' unless resolved_one

--- a/lib/modules/uscore_v3.1.1/us_core_documentreference_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_documentreference_sequence.rb
@@ -367,9 +367,7 @@ module Inferno
         patient_ids.each do |patient|
           next unless @document_reference_ary[patient].present?
 
-          document_reference_ary = Array.wrap(@document_reference_ary[patient])
-
-          document_reference_ary.each do |document_reference|
+          Array.wrap(@document_reference_ary[patient]).each do |document_reference|
             search_params = {
               'patient': patient,
               'category': get_value_for_search_param(resolve_element_from_path(document_reference, 'category') { |el| get_value_for_search_param(el).present? }),
@@ -471,9 +469,7 @@ module Inferno
         patient_ids.each do |patient|
           next unless @document_reference_ary[patient].present?
 
-          document_reference_ary = Array.wrap(@document_reference_ary[patient])
-
-          document_reference_ary.each do |document_reference|
+          Array.wrap(@document_reference_ary[patient]).each do |document_reference|
             search_params = {
               'patient': patient,
               'type': get_value_for_search_param(resolve_element_from_path(document_reference, 'type') { |el| get_value_for_search_param(el).present? }),

--- a/lib/modules/uscore_v3.1.1/us_core_medicationrequest_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_medicationrequest_sequence.rb
@@ -303,9 +303,7 @@ module Inferno
         patient_ids.each do |patient|
           next unless @medication_request_ary[patient].present?
 
-          medication_request_ary = Array.wrap(@medication_request_ary[patient])
-
-          medication_request_ary.each do |medication_request|
+          Array.wrap(@medication_request_ary[patient]).each do |medication_request|
             search_params = {
               'patient': patient,
               'intent': get_value_for_search_param(resolve_element_from_path(medication_request, 'intent') { |el| get_value_for_search_param(el).present? }),
@@ -360,9 +358,7 @@ module Inferno
         patient_ids.each do |patient|
           next unless @medication_request_ary[patient].present?
 
-          medication_request_ary = Array.wrap(@medication_request_ary[patient])
-
-          medication_request_ary.each do |medication_request|
+          Array.wrap(@medication_request_ary[patient]).each do |medication_request|
             search_params = {
               'patient': patient,
               'intent': get_value_for_search_param(resolve_element_from_path(medication_request, 'intent') { |el| get_value_for_search_param(el).present? }),
@@ -423,9 +419,7 @@ module Inferno
         patient_ids.each do |patient|
           next unless @medication_request_ary[patient].present?
 
-          medication_request_ary = Array.wrap(@medication_request_ary[patient])
-
-          medication_request_ary.each do |medication_request|
+          Array.wrap(@medication_request_ary[patient]).each do |medication_request|
             search_params = {
               'patient': patient,
               'intent': get_value_for_search_param(resolve_element_from_path(medication_request, 'intent') { |el| get_value_for_search_param(el).present? }),
@@ -745,8 +739,7 @@ module Inferno
         patient_ids.each do |patient|
           next unless @medication_request_ary[patient].present?
 
-          medication_request_ary = Array.wrap(@medication_request_ary[patient])
-          medication_request_ary.each do |medication_request|
+          Array.wrap(@medication_request_ary[patient]).each do |medication_request|
             search_params = {
               'patient': patient,
               'intent': get_value_for_search_param(resolve_element_from_path(medication_request, 'intent') { |el| get_value_for_search_param(el).present? }),

--- a/lib/modules/uscore_v3.1.1/us_core_medicationrequest_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_medicationrequest_sequence.rb
@@ -303,25 +303,31 @@ module Inferno
         patient_ids.each do |patient|
           next unless @medication_request_ary[patient].present?
 
-          search_params = {
-            'patient': patient,
-            'intent': get_value_for_search_param(resolve_element_from_path(@medication_request_ary[patient], 'intent') { |el| get_value_for_search_param(el).present? }),
-            'status': get_value_for_search_param(resolve_element_from_path(@medication_request_ary[patient], 'status') { |el| get_value_for_search_param(el).present? })
-          }
+          medication_request_ary = Array.wrap(@medication_request_ary[patient])
 
-          next if search_params.any? { |_param, value| value.nil? }
+          medication_request_ary.each do |medication_request|
+            search_params = {
+              'patient': patient,
+              'intent': get_value_for_search_param(resolve_element_from_path(medication_request, 'intent') { |el| get_value_for_search_param(el).present? }),
+              'status': get_value_for_search_param(resolve_element_from_path(medication_request, 'status') { |el| get_value_for_search_param(el).present? })
+            }
 
-          resolved_one = true
+            next if search_params.any? { |_param, value| value.nil? }
 
-          reply = get_resource_by_params(versioned_resource_class('MedicationRequest'), search_params)
+            resolved_one = true
 
-          validate_search_reply(versioned_resource_class('MedicationRequest'), reply, search_params)
+            reply = get_resource_by_params(versioned_resource_class('MedicationRequest'), search_params)
 
-          resources_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
-          assert(resources_returned.all? { |resource| ['MedicationRequest', 'OperationOutcome'].include? resource.resourceType },
-                 'All resources returned must be of the type MedicationRequest or OperationOutcome')
-          resources_returned.reject! { |resource| resource.resourceType == 'OperationOutcome' }
-          test_medication_inclusion(resources_returned, search_params)
+            validate_search_reply(versioned_resource_class('MedicationRequest'), reply, search_params)
+
+            resources_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
+            assert(resources_returned.all? { |resource| ['MedicationRequest', 'OperationOutcome'].include? resource.resourceType },
+                   'All resources returned must be of the type MedicationRequest or OperationOutcome')
+            resources_returned.reject! { |resource| resource.resourceType == 'OperationOutcome' }
+            test_medication_inclusion(resources_returned, search_params)
+
+            break if resolved_one
+          end
         end
 
         skip 'Could not resolve all parameters (patient, intent, status) in any resource.' unless resolved_one
@@ -354,27 +360,33 @@ module Inferno
         patient_ids.each do |patient|
           next unless @medication_request_ary[patient].present?
 
-          search_params = {
-            'patient': patient,
-            'intent': get_value_for_search_param(resolve_element_from_path(@medication_request_ary[patient], 'intent') { |el| get_value_for_search_param(el).present? }),
-            'encounter': get_value_for_search_param(resolve_element_from_path(@medication_request_ary[patient], 'encounter') { |el| get_value_for_search_param(el).present? })
-          }
+          medication_request_ary = Array.wrap(@medication_request_ary[patient])
 
-          next if search_params.any? { |_param, value| value.nil? }
+          medication_request_ary.each do |medication_request|
+            search_params = {
+              'patient': patient,
+              'intent': get_value_for_search_param(resolve_element_from_path(medication_request, 'intent') { |el| get_value_for_search_param(el).present? }),
+              'encounter': get_value_for_search_param(resolve_element_from_path(medication_request, 'encounter') { |el| get_value_for_search_param(el).present? })
+            }
 
-          resolved_one = true
+            next if search_params.any? { |_param, value| value.nil? }
 
-          reply = get_resource_by_params(versioned_resource_class('MedicationRequest'), search_params)
+            resolved_one = true
 
-          reply = perform_search_with_status(reply, search_params, search_method: :get) if reply.code == 400
+            reply = get_resource_by_params(versioned_resource_class('MedicationRequest'), search_params)
 
-          validate_search_reply(versioned_resource_class('MedicationRequest'), reply, search_params)
+            reply = perform_search_with_status(reply, search_params, search_method: :get) if reply.code == 400
 
-          resources_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
-          assert(resources_returned.all? { |resource| ['MedicationRequest', 'OperationOutcome'].include? resource.resourceType },
-                 'All resources returned must be of the type MedicationRequest or OperationOutcome')
-          resources_returned.reject! { |resource| resource.resourceType == 'OperationOutcome' }
-          test_medication_inclusion(resources_returned, search_params)
+            validate_search_reply(versioned_resource_class('MedicationRequest'), reply, search_params)
+
+            resources_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
+            assert(resources_returned.all? { |resource| ['MedicationRequest', 'OperationOutcome'].include? resource.resourceType },
+                   'All resources returned must be of the type MedicationRequest or OperationOutcome')
+            resources_returned.reject! { |resource| resource.resourceType == 'OperationOutcome' }
+            test_medication_inclusion(resources_returned, search_params)
+
+            break if resolved_one
+          end
         end
 
         skip 'Could not resolve all parameters (patient, intent, encounter) in any resource.' unless resolved_one
@@ -411,27 +423,33 @@ module Inferno
         patient_ids.each do |patient|
           next unless @medication_request_ary[patient].present?
 
-          search_params = {
-            'patient': patient,
-            'intent': get_value_for_search_param(resolve_element_from_path(@medication_request_ary[patient], 'intent') { |el| get_value_for_search_param(el).present? }),
-            'authoredon': get_value_for_search_param(resolve_element_from_path(@medication_request_ary[patient], 'authoredOn') { |el| get_value_for_search_param(el).present? })
-          }
+          medication_request_ary = Array.wrap(@medication_request_ary[patient])
 
-          next if search_params.any? { |_param, value| value.nil? }
+          medication_request_ary.each do |medication_request|
+            search_params = {
+              'patient': patient,
+              'intent': get_value_for_search_param(resolve_element_from_path(medication_request, 'intent') { |el| get_value_for_search_param(el).present? }),
+              'authoredon': get_value_for_search_param(resolve_element_from_path(medication_request, 'authoredOn') { |el| get_value_for_search_param(el).present? })
+            }
 
-          resolved_one = true
+            next if search_params.any? { |_param, value| value.nil? }
 
-          reply = get_resource_by_params(versioned_resource_class('MedicationRequest'), search_params)
+            resolved_one = true
 
-          reply = perform_search_with_status(reply, search_params, search_method: :get) if reply.code == 400
+            reply = get_resource_by_params(versioned_resource_class('MedicationRequest'), search_params)
 
-          validate_search_reply(versioned_resource_class('MedicationRequest'), reply, search_params)
+            reply = perform_search_with_status(reply, search_params, search_method: :get) if reply.code == 400
 
-          resources_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
-          assert(resources_returned.all? { |resource| ['MedicationRequest', 'OperationOutcome'].include? resource.resourceType },
-                 'All resources returned must be of the type MedicationRequest or OperationOutcome')
-          resources_returned.reject! { |resource| resource.resourceType == 'OperationOutcome' }
-          test_medication_inclusion(resources_returned, search_params)
+            validate_search_reply(versioned_resource_class('MedicationRequest'), reply, search_params)
+
+            resources_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
+            assert(resources_returned.all? { |resource| ['MedicationRequest', 'OperationOutcome'].include? resource.resourceType },
+                   'All resources returned must be of the type MedicationRequest or OperationOutcome')
+            resources_returned.reject! { |resource| resource.resourceType == 'OperationOutcome' }
+            test_medication_inclusion(resources_returned, search_params)
+
+            break if resolved_one
+          end
         end
 
         skip 'Could not resolve all parameters (patient, intent, authoredon) in any resource.' unless resolved_one
@@ -727,29 +745,34 @@ module Inferno
         patient_ids.each do |patient|
           next unless @medication_request_ary[patient].present?
 
-          search_params = {
-            'patient': patient,
-            'intent': get_value_for_search_param(resolve_element_from_path(@medication_request_ary[patient], 'intent') { |el| get_value_for_search_param(el).present? }),
-            'status': get_value_for_search_param(resolve_element_from_path(@medication_request_ary[patient], 'status') { |el| get_value_for_search_param(el).present? })
-          }
+          medication_request_ary = Array.wrap(@medication_request_ary[patient])
+          medication_request_ary.each do |medication_request|
+            search_params = {
+              'patient': patient,
+              'intent': get_value_for_search_param(resolve_element_from_path(medication_request, 'intent') { |el| get_value_for_search_param(el).present? }),
+              'status': get_value_for_search_param(resolve_element_from_path(medication_request, 'status') { |el| get_value_for_search_param(el).present? })
+            }
 
-          next if search_params.any? { |_param, value| value.nil? }
+            next if search_params.any? { |_param, value| value.nil? }
 
-          resolved_one = true
+            resolved_one = true
 
-          second_status_val = resolve_element_from_path(@medication_request_ary[patient], 'status') { |el| get_value_for_search_param(el) != search_params[:status] }
-          next if second_status_val.nil?
+            second_status_val = resolve_element_from_path(@medication_request_ary[patient], 'status') { |el| get_value_for_search_param(el) != search_params[:status] }
+            next if second_status_val.nil?
 
-          found_second_val = true
-          search_params[:status] += ',' + get_value_for_search_param(second_status_val)
-          reply = get_resource_by_params(versioned_resource_class('MedicationRequest'), search_params)
-          validate_search_reply(versioned_resource_class('MedicationRequest'), reply, search_params)
-          assert_response_ok(reply)
-          resources_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
-          missing_values = search_params[:status].split(',').reject do |val|
-            resolve_element_from_path(resources_returned, 'status') { |val_found| val_found == val }
+            found_second_val = true
+            search_params[:status] += ',' + get_value_for_search_param(second_status_val)
+            reply = get_resource_by_params(versioned_resource_class('MedicationRequest'), search_params)
+            validate_search_reply(versioned_resource_class('MedicationRequest'), reply, search_params)
+            assert_response_ok(reply)
+            resources_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
+            missing_values = search_params[:status].split(',').reject do |val|
+              resolve_element_from_path(resources_returned, 'status') { |val_found| val_found == val }
+            end
+            assert missing_values.blank?, "Could not find #{missing_values.join(',')} values from status in any of the resources returned"
+
+            break if resolved_one
           end
-          assert missing_values.blank?, "Could not find #{missing_values.join(',')} values from status in any of the resources returned"
         end
         skip 'Cannot find second value for status to perform a multipleOr search' unless found_second_val
 
@@ -759,6 +782,8 @@ module Inferno
 
         found_second_val = false
         patient_ids.each do |patient|
+          next unless @medication_request_ary[patient].present?
+
           search_params = {
             'patient': patient,
             'intent': get_value_for_search_param(resolve_element_from_path(@medication_request_ary[patient], 'intent') { |el| get_value_for_search_param(el).present? })

--- a/lib/modules/uscore_v3.1.1/us_core_observation_lab_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_observation_lab_sequence.rb
@@ -332,33 +332,39 @@ module Inferno
         patient_ids.each do |patient|
           next unless @observation_ary[patient].present?
 
-          search_params = {
-            'patient': patient,
-            'category': get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category') { |el| get_value_for_search_param(el).present? }),
-            'date': get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'effective') { |el| get_value_for_search_param(el).present? })
-          }
+          observation_ary = Array.wrap(@observation_ary[patient])
 
-          next if search_params.any? { |_param, value| value.nil? }
+          observation_ary.each do |observation|
+            search_params = {
+              'patient': patient,
+              'category': get_value_for_search_param(resolve_element_from_path(observation, 'category') { |el| get_value_for_search_param(el).present? }),
+              'date': get_value_for_search_param(resolve_element_from_path(observation, 'effective') { |el| get_value_for_search_param(el).present? })
+            }
 
-          resolved_one = true
+            next if search_params.any? { |_param, value| value.nil? }
 
-          reply = get_resource_by_params(versioned_resource_class('Observation'), search_params)
+            resolved_one = true
 
-          reply = perform_search_with_status(reply, search_params, search_method: :get) if reply.code == 400
+            reply = get_resource_by_params(versioned_resource_class('Observation'), search_params)
 
-          validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
+            reply = perform_search_with_status(reply, search_params, search_method: :get) if reply.code == 400
 
-          ['gt', 'ge', 'lt', 'le'].each do |comparator|
-            comparator_val = date_comparator_value(comparator, resolve_element_from_path(@observation_ary[patient], 'effective') { |el| get_value_for_search_param(el).present? })
-            comparator_search_params = search_params.merge('date': comparator_val)
-            reply = get_resource_by_params(versioned_resource_class('Observation'), comparator_search_params)
-            validate_search_reply(versioned_resource_class('Observation'), reply, comparator_search_params)
+            validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
+
+            ['gt', 'ge', 'lt', 'le'].each do |comparator|
+              comparator_val = date_comparator_value(comparator, resolve_element_from_path(observation, 'effective') { |el| get_value_for_search_param(el).present? })
+              comparator_search_params = search_params.merge('date': comparator_val)
+              reply = get_resource_by_params(versioned_resource_class('Observation'), comparator_search_params)
+              validate_search_reply(versioned_resource_class('Observation'), reply, comparator_search_params)
+            end
+
+            value_with_system = get_value_for_search_param(resolve_element_from_path(observation, 'category') { |el| get_value_for_search_param(el).present? }, true)
+            token_with_system_search_params = search_params.merge('category': value_with_system)
+            reply = get_resource_by_params(versioned_resource_class('Observation'), token_with_system_search_params)
+            validate_search_reply(versioned_resource_class('Observation'), reply, token_with_system_search_params)
+
+            break if resolved_one
           end
-
-          value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category') { |el| get_value_for_search_param(el).present? }, true)
-          token_with_system_search_params = search_params.merge('category': value_with_system)
-          reply = get_resource_by_params(versioned_resource_class('Observation'), token_with_system_search_params)
-          validate_search_reply(versioned_resource_class('Observation'), reply, token_with_system_search_params)
         end
 
         skip 'Could not resolve all parameters (patient, category, date) in any resource.' unless resolved_one
@@ -387,24 +393,30 @@ module Inferno
         patient_ids.each do |patient|
           next unless @observation_ary[patient].present?
 
-          search_params = {
-            'patient': patient,
-            'category': get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category') { |el| get_value_for_search_param(el).present? }),
-            'status': get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'status') { |el| get_value_for_search_param(el).present? })
-          }
+          observation_ary = Array.wrap(@observation_ary[patient])
 
-          next if search_params.any? { |_param, value| value.nil? }
+          observation_ary.each do |observation|
+            search_params = {
+              'patient': patient,
+              'category': get_value_for_search_param(resolve_element_from_path(observation, 'category') { |el| get_value_for_search_param(el).present? }),
+              'status': get_value_for_search_param(resolve_element_from_path(observation, 'status') { |el| get_value_for_search_param(el).present? })
+            }
 
-          resolved_one = true
+            next if search_params.any? { |_param, value| value.nil? }
 
-          reply = get_resource_by_params(versioned_resource_class('Observation'), search_params)
+            resolved_one = true
 
-          validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
+            reply = get_resource_by_params(versioned_resource_class('Observation'), search_params)
 
-          value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category') { |el| get_value_for_search_param(el).present? }, true)
-          token_with_system_search_params = search_params.merge('category': value_with_system)
-          reply = get_resource_by_params(versioned_resource_class('Observation'), token_with_system_search_params)
-          validate_search_reply(versioned_resource_class('Observation'), reply, token_with_system_search_params)
+            validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
+
+            value_with_system = get_value_for_search_param(resolve_element_from_path(observation, 'category') { |el| get_value_for_search_param(el).present? }, true)
+            token_with_system_search_params = search_params.merge('category': value_with_system)
+            reply = get_resource_by_params(versioned_resource_class('Observation'), token_with_system_search_params)
+            validate_search_reply(versioned_resource_class('Observation'), reply, token_with_system_search_params)
+
+            break if resolved_one
+          end
         end
 
         skip 'Could not resolve all parameters (patient, category, status) in any resource.' unless resolved_one
@@ -437,33 +449,39 @@ module Inferno
         patient_ids.each do |patient|
           next unless @observation_ary[patient].present?
 
-          search_params = {
-            'patient': patient,
-            'code': get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'code') { |el| get_value_for_search_param(el).present? }),
-            'date': get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'effective') { |el| get_value_for_search_param(el).present? })
-          }
+          observation_ary = Array.wrap(@observation_ary[patient])
 
-          next if search_params.any? { |_param, value| value.nil? }
+          observation_ary.each do |observation|
+            search_params = {
+              'patient': patient,
+              'code': get_value_for_search_param(resolve_element_from_path(observation, 'code') { |el| get_value_for_search_param(el).present? }),
+              'date': get_value_for_search_param(resolve_element_from_path(observation, 'effective') { |el| get_value_for_search_param(el).present? })
+            }
 
-          resolved_one = true
+            next if search_params.any? { |_param, value| value.nil? }
 
-          reply = get_resource_by_params(versioned_resource_class('Observation'), search_params)
+            resolved_one = true
 
-          reply = perform_search_with_status(reply, search_params, search_method: :get) if reply.code == 400
+            reply = get_resource_by_params(versioned_resource_class('Observation'), search_params)
 
-          validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
+            reply = perform_search_with_status(reply, search_params, search_method: :get) if reply.code == 400
 
-          ['gt', 'ge', 'lt', 'le'].each do |comparator|
-            comparator_val = date_comparator_value(comparator, resolve_element_from_path(@observation_ary[patient], 'effective') { |el| get_value_for_search_param(el).present? })
-            comparator_search_params = search_params.merge('date': comparator_val)
-            reply = get_resource_by_params(versioned_resource_class('Observation'), comparator_search_params)
-            validate_search_reply(versioned_resource_class('Observation'), reply, comparator_search_params)
+            validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
+
+            ['gt', 'ge', 'lt', 'le'].each do |comparator|
+              comparator_val = date_comparator_value(comparator, resolve_element_from_path(observation, 'effective') { |el| get_value_for_search_param(el).present? })
+              comparator_search_params = search_params.merge('date': comparator_val)
+              reply = get_resource_by_params(versioned_resource_class('Observation'), comparator_search_params)
+              validate_search_reply(versioned_resource_class('Observation'), reply, comparator_search_params)
+            end
+
+            value_with_system = get_value_for_search_param(resolve_element_from_path(observation, 'code') { |el| get_value_for_search_param(el).present? }, true)
+            token_with_system_search_params = search_params.merge('code': value_with_system)
+            reply = get_resource_by_params(versioned_resource_class('Observation'), token_with_system_search_params)
+            validate_search_reply(versioned_resource_class('Observation'), reply, token_with_system_search_params)
+
+            break if resolved_one
           end
-
-          value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'code') { |el| get_value_for_search_param(el).present? }, true)
-          token_with_system_search_params = search_params.merge('code': value_with_system)
-          reply = get_resource_by_params(versioned_resource_class('Observation'), token_with_system_search_params)
-          validate_search_reply(versioned_resource_class('Observation'), reply, token_with_system_search_params)
         end
 
         skip 'Could not resolve all parameters (patient, code, date) in any resource.' unless resolved_one

--- a/lib/modules/uscore_v3.1.1/us_core_observation_lab_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_observation_lab_sequence.rb
@@ -332,9 +332,7 @@ module Inferno
         patient_ids.each do |patient|
           next unless @observation_ary[patient].present?
 
-          observation_ary = Array.wrap(@observation_ary[patient])
-
-          observation_ary.each do |observation|
+          Array.wrap(@observation_ary[patient]).each do |observation|
             search_params = {
               'patient': patient,
               'category': get_value_for_search_param(resolve_element_from_path(observation, 'category') { |el| get_value_for_search_param(el).present? }),
@@ -393,9 +391,7 @@ module Inferno
         patient_ids.each do |patient|
           next unless @observation_ary[patient].present?
 
-          observation_ary = Array.wrap(@observation_ary[patient])
-
-          observation_ary.each do |observation|
+          Array.wrap(@observation_ary[patient]).each do |observation|
             search_params = {
               'patient': patient,
               'category': get_value_for_search_param(resolve_element_from_path(observation, 'category') { |el| get_value_for_search_param(el).present? }),
@@ -449,9 +445,7 @@ module Inferno
         patient_ids.each do |patient|
           next unless @observation_ary[patient].present?
 
-          observation_ary = Array.wrap(@observation_ary[patient])
-
-          observation_ary.each do |observation|
+          Array.wrap(@observation_ary[patient]).each do |observation|
             search_params = {
               'patient': patient,
               'code': get_value_for_search_param(resolve_element_from_path(observation, 'code') { |el| get_value_for_search_param(el).present? }),

--- a/lib/modules/uscore_v3.1.1/us_core_procedure_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_procedure_sequence.rb
@@ -348,9 +348,7 @@ module Inferno
         patient_ids.each do |patient|
           next unless @procedure_ary[patient].present?
 
-          procedure_ary = Array.wrap(@procedure_ary[patient])
-
-          procedure_ary.each do |procedure|
+          Array.wrap(@procedure_ary[patient]).each do |procedure|
             search_params = {
               'patient': patient,
               'code': get_value_for_search_param(resolve_element_from_path(procedure, 'code') { |el| get_value_for_search_param(el).present? }),

--- a/lib/modules/uscore_v3.1.1/us_core_pulse_oximetry_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_pulse_oximetry_sequence.rb
@@ -286,33 +286,39 @@ module Inferno
         patient_ids.each do |patient|
           next unless @observation_ary[patient].present?
 
-          search_params = {
-            'patient': patient,
-            'category': get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category') { |el| get_value_for_search_param(el).present? }),
-            'date': get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'effective') { |el| get_value_for_search_param(el).present? })
-          }
+          observation_ary = Array.wrap(@observation_ary[patient])
 
-          next if search_params.any? { |_param, value| value.nil? }
+          observation_ary.each do |observation|
+            search_params = {
+              'patient': patient,
+              'category': get_value_for_search_param(resolve_element_from_path(observation, 'category') { |el| get_value_for_search_param(el).present? }),
+              'date': get_value_for_search_param(resolve_element_from_path(observation, 'effective') { |el| get_value_for_search_param(el).present? })
+            }
 
-          resolved_one = true
+            next if search_params.any? { |_param, value| value.nil? }
 
-          reply = get_resource_by_params(versioned_resource_class('Observation'), search_params)
+            resolved_one = true
 
-          reply = perform_search_with_status(reply, search_params, search_method: :get) if reply.code == 400
+            reply = get_resource_by_params(versioned_resource_class('Observation'), search_params)
 
-          validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
+            reply = perform_search_with_status(reply, search_params, search_method: :get) if reply.code == 400
 
-          ['gt', 'ge', 'lt', 'le'].each do |comparator|
-            comparator_val = date_comparator_value(comparator, resolve_element_from_path(@observation_ary[patient], 'effective') { |el| get_value_for_search_param(el).present? })
-            comparator_search_params = search_params.merge('date': comparator_val)
-            reply = get_resource_by_params(versioned_resource_class('Observation'), comparator_search_params)
-            validate_search_reply(versioned_resource_class('Observation'), reply, comparator_search_params)
+            validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
+
+            ['gt', 'ge', 'lt', 'le'].each do |comparator|
+              comparator_val = date_comparator_value(comparator, resolve_element_from_path(observation, 'effective') { |el| get_value_for_search_param(el).present? })
+              comparator_search_params = search_params.merge('date': comparator_val)
+              reply = get_resource_by_params(versioned_resource_class('Observation'), comparator_search_params)
+              validate_search_reply(versioned_resource_class('Observation'), reply, comparator_search_params)
+            end
+
+            value_with_system = get_value_for_search_param(resolve_element_from_path(observation, 'category') { |el| get_value_for_search_param(el).present? }, true)
+            token_with_system_search_params = search_params.merge('category': value_with_system)
+            reply = get_resource_by_params(versioned_resource_class('Observation'), token_with_system_search_params)
+            validate_search_reply(versioned_resource_class('Observation'), reply, token_with_system_search_params)
+
+            break if resolved_one
           end
-
-          value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category') { |el| get_value_for_search_param(el).present? }, true)
-          token_with_system_search_params = search_params.merge('category': value_with_system)
-          reply = get_resource_by_params(versioned_resource_class('Observation'), token_with_system_search_params)
-          validate_search_reply(versioned_resource_class('Observation'), reply, token_with_system_search_params)
         end
 
         skip 'Could not resolve all parameters (patient, category, date) in any resource.' unless resolved_one
@@ -387,24 +393,30 @@ module Inferno
         patient_ids.each do |patient|
           next unless @observation_ary[patient].present?
 
-          search_params = {
-            'patient': patient,
-            'category': get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category') { |el| get_value_for_search_param(el).present? }),
-            'status': get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'status') { |el| get_value_for_search_param(el).present? })
-          }
+          observation_ary = Array.wrap(@observation_ary[patient])
 
-          next if search_params.any? { |_param, value| value.nil? }
+          observation_ary.each do |observation|
+            search_params = {
+              'patient': patient,
+              'category': get_value_for_search_param(resolve_element_from_path(observation, 'category') { |el| get_value_for_search_param(el).present? }),
+              'status': get_value_for_search_param(resolve_element_from_path(observation, 'status') { |el| get_value_for_search_param(el).present? })
+            }
 
-          resolved_one = true
+            next if search_params.any? { |_param, value| value.nil? }
 
-          reply = get_resource_by_params(versioned_resource_class('Observation'), search_params)
+            resolved_one = true
 
-          validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
+            reply = get_resource_by_params(versioned_resource_class('Observation'), search_params)
 
-          value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'category') { |el| get_value_for_search_param(el).present? }, true)
-          token_with_system_search_params = search_params.merge('category': value_with_system)
-          reply = get_resource_by_params(versioned_resource_class('Observation'), token_with_system_search_params)
-          validate_search_reply(versioned_resource_class('Observation'), reply, token_with_system_search_params)
+            validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
+
+            value_with_system = get_value_for_search_param(resolve_element_from_path(observation, 'category') { |el| get_value_for_search_param(el).present? }, true)
+            token_with_system_search_params = search_params.merge('category': value_with_system)
+            reply = get_resource_by_params(versioned_resource_class('Observation'), token_with_system_search_params)
+            validate_search_reply(versioned_resource_class('Observation'), reply, token_with_system_search_params)
+
+            break if resolved_one
+          end
         end
 
         skip 'Could not resolve all parameters (patient, category, status) in any resource.' unless resolved_one
@@ -437,33 +449,39 @@ module Inferno
         patient_ids.each do |patient|
           next unless @observation_ary[patient].present?
 
-          search_params = {
-            'patient': patient,
-            'code': get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'code') { |el| get_value_for_search_param(el).present? }),
-            'date': get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'effective') { |el| get_value_for_search_param(el).present? })
-          }
+          observation_ary = Array.wrap(@observation_ary[patient])
 
-          next if search_params.any? { |_param, value| value.nil? }
+          observation_ary.each do |observation|
+            search_params = {
+              'patient': patient,
+              'code': get_value_for_search_param(resolve_element_from_path(observation, 'code') { |el| get_value_for_search_param(el).present? }),
+              'date': get_value_for_search_param(resolve_element_from_path(observation, 'effective') { |el| get_value_for_search_param(el).present? })
+            }
 
-          resolved_one = true
+            next if search_params.any? { |_param, value| value.nil? }
 
-          reply = get_resource_by_params(versioned_resource_class('Observation'), search_params)
+            resolved_one = true
 
-          reply = perform_search_with_status(reply, search_params, search_method: :get) if reply.code == 400
+            reply = get_resource_by_params(versioned_resource_class('Observation'), search_params)
 
-          validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
+            reply = perform_search_with_status(reply, search_params, search_method: :get) if reply.code == 400
 
-          ['gt', 'ge', 'lt', 'le'].each do |comparator|
-            comparator_val = date_comparator_value(comparator, resolve_element_from_path(@observation_ary[patient], 'effective') { |el| get_value_for_search_param(el).present? })
-            comparator_search_params = search_params.merge('date': comparator_val)
-            reply = get_resource_by_params(versioned_resource_class('Observation'), comparator_search_params)
-            validate_search_reply(versioned_resource_class('Observation'), reply, comparator_search_params)
+            validate_search_reply(versioned_resource_class('Observation'), reply, search_params)
+
+            ['gt', 'ge', 'lt', 'le'].each do |comparator|
+              comparator_val = date_comparator_value(comparator, resolve_element_from_path(observation, 'effective') { |el| get_value_for_search_param(el).present? })
+              comparator_search_params = search_params.merge('date': comparator_val)
+              reply = get_resource_by_params(versioned_resource_class('Observation'), comparator_search_params)
+              validate_search_reply(versioned_resource_class('Observation'), reply, comparator_search_params)
+            end
+
+            value_with_system = get_value_for_search_param(resolve_element_from_path(observation, 'code') { |el| get_value_for_search_param(el).present? }, true)
+            token_with_system_search_params = search_params.merge('code': value_with_system)
+            reply = get_resource_by_params(versioned_resource_class('Observation'), token_with_system_search_params)
+            validate_search_reply(versioned_resource_class('Observation'), reply, token_with_system_search_params)
+
+            break if resolved_one
           end
-
-          value_with_system = get_value_for_search_param(resolve_element_from_path(@observation_ary[patient], 'code') { |el| get_value_for_search_param(el).present? }, true)
-          token_with_system_search_params = search_params.merge('code': value_with_system)
-          reply = get_resource_by_params(versioned_resource_class('Observation'), token_with_system_search_params)
-          validate_search_reply(versioned_resource_class('Observation'), reply, token_with_system_search_params)
         end
 
         skip 'Could not resolve all parameters (patient, code, date) in any resource.' unless resolved_one

--- a/lib/modules/uscore_v3.1.1/us_core_pulse_oximetry_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_pulse_oximetry_sequence.rb
@@ -286,9 +286,7 @@ module Inferno
         patient_ids.each do |patient|
           next unless @observation_ary[patient].present?
 
-          observation_ary = Array.wrap(@observation_ary[patient])
-
-          observation_ary.each do |observation|
+          Array.wrap(@observation_ary[patient]).each do |observation|
             search_params = {
               'patient': patient,
               'category': get_value_for_search_param(resolve_element_from_path(observation, 'category') { |el| get_value_for_search_param(el).present? }),
@@ -393,9 +391,7 @@ module Inferno
         patient_ids.each do |patient|
           next unless @observation_ary[patient].present?
 
-          observation_ary = Array.wrap(@observation_ary[patient])
-
-          observation_ary.each do |observation|
+          Array.wrap(@observation_ary[patient]).each do |observation|
             search_params = {
               'patient': patient,
               'category': get_value_for_search_param(resolve_element_from_path(observation, 'category') { |el| get_value_for_search_param(el).present? }),
@@ -449,9 +445,7 @@ module Inferno
         patient_ids.each do |patient|
           next unless @observation_ary[patient].present?
 
-          observation_ary = Array.wrap(@observation_ary[patient])
-
-          observation_ary.each do |observation|
+          Array.wrap(@observation_ary[patient]).each do |observation|
             search_params = {
               'patient': patient,
               'code': get_value_for_search_param(resolve_element_from_path(observation, 'code') { |el| get_value_for_search_param(el).present? }),


### PR DESCRIPTION
… resource when there are more than 2 search parameters

# Summary
When there are more than two search parameters, in some rare case, Inferno may take the search value from different resource under the same patient.

This fix is to force the get_value_for_search_param() to take search parameter values from the same resource 

This PR address Issue #310 and #312

## New behavior

## Code changes
Add an inner loop inside `patient_ids.each do |patient|` that looping through each resource the patient has to find search parameter values

Example:
```
        patient_ids.each do |patient|
          next unless @procedure_ary[patient].present?

          Array.wrap(@procedure_ary[patient]).each do |procedure|
            search_params = {
              'patient': patient,
              'code': get_value_for_search_param(resolve_element_from_path(procedure, 'code') { |el| get_value_for_search_param(el).present? }),
              'date': get_value_for_search_param(resolve_element_from_path(procedure, 'performed') { |el| get_value_for_search_param(el).present? })
            }
...
```


## Testing guidance
Create a new patient in reference server
Create two DocumentReference resource where the first DocumentReference resource has `DocumentReference.category` and `DocumentReference.date` as
```
...
    "category": [
        {
            "text": "Unknown"
        }
    ],
    "date": "2019-09-09",
...
```
and the second DocumentReference resource has
```
    "category": [
        {
            "coding": [
                {
                    "system": "http://hl7.org/fhir/us/core/CodeSystem/us-core-documentreference-category",
                    "code": "clinical-note",
                    "display": "Clinical Note"
                }
            ],
            "text": "Clinical Note"
        }
    ],
    "date": "2020-09-09",
```
Run the "Single Patient" test 
Verify that all tests passed (except secured by TLS test if the reference server is running on http)
Verify that DocumentReference test USCDR-04 has the correct search parameter values like `DocumentReference?category=clinical-note&date=2020-09-09&patient=[patient id]` 