### PR TITLE
FI-1271 Update links to US Core 3.1.1. to include "STU3.1.1"

### DIFF
--- a/generator/uscore/metadata_extractor.rb
+++ b/generator/uscore/metadata_extractor.rb
@@ -79,6 +79,7 @@ module Inferno
           resource: resource['type'],
           profile: profile,
           profile_name: profile_json['title'],
+          versioned_profile: get_versioned_url(profile, metadata[:version]),
           title: profile_title,
           interactions: [],
           operations: [],
@@ -552,6 +553,16 @@ module Inferno
 
       def capitalize_first_letter(str)
         str.slice(0).capitalize + str.slice(1..-1)
+      end
+
+      def get_versioned_url(profile, version)
+        versioned_url = profile
+        case version
+        when 'v3.1.1'
+          versioned_url = profile.gsub('http://hl7.org/fhir/us/core/StructureDefinition', 'http://hl7.org/fhir/us/core/STU3.1.1/StructureDefinition')
+        end
+
+        versioned_url
       end
     end
   end

--- a/generator/uscore/templates/access_verify_sequence.rb.erb
+++ b/generator/uscore/templates/access_verify_sequence.rb.erb
@@ -129,7 +129,7 @@ module Inferno
           <% if access_verify_restriction == 'restricted' %>name 'Scope granted is limited to those chosen by user during authorization.'
           <% else %>name 'Scope granted enables access to all US Core resource types.'
           <% end %>
-          link 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient'
+          link 'http://hl7.org/fhir/us/core/STU3.1.1/StructureDefinition/us-core-patient'
           description %(
             <% if access_verify_restriction == 'unrestricted' %>
             This test confirms that the scopes granted during authorization are sufficient to access

--- a/generator/uscore/templates/sequence.rb.erb
+++ b/generator/uscore/templates/sequence.rb.erb
@@ -69,7 +69,7 @@ module Inferno
         resources found for these elements.
 
         ## Profile Validation
-        Each resource returned from the first search is expected to conform to the [<%=profile_name%>](<%=profile%>).
+        Each resource returned from the first search is expected to conform to the [<%=profile_name%>](<%=versioned_profile%>).
         Each element is checked against teminology binding and cardinality requirements.
 
         Elements with a required binding is validated against its bound valueset. If the code/system in the element is not part

--- a/generator/uscore/uscore_generator.rb
+++ b/generator/uscore/uscore_generator.rb
@@ -163,7 +163,7 @@ module Inferno
           tests_that: "Server returns correct #{sequence[:resource]} resource from the #{sequence[:resource]} read interaction",
           key: test_key,
           index: sequence[:tests].length + 1,
-          link: 'https://www.hl7.org/fhir/us/core/CapabilityStatement-us-core-server.html',
+          link: 'http://www.hl7.org/fhir/us/core/STU3.1.1/CapabilityStatement-us-core-server.html',
           description: "This test will attempt to Reference to #{sequence[:resource]} can be resolved and read."
         }
 
@@ -377,7 +377,7 @@ module Inferno
           tests_that: "Server returns valid results for #{sequence[:resource]} search by #{search_param[:names].join('+')}.",
           key: test_key,
           index: sequence[:tests].length + 1,
-          link: 'https://www.hl7.org/fhir/us/core/CapabilityStatement-us-core-server.html',
+          link: 'http://www.hl7.org/fhir/us/core/STU3.1.1/CapabilityStatement-us-core-server.html',
           optional: search_param[:expectation] != 'SHALL',
           description: %(
             A server #{search_param[:expectation]} support searching by #{search_param[:names].join('+')} on the #{sequence[:resource]} resource.
@@ -498,7 +498,7 @@ module Inferno
           tests_that: "Server returns expected results from #{sequence[:resource]} chained search by #{chained_param_string}",
           key: :"chained_search_by_#{search_param}",
           index: sequence[:tests].length + 1,
-          link: 'https://www.hl7.org/fhir/us/core/StructureDefinition-us-core-practitionerrole.html#mandatory-search-parameters',
+          link: 'http://www.hl7.org/fhir/us/core/STU3.1.1/StructureDefinition-us-core-practitionerrole.html#mandatory-search-parameters',
           optional: false,
           description: %(
             A server SHALL support searching the #{sequence[:resource]} resource
@@ -563,7 +563,7 @@ module Inferno
           tests_that: "Server returns correct #{sequence[:resource]} resource from #{sequence[:resource]} #{interaction[:code]} interaction",
           key: test_key,
           index: sequence[:tests].length + 1,
-          link: 'https://www.hl7.org/fhir/us/core/CapabilityStatement-us-core-server.html',
+          link: 'http://www.hl7.org/fhir/us/core/STU3.1.1/CapabilityStatement-us-core-server.html',
           description: "A server #{interaction[:expectation]} support the #{sequence[:resource]} #{interaction[:code]} interaction.",
           optional: interaction[:expectation] != 'SHALL'
         }
@@ -604,7 +604,7 @@ module Inferno
         test = {
           tests_that: "All must support elements are provided in the #{sequence[:resource]} resources returned.",
           index: sequence[:tests].length + 1,
-          link: 'http://www.hl7.org/fhir/us/core/general-guidance.html#must-support',
+          link: 'http://www.hl7.org/fhir/us/core/STU3.1.1/general-guidance.html#must-support',
           test_code: '',
           description: %(
             US Core Responders SHALL be capable of populating all data elements as part of the query results as specified by the US Core Server Capability Statement.
@@ -719,9 +719,9 @@ module Inferno
           tests_that: "#{sequence[:resource]} resources returned during previous tests conform to the #{sequence[:profile_name]}.",
           key: test_key,
           index: sequence[:tests].length + 1,
-          link: sequence[:profile],
+          link: sequence[:versioned_profile],
           description: %(
-            This test verifies resources returned from the first search conform to the [US Core #{sequence[:resource]} Profile](#{sequence[:profile]}).
+            This test verifies resources returned from the first search conform to the [#{sequence[:profile_name]}](#{sequence[:versioned_profile]}).
             It verifies the presence of manditory elements and that elements with required bindgings contain appropriate values.
             CodeableConcept element bindings will fail if none of its codings have a code/system that is part of the bound ValueSet.
             Quantity, Coding, and code element bindings will fail if its code/system is not found in the valueset.
@@ -817,7 +817,7 @@ module Inferno
             tests_that: "Medication resources returned conform to US Core #{sequence[:version]} profiles",
             key: :validate_medication_resources,
             index: sequence[:tests].length + 1,
-            link: 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-medicationrequest',
+            link: 'http://hl7.org/fhir/us/core/STU3.1.1/StructureDefinition/us-core-medicationrequest',
             description: %(
               This test checks if the resources returned from prior searches conform to the US Core profiles.
               This includes checking for missing data elements and valueset verification.

--- a/lib/modules/onc_program/bulk_data_group_validation_sequence.rb
+++ b/lib/modules/onc_program/bulk_data_group_validation_sequence.rb
@@ -462,7 +462,7 @@ module Inferno
         metadata do
           id '03'
           name 'Patient resources returned conform to the US Core Patient Profile'
-          link 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient'
+          link 'http://hl7.org/fhir/us/core/STU3.1.1/StructureDefinition/us-core-patient'
           description %(
             This test verifies that the resources returned from bulk data export conform to the US Core profiles. This includes checking for missing data elements and value set verification.
           )
@@ -498,7 +498,7 @@ module Inferno
         metadata do
           id '05'
           name 'Patient IDs match those expected in Group'
-          link 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient'
+          link 'http://hl7.org/fhir/us/core/STU3.1.1/StructureDefinition/us-core-patient'
           description %(
             This test checks that the list of patient IDs that are expected match those that are returned.
             If no patient ids are provided to the test, then the test will be omitted.
@@ -518,7 +518,7 @@ module Inferno
         metadata do
           id '06'
           name 'AllergyIntolerance resources returned conform to the US Core AllergyIntolerance Profile'
-          link 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-allergyintolerance'
+          link 'http://hl7.org/fhir/us/core/STU3.1.1/StructureDefinition/us-core-allergyintolerance'
           description %(
             This test verifies that the resources returned from bulk data export conform to the US Core profiles. This includes checking for missing data elements and value set verification.
           )
@@ -538,7 +538,7 @@ module Inferno
         metadata do
           id '07'
           name 'CarePlan resources returned conform to the US Core CarePlan Profile'
-          link 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-careplan'
+          link 'http://hl7.org/fhir/us/core/STU3.1.1/StructureDefinition/us-core-careplan'
           description %(
             This test verifies that the resources returned from bulk data export conform to the US Core profiles. This includes checking for missing data elements and value set verification.
           )
@@ -558,7 +558,7 @@ module Inferno
         metadata do
           id '08'
           name 'CareTeam resources returned conform to the US Core CareTeam Profile'
-          link 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-careteam'
+          link 'http://hl7.org/fhir/us/core/STU3.1.1/StructureDefinition/us-core-careteam'
           description %(
             This test verifies that the resources returned from bulk data export conform to the US Core profiles. This includes checking for missing data elements and value set verification.
           )
@@ -578,7 +578,7 @@ module Inferno
         metadata do
           id '09'
           name 'Condition resources returned conform to the US Core Condition Profile'
-          link 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-condition'
+          link 'http://hl7.org/fhir/us/core/STU3.1.1/StructureDefinition/us-core-condition'
           description %(
             This test verifies that the resources returned from bulk data export conform to the US Core profiles. This includes checking for missing data elements and value set verification.
           )
@@ -598,7 +598,7 @@ module Inferno
         metadata do
           id '10'
           name 'Device resources returned conform to the US Core Implantable Device Profile'
-          link 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-implantable-device'
+          link 'http://hl7.org/fhir/us/core/STU3.1.1/StructureDefinition/us-core-implantable-device'
           description %(
             This test verifies that the resources returned from bulk data export conform to the US Core profiles. This includes checking for missing data elements and value set verification.
           )
@@ -619,12 +619,12 @@ module Inferno
         metadata do
           id '11'
           name 'DiagnosticReport resources returned conform to the US Core DiagnosticReport Profiles'
-          link 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-diagnosticreport-lab'
+          link 'http://hl7.org/fhir/us/core/STU3.1.1/StructureDefinition/us-core-diagnosticreport-lab'
           description %(
             This test verifies that the resources returned from bulk data export conform to the following US Core profiles. This includes checking for missing data elements and value set verification.
 
-            * http://hl7.org/fhir/us/core/StructureDefinition/us-core-diagnosticreport-lab
-            * http://hl7.org/fhir/us/core/StructureDefinition/us-core-diagnosticreport-note
+            * [DiagnosticReport Lab](http://hl7.org/fhir/us/core/STU3.1.1/StructureDefinition/us-core-diagnosticreport-lab)
+            * [DiagnosticReport Note](http://hl7.org/fhir/us/core/STU3.1.1/StructureDefinition/us-core-diagnosticreport-note)
           )
         end
 
@@ -647,7 +647,7 @@ module Inferno
         metadata do
           id '12'
           name 'DocumentReference resources returned conform to the US Core DocumentationReference Profile'
-          link 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-documentreference'
+          link 'http://hl7.org/fhir/us/core/STU3.1.1/StructureDefinition/us-core-documentreference'
           description %(
             This test verifies that the resources returned from bulk data export conform to the US Core profiles. This includes checking for missing data elements and value set verification.
           )
@@ -667,7 +667,7 @@ module Inferno
         metadata do
           id '13'
           name 'Goal resources returned conform to the US Core Goal Profile'
-          link 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-goal'
+          link 'http://hl7.org/fhir/us/core/STU3.1.1/StructureDefinition/us-core-goal'
           description %(
             This test verifies that the resources returned from bulk data export conform to the US Core profiles. This includes checking for missing data elements and value set verification.
           )
@@ -687,7 +687,7 @@ module Inferno
         metadata do
           id '14'
           name 'Immunization resources returned conform to the US Core Immunization Profile'
-          link 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-immunization'
+          link 'http://hl7.org/fhir/us/core/STU3.1.1/StructureDefinition/us-core-immunization'
           description %(
             This test verifies that the resources returned from bulk data export conform to the US Core profiles. This includes checking for missing data elements and value set verification.
           )
@@ -707,7 +707,7 @@ module Inferno
         metadata do
           id '15'
           name 'MedicationRequest resources returned conform to the US Core MedicationRequest Profile'
-          link 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-medicationrequest'
+          link 'http://hl7.org/fhir/us/core/STU3.1.1/StructureDefinition/us-core-medicationrequest'
           description %(
             This test verifies that the resources returned from bulk data export conform to the US Core profiles. This includes checking for missing data elements and value set verification.
           )
@@ -727,24 +727,24 @@ module Inferno
         metadata do
           id '16'
           name 'Observation resources returned conform to the US Core Observation Profiles'
-          link 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-lab'
+          link 'http://hl7.org/fhir/us/core/STU3.1.1/StructureDefinition/us-core-observation-lab'
           description %(
             This test verifies that the resources returned from bulk data
             export conform to the following US Core profiles. This includes
             checking for missing data elements and value set verification.
 
-            * http://hl7.org/fhir/us/core/StructureDefinition/pediatric-bmi-for-age
-            * http://hl7.org/fhir/us/core/StructureDefinition/pediatric-weight-for-height
-            * http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-lab
-            * http://hl7.org/fhir/us/core/StructureDefinition/us-core-pulse-oximetry
-            * http://hl7.org/fhir/us/core/StructureDefinition/us-core-smokingstatus
-            * http://hl7.org/fhir/us/core/StructureDefinition/head-occipital-frontal-circumference-percentile
-            * http://hl7.org/fhir/StructureDefinition/bp
-            * http://hl7.org/fhir/StructureDefinition/bodyheight
-            * http://hl7.org/fhir/StructureDefinition/bodytemp
-            * http://hl7.org/fhir/StructureDefinition/bodyweight
-            * http://hl7.org/fhir/StructureDefinition/heartrate
-            * http://hl7.org/fhir/StructureDefinition/resprate
+            * [Observation Lab](http://hl7.org/fhir/us/core/STU3.1.1/StructureDefinition/us-core-observation-lab)
+            * [Pediatric BMI For Age](http://hl7.org/fhir/us/core/STU3.1.1/StructureDefinition/pediatric-bmi-for-age)
+            * [Pediatric Head Occipital-frontal Circumference Percentile](http://hl7.org/fhir/us/core/STU3.1.1/StructureDefinition/head-occipital-frontal-circumference-percentile)
+            * [Pediatric Weight For Height](http://hl7.org/fhir/us/core/STU3.1.1/StructureDefinition/pediatric-weight-for-height)
+            * [Pulse Oximetry](http://hl7.org/fhir/us/core/STU3.1.1/StructureDefinition/us-core-pulse-oximetry)
+            * [Smokingstatus](http://hl7.org/fhir/us/core/STU3.1.1/StructureDefinition/us-core-smokingstatus)
+            * [Blood Pressure](http://hl7.org/fhir/StructureDefinition/bp)
+            * [Body Height](http://hl7.org/fhir/StructureDefinition/bodyheight)
+            * [Body Temperature](http://hl7.org/fhir/StructureDefinition/bodytemp)
+            * [Body Weight](http://hl7.org/fhir/StructureDefinition/bodyweight)
+            * [Heart Rate](http://hl7.org/fhir/StructureDefinition/heartrate)
+            * [Respiratory Rate](http://hl7.org/fhir/StructureDefinition/resprate)
           )
         end
 
@@ -818,7 +818,7 @@ module Inferno
         metadata do
           id '17'
           name 'Procedure resources returned conform to the US Core Procedure Profile'
-          link 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-procedure'
+          link 'http://hl7.org/fhir/us/core/STU3.1.1/StructureDefinition/us-core-procedure'
           description %(
             This test verifies that the resources returned from bulk data export conform to the US Core profiles. This includes checking for missing data elements and value set verification.
           )
@@ -838,14 +838,14 @@ module Inferno
         metadata do
           id '18'
           name 'Encounter resources returned conform to the US Core Encounter Profile'
-          link 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-encounter'
+          link 'http://hl7.org/fhir/us/core/STU3.1.1/StructureDefinition/us-core-encounter'
           description %(
             This test verifies that at least one of the resources returned from bulk data export conform to the US Core profiles. This includes checking for missing data elements and value set verification.
 
             The following US Core profiles have "Must Support" data element which reference Encounter resources:
 
-            * [DiagnosticReport Note](http://hl7.org/fhir/us/core/StructureDefinition/us-core-diagnosticreport-note)
-            * [DocumentReference](http://hl7.org/fhir/us/core/StructureDefinition/us-core-documentreference)
+            * [DiagnosticReport Note](http://hl7.org/fhir/us/core/STU3.1.1/StructureDefinition/us-core-diagnosticreport-note)
+            * [DocumentReference](http://hl7.org/fhir/us/core/STU3.1.1/StructureDefinition/us-core-documentreference)
           )
         end
 
@@ -865,18 +865,18 @@ module Inferno
         metadata do
           id '19'
           name 'Organization resources returned conform to the US Core Organization Profile'
-          link 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-organization'
+          link 'http://hl7.org/fhir/us/core/STU3.1.1/StructureDefinition/us-core-organization'
           description %(
             This test verifies that the resources returned from bulk data export conform to the US Core profiles. This includes checking for missing data elements and value set verification.
 
             The following US Core profiles have "Must Support" data element which reference Organization resources:
 
-            * [CareTeam](http://hl7.org/fhir/us/core/StructureDefinition/us-core-careteam)
-            * [DiagnosticReport Lab](http://hl7.org/fhir/us/core/StructureDefinition/us-core-diagnosticreport-lab)
-            * [DiagnosticReport Note](http://hl7.org/fhir/us/core/StructureDefinition/us-core-diagnosticreport-note)
-            * [DocumentReference](http://hl7.org/fhir/us/core/StructureDefinition/us-core-documentreference)
-            * [MedicationRequest](http://hl7.org/fhir/us/core/StructureDefinition/us-core-medicationrequest)
-            * [Provenance](http://hl7.org/fhir/us/core/StructureDefinition/us-core-provenance)
+            * [CareTeam](http://hl7.org/fhir/us/core/STU3.1.1/StructureDefinition/us-core-careteam)
+            * [DiagnosticReport Lab](http://hl7.org/fhir/us/core/STU3.1.1/StructureDefinition/us-core-diagnosticreport-lab)
+            * [DiagnosticReport Note](http://hl7.org/fhir/us/core/STU3.1.1/StructureDefinition/us-core-diagnosticreport-note)
+            * [DocumentReference](http://hl7.org/fhir/us/core/STU3.1.1/StructureDefinition/us-core-documentreference)
+            * [MedicationRequest](http://hl7.org/fhir/us/core/STU3.1.1/StructureDefinition/us-core-medicationrequest)
+            * [Provenance](http://hl7.org/fhir/us/core/STU3.1.1/StructureDefinition/us-core-provenance)
           )
         end
 
@@ -894,19 +894,19 @@ module Inferno
         metadata do
           id '20'
           name 'Practitioner resources returned conform to the US Core Practitioner Profile'
-          link 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitioner'
+          link 'http://hl7.org/fhir/us/core/STU3.1.1/StructureDefinition/us-core-practitioner'
           description %(
             This test verifies that the resources returned from bulk data export conform to the US Core profiles. This includes checking for missing data elements and value set verification.
 
             The following US Core profiles have "Must Support" data element which reference Practitioner resources:
 
-            * [CareTeam](http://hl7.org/fhir/us/core/StructureDefinition/us-core-careteam)
-            * [DiagnosticReport Lab](http://hl7.org/fhir/us/core/StructureDefinition/us-core-diagnosticreport-lab)
-            * [DiagnosticReport Note](http://hl7.org/fhir/us/core/StructureDefinition/us-core-diagnosticreport-note)
-            * [DocumentReference](http://hl7.org/fhir/us/core/StructureDefinition/us-core-documentreference)
-            * [Encounter](http://hl7.org/fhir/us/core/StructureDefinition/us-core-encounter)
-            * [MedicationRequest](http://hl7.org/fhir/us/core/StructureDefinition/us-core-medicationrequest)
-            * [Provenance](http://hl7.org/fhir/us/core/StructureDefinition/us-core-provenance)
+            * [CareTeam](http://hl7.org/fhir/us/core/STU3.1.1/StructureDefinition/us-core-careteam)
+            * [DiagnosticReport Lab](http://hl7.org/fhir/us/core/STU3.1.1/StructureDefinition/us-core-diagnosticreport-lab)
+            * [DiagnosticReport Note](http://hl7.org/fhir/us/core/STU3.1.1/StructureDefinition/us-core-diagnosticreport-note)
+            * [DocumentReference](http://hl7.org/fhir/us/core/STU3.1.1/StructureDefinition/us-core-documentreference)
+            * [Encounter](http://hl7.org/fhir/us/core/STU3.1.1/StructureDefinition/us-core-encounter)
+            * [MedicationRequest](http://hl7.org/fhir/us/core/STU3.1.1/StructureDefinition/us-core-medicationrequest)
+            * [Provenance](http://hl7.org/fhir/us/core/STU3.1.1/StructureDefinition/us-core-provenance)
           )
         end
 
@@ -924,7 +924,7 @@ module Inferno
         metadata do
           id '21'
           name 'Provenance resources returned conform to the US Core Provenance Profile'
-          link 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-provenance'
+          link 'http://hl7.org/fhir/us/core/STU3.1.1/StructureDefinition/us-core-provenance'
           description %(
             This test verifies that the resources returned from bulk data export conform to the US Core profiles. This includes checking for missing data elements and value set verification.
           )
@@ -951,7 +951,7 @@ module Inferno
 
             The following US Core profiles have "Must Support" data elements which reference Location resources:
 
-            * [Encounter](http://hl7.org/fhir/us/core/StructureDefinition/us-core-encounter)
+            * [Encounter](http://hl7.org/fhir/us/core/STU3.1.1/StructureDefinition/us-core-encounter)
           )
         end
 
@@ -962,14 +962,14 @@ module Inferno
         metadata do
           id '23'
           name 'Medication resources returned conform to the US Core Medication Profile if bulk data export has Medication resources'
-          link 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-medication'
+          link 'http://hl7.org/fhir/us/core/STU3.1.1/StructureDefinition/us-core-medication'
           description %(
             This test verifies that the resources returned from bulk data export conform to the US Core profiles. This includes checking for missing data elements and value set verification.
             This test is omitted if bulk data export does not return any Medication resources.
 
             The following US Core profiles have "Must Support" data elements which reference Medication resources:
 
-            * [MedicationRequest](http://hl7.org/fhir/us/core/StructureDefinition/us-core-medicationrequest)
+            * [MedicationRequest](http://hl7.org/fhir/us/core/STU3.1.1/StructureDefinition/us-core-medicationrequest)
           )
         end
 

--- a/lib/modules/onc_program/onc_ehr_launch_sequence.rb
+++ b/lib/modules/onc_program/onc_ehr_launch_sequence.rb
@@ -201,7 +201,7 @@ module Inferno
         metadata do
           id '13'
           name 'Server rejects unauthorized access'
-          link 'https://www.hl7.org/fhir/us/core/CapabilityStatement-us-core-server.html#behavior'
+          link 'https://www.hl7.org/fhir/us/core/STU3.1.1/CapabilityStatement-us-core-server.html#behavior'
           description %(
             A server SHALL reject any unauthorized requests by returning an HTTP
             401 unauthorized response code.

--- a/lib/modules/onc_program/onc_standalone_launch_sequence.rb
+++ b/lib/modules/onc_program/onc_standalone_launch_sequence.rb
@@ -205,7 +205,7 @@ module Inferno
         metadata do
           id '11'
           name 'Server rejects unauthorized access'
-          link 'https://www.hl7.org/fhir/us/core/CapabilityStatement-us-core-server.html#behavior'
+          link 'https://www.hl7.org/fhir/us/core/STU3.1.1/CapabilityStatement-us-core-server.html#behavior'
           description %(
             A server SHALL reject any unauthorized requests by returning an HTTP
             401 unauthorized response code.

--- a/lib/modules/onc_program_module.yml
+++ b/lib/modules/onc_program_module.yml
@@ -123,7 +123,7 @@ test_sets:
         overview: >
           For each of the relevant USCDI data elements provided in the
           conformance statement, this test executes the [required supported
-          searches](https://www.hl7.org/fhir/us/core/CapabilityStatement-us-core-server.html)
+          searches](http://www.hl7.org/fhir/us/core/STU3.1.1/CapabilityStatement-us-core-server.html)
           as defined by the US Core Implementation Guide v3.1.1.  The test begins
           by searching by one or more patients, with the expectation that the
           Bearer token provided to the test grants access to all USCDI
@@ -131,7 +131,7 @@ test_sets:
           queries and checks that the results are consistent with the provided
           search parameters.  It then performs a read on each Resource returned
           and validates the response against the relevant
-          [profile](https://www.hl7.org/fhir/us/core/profiles.html) as currently
+          [profile](http://www.hl7.org/fhir/us/core/STU3.1.1/profiles.html) as currently
           defined in the US Core Implementation Guide. All MUST SUPPORT elements
           must be seen before the test can pass, as well as Data Absent Reason
           to demonstrate that the server can properly handle missing data. Note that

--- a/lib/modules/us_core_guidance/us_core_r4_capability_statement_sequence.rb
+++ b/lib/modules/us_core_guidance/us_core_r4_capability_statement_sequence.rb
@@ -220,7 +220,7 @@ module Inferno
         metadata do
           id '05'
           name 'Capability Statement lists support for required US Core Profiles'
-          link 'https://www.hl7.org/fhir/us/core/CapabilityStatement-us-core-server.html#behavior'
+          link 'https://www.hl7.org/fhir/us/core/STU3.1.1/CapabilityStatement-us-core-server.html#behavior'
           description %(
            The US Core Implementation Guide states:
 

--- a/lib/modules/uscore_v3.1.1/access_verify_restricted_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/access_verify_restricted_sequence.rb
@@ -96,7 +96,7 @@ module Inferno
           id '01'
           name 'Scope granted is limited to those chosen by user during authorization.'
 
-          link 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient'
+          link 'http://hl7.org/fhir/us/core/STU3.1.1/StructureDefinition/us-core-patient'
           description %(
 
             This test confirms that the scopes granted during authorization match those that

--- a/lib/modules/uscore_v3.1.1/access_verify_unrestricted_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/access_verify_unrestricted_sequence.rb
@@ -102,7 +102,7 @@ module Inferno
           id '01'
           name 'Scope granted enables access to all US Core resource types.'
 
-          link 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient'
+          link 'http://hl7.org/fhir/us/core/STU3.1.1/StructureDefinition/us-core-patient'
           description %(
 
             This test confirms that the scopes granted during authorization are sufficient to access

--- a/lib/modules/uscore_v3.1.1/bodyheight_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/bodyheight_sequence.rb
@@ -160,7 +160,7 @@ module Inferno
         metadata do
           id '01'
           name 'Server returns valid results for Observation search by patient+code.'
-          link 'https://www.hl7.org/fhir/us/core/CapabilityStatement-us-core-server.html'
+          link 'http://www.hl7.org/fhir/us/core/STU3.1.1/CapabilityStatement-us-core-server.html'
           description %(
 
             A server SHALL support searching by patient+code on the Observation resource.
@@ -264,7 +264,7 @@ module Inferno
         metadata do
           id '02'
           name 'Server returns valid results for Observation search by patient+category+date.'
-          link 'https://www.hl7.org/fhir/us/core/CapabilityStatement-us-core-server.html'
+          link 'http://www.hl7.org/fhir/us/core/STU3.1.1/CapabilityStatement-us-core-server.html'
           description %(
 
             A server SHALL support searching by patient+category+date on the Observation resource.
@@ -322,7 +322,7 @@ module Inferno
         metadata do
           id '03'
           name 'Server returns valid results for Observation search by patient+category.'
-          link 'https://www.hl7.org/fhir/us/core/CapabilityStatement-us-core-server.html'
+          link 'http://www.hl7.org/fhir/us/core/STU3.1.1/CapabilityStatement-us-core-server.html'
           description %(
 
             A server SHALL support searching by patient+category on the Observation resource.
@@ -368,7 +368,7 @@ module Inferno
         metadata do
           id '04'
           name 'Server returns valid results for Observation search by patient+category+status.'
-          link 'https://www.hl7.org/fhir/us/core/CapabilityStatement-us-core-server.html'
+          link 'http://www.hl7.org/fhir/us/core/STU3.1.1/CapabilityStatement-us-core-server.html'
           optional
           description %(
 
@@ -414,7 +414,7 @@ module Inferno
         metadata do
           id '05'
           name 'Server returns valid results for Observation search by patient+code+date.'
-          link 'https://www.hl7.org/fhir/us/core/CapabilityStatement-us-core-server.html'
+          link 'http://www.hl7.org/fhir/us/core/STU3.1.1/CapabilityStatement-us-core-server.html'
           optional
           description %(
 
@@ -473,7 +473,7 @@ module Inferno
         metadata do
           id '06'
           name 'Server returns correct Observation resource from Observation read interaction'
-          link 'https://www.hl7.org/fhir/us/core/CapabilityStatement-us-core-server.html'
+          link 'http://www.hl7.org/fhir/us/core/STU3.1.1/CapabilityStatement-us-core-server.html'
           description %(
             A server SHALL support the Observation read interaction.
           )
@@ -490,7 +490,7 @@ module Inferno
         metadata do
           id '07'
           name 'Server returns correct Observation resource from Observation vread interaction'
-          link 'https://www.hl7.org/fhir/us/core/CapabilityStatement-us-core-server.html'
+          link 'http://www.hl7.org/fhir/us/core/STU3.1.1/CapabilityStatement-us-core-server.html'
           optional
           description %(
             A server SHOULD support the Observation vread interaction.
@@ -508,7 +508,7 @@ module Inferno
         metadata do
           id '08'
           name 'Server returns correct Observation resource from Observation history interaction'
-          link 'https://www.hl7.org/fhir/us/core/CapabilityStatement-us-core-server.html'
+          link 'http://www.hl7.org/fhir/us/core/STU3.1.1/CapabilityStatement-us-core-server.html'
           optional
           description %(
             A server SHOULD support the Observation history interaction.
@@ -576,7 +576,7 @@ module Inferno
           link 'http://hl7.org/fhir/StructureDefinition/bodyheight'
           description %(
 
-            This test verifies resources returned from the first search conform to the [US Core Observation Profile](http://hl7.org/fhir/StructureDefinition/bodyheight).
+            This test verifies resources returned from the first search conform to the [Observation Body Height Profile](http://hl7.org/fhir/StructureDefinition/bodyheight).
             It verifies the presence of manditory elements and that elements with required bindgings contain appropriate values.
             CodeableConcept element bindings will fail if none of its codings have a code/system that is part of the bound ValueSet.
             Quantity, Coding, and code element bindings will fail if its code/system is not found in the valueset.
@@ -633,7 +633,7 @@ module Inferno
       test 'All must support elements are provided in the Observation resources returned.' do
         metadata do
           id '11'
-          link 'http://www.hl7.org/fhir/us/core/general-guidance.html#must-support'
+          link 'http://www.hl7.org/fhir/us/core/STU3.1.1/general-guidance.html#must-support'
           description %(
 
             US Core Responders SHALL be capable of populating all data elements as part of the query results as specified by the US Core Server Capability Statement.

--- a/lib/modules/uscore_v3.1.1/bodytemp_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/bodytemp_sequence.rb
@@ -160,7 +160,7 @@ module Inferno
         metadata do
           id '01'
           name 'Server returns valid results for Observation search by patient+code.'
-          link 'https://www.hl7.org/fhir/us/core/CapabilityStatement-us-core-server.html'
+          link 'http://www.hl7.org/fhir/us/core/STU3.1.1/CapabilityStatement-us-core-server.html'
           description %(
 
             A server SHALL support searching by patient+code on the Observation resource.
@@ -264,7 +264,7 @@ module Inferno
         metadata do
           id '02'
           name 'Server returns valid results for Observation search by patient+category+date.'
-          link 'https://www.hl7.org/fhir/us/core/CapabilityStatement-us-core-server.html'
+          link 'http://www.hl7.org/fhir/us/core/STU3.1.1/CapabilityStatement-us-core-server.html'
           description %(
 
             A server SHALL support searching by patient+category+date on the Observation resource.
@@ -322,7 +322,7 @@ module Inferno
         metadata do
           id '03'
           name 'Server returns valid results for Observation search by patient+category.'
-          link 'https://www.hl7.org/fhir/us/core/CapabilityStatement-us-core-server.html'
+          link 'http://www.hl7.org/fhir/us/core/STU3.1.1/CapabilityStatement-us-core-server.html'
           description %(
 
             A server SHALL support searching by patient+category on the Observation resource.
@@ -368,7 +368,7 @@ module Inferno
         metadata do
           id '04'
           name 'Server returns valid results for Observation search by patient+category+status.'
-          link 'https://www.hl7.org/fhir/us/core/CapabilityStatement-us-core-server.html'
+          link 'http://www.hl7.org/fhir/us/core/STU3.1.1/CapabilityStatement-us-core-server.html'
           optional
           description %(
 
@@ -414,7 +414,7 @@ module Inferno
         metadata do
           id '05'
           name 'Server returns valid results for Observation search by patient+code+date.'
-          link 'https://www.hl7.org/fhir/us/core/CapabilityStatement-us-core-server.html'
+          link 'http://www.hl7.org/fhir/us/core/STU3.1.1/CapabilityStatement-us-core-server.html'
           optional
           description %(
 
@@ -473,7 +473,7 @@ module Inferno
         metadata do
           id '06'
           name 'Server returns correct Observation resource from Observation read interaction'
-          link 'https://www.hl7.org/fhir/us/core/CapabilityStatement-us-core-server.html'
+          link 'http://www.hl7.org/fhir/us/core/STU3.1.1/CapabilityStatement-us-core-server.html'
           description %(
             A server SHALL support the Observation read interaction.
           )
@@ -490,7 +490,7 @@ module Inferno
         metadata do
           id '07'
           name 'Server returns correct Observation resource from Observation vread interaction'
-          link 'https://www.hl7.org/fhir/us/core/CapabilityStatement-us-core-server.html'
+          link 'http://www.hl7.org/fhir/us/core/STU3.1.1/CapabilityStatement-us-core-server.html'
           optional
           description %(
             A server SHOULD support the Observation vread interaction.
@@ -508,7 +508,7 @@ module Inferno
         metadata do
           id '08'
           name 'Server returns correct Observation resource from Observation history interaction'
-          link 'https://www.hl7.org/fhir/us/core/CapabilityStatement-us-core-server.html'
+          link 'http://www.hl7.org/fhir/us/core/STU3.1.1/CapabilityStatement-us-core-server.html'
           optional
           description %(
             A server SHOULD support the Observation history interaction.
@@ -576,7 +576,7 @@ module Inferno
           link 'http://hl7.org/fhir/StructureDefinition/bodytemp'
           description %(
 
-            This test verifies resources returned from the first search conform to the [US Core Observation Profile](http://hl7.org/fhir/StructureDefinition/bodytemp).
+            This test verifies resources returned from the first search conform to the [Observation Body Temperature Profile](http://hl7.org/fhir/StructureDefinition/bodytemp).
             It verifies the presence of manditory elements and that elements with required bindgings contain appropriate values.
             CodeableConcept element bindings will fail if none of its codings have a code/system that is part of the bound ValueSet.
             Quantity, Coding, and code element bindings will fail if its code/system is not found in the valueset.
@@ -633,7 +633,7 @@ module Inferno
       test 'All must support elements are provided in the Observation resources returned.' do
         metadata do
           id '11'
-          link 'http://www.hl7.org/fhir/us/core/general-guidance.html#must-support'
+          link 'http://www.hl7.org/fhir/us/core/STU3.1.1/general-guidance.html#must-support'
           description %(
 
             US Core Responders SHALL be capable of populating all data elements as part of the query results as specified by the US Core Server Capability Statement.

--- a/lib/modules/uscore_v3.1.1/bodyweight_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/bodyweight_sequence.rb
@@ -160,7 +160,7 @@ module Inferno
         metadata do
           id '01'
           name 'Server returns valid results for Observation search by patient+code.'
-          link 'https://www.hl7.org/fhir/us/core/CapabilityStatement-us-core-server.html'
+          link 'http://www.hl7.org/fhir/us/core/STU3.1.1/CapabilityStatement-us-core-server.html'
           description %(
 
             A server SHALL support searching by patient+code on the Observation resource.
@@ -264,7 +264,7 @@ module Inferno
         metadata do
           id '02'
           name 'Server returns valid results for Observation search by patient+category+date.'
-          link 'https://www.hl7.org/fhir/us/core/CapabilityStatement-us-core-server.html'
+          link 'http://www.hl7.org/fhir/us/core/STU3.1.1/CapabilityStatement-us-core-server.html'
           description %(
 
             A server SHALL support searching by patient+category+date on the Observation resource.
@@ -322,7 +322,7 @@ module Inferno
         metadata do
           id '03'
           name 'Server returns valid results for Observation search by patient+category.'
-          link 'https://www.hl7.org/fhir/us/core/CapabilityStatement-us-core-server.html'
+          link 'http://www.hl7.org/fhir/us/core/STU3.1.1/CapabilityStatement-us-core-server.html'
           description %(
 
             A server SHALL support searching by patient+category on the Observation resource.
@@ -368,7 +368,7 @@ module Inferno
         metadata do
           id '04'
           name 'Server returns valid results for Observation search by patient+category+status.'
-          link 'https://www.hl7.org/fhir/us/core/CapabilityStatement-us-core-server.html'
+          link 'http://www.hl7.org/fhir/us/core/STU3.1.1/CapabilityStatement-us-core-server.html'
           optional
           description %(
 
@@ -414,7 +414,7 @@ module Inferno
         metadata do
           id '05'
           name 'Server returns valid results for Observation search by patient+code+date.'
-          link 'https://www.hl7.org/fhir/us/core/CapabilityStatement-us-core-server.html'
+          link 'http://www.hl7.org/fhir/us/core/STU3.1.1/CapabilityStatement-us-core-server.html'
           optional
           description %(
 
@@ -473,7 +473,7 @@ module Inferno
         metadata do
           id '06'
           name 'Server returns correct Observation resource from Observation read interaction'
-          link 'https://www.hl7.org/fhir/us/core/CapabilityStatement-us-core-server.html'
+          link 'http://www.hl7.org/fhir/us/core/STU3.1.1/CapabilityStatement-us-core-server.html'
           description %(
             A server SHALL support the Observation read interaction.
           )
@@ -490,7 +490,7 @@ module Inferno
         metadata do
           id '07'
           name 'Server returns correct Observation resource from Observation vread interaction'
-          link 'https://www.hl7.org/fhir/us/core/CapabilityStatement-us-core-server.html'
+          link 'http://www.hl7.org/fhir/us/core/STU3.1.1/CapabilityStatement-us-core-server.html'
           optional
           description %(
             A server SHOULD support the Observation vread interaction.
@@ -508,7 +508,7 @@ module Inferno
         metadata do
           id '08'
           name 'Server returns correct Observation resource from Observation history interaction'
-          link 'https://www.hl7.org/fhir/us/core/CapabilityStatement-us-core-server.html'
+          link 'http://www.hl7.org/fhir/us/core/STU3.1.1/CapabilityStatement-us-core-server.html'
           optional
           description %(
             A server SHOULD support the Observation history interaction.
@@ -576,7 +576,7 @@ module Inferno
           link 'http://hl7.org/fhir/StructureDefinition/bodyweight'
           description %(
 
-            This test verifies resources returned from the first search conform to the [US Core Observation Profile](http://hl7.org/fhir/StructureDefinition/bodyweight).
+            This test verifies resources returned from the first search conform to the [Observation Body Weight Profile](http://hl7.org/fhir/StructureDefinition/bodyweight).
             It verifies the presence of manditory elements and that elements with required bindgings contain appropriate values.
             CodeableConcept element bindings will fail if none of its codings have a code/system that is part of the bound ValueSet.
             Quantity, Coding, and code element bindings will fail if its code/system is not found in the valueset.
@@ -633,7 +633,7 @@ module Inferno
       test 'All must support elements are provided in the Observation resources returned.' do
         metadata do
           id '11'
-          link 'http://www.hl7.org/fhir/us/core/general-guidance.html#must-support'
+          link 'http://www.hl7.org/fhir/us/core/STU3.1.1/general-guidance.html#must-support'
           description %(
 
             US Core Responders SHALL be capable of populating all data elements as part of the query results as specified by the US Core Server Capability Statement.

--- a/lib/modules/uscore_v3.1.1/bp_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/bp_sequence.rb
@@ -160,7 +160,7 @@ module Inferno
         metadata do
           id '01'
           name 'Server returns valid results for Observation search by patient+code.'
-          link 'https://www.hl7.org/fhir/us/core/CapabilityStatement-us-core-server.html'
+          link 'http://www.hl7.org/fhir/us/core/STU3.1.1/CapabilityStatement-us-core-server.html'
           description %(
 
             A server SHALL support searching by patient+code on the Observation resource.
@@ -264,7 +264,7 @@ module Inferno
         metadata do
           id '02'
           name 'Server returns valid results for Observation search by patient+category+date.'
-          link 'https://www.hl7.org/fhir/us/core/CapabilityStatement-us-core-server.html'
+          link 'http://www.hl7.org/fhir/us/core/STU3.1.1/CapabilityStatement-us-core-server.html'
           description %(
 
             A server SHALL support searching by patient+category+date on the Observation resource.
@@ -322,7 +322,7 @@ module Inferno
         metadata do
           id '03'
           name 'Server returns valid results for Observation search by patient+category.'
-          link 'https://www.hl7.org/fhir/us/core/CapabilityStatement-us-core-server.html'
+          link 'http://www.hl7.org/fhir/us/core/STU3.1.1/CapabilityStatement-us-core-server.html'
           description %(
 
             A server SHALL support searching by patient+category on the Observation resource.
@@ -368,7 +368,7 @@ module Inferno
         metadata do
           id '04'
           name 'Server returns valid results for Observation search by patient+category+status.'
-          link 'https://www.hl7.org/fhir/us/core/CapabilityStatement-us-core-server.html'
+          link 'http://www.hl7.org/fhir/us/core/STU3.1.1/CapabilityStatement-us-core-server.html'
           optional
           description %(
 
@@ -414,7 +414,7 @@ module Inferno
         metadata do
           id '05'
           name 'Server returns valid results for Observation search by patient+code+date.'
-          link 'https://www.hl7.org/fhir/us/core/CapabilityStatement-us-core-server.html'
+          link 'http://www.hl7.org/fhir/us/core/STU3.1.1/CapabilityStatement-us-core-server.html'
           optional
           description %(
 
@@ -473,7 +473,7 @@ module Inferno
         metadata do
           id '06'
           name 'Server returns correct Observation resource from Observation read interaction'
-          link 'https://www.hl7.org/fhir/us/core/CapabilityStatement-us-core-server.html'
+          link 'http://www.hl7.org/fhir/us/core/STU3.1.1/CapabilityStatement-us-core-server.html'
           description %(
             A server SHALL support the Observation read interaction.
           )
@@ -490,7 +490,7 @@ module Inferno
         metadata do
           id '07'
           name 'Server returns correct Observation resource from Observation vread interaction'
-          link 'https://www.hl7.org/fhir/us/core/CapabilityStatement-us-core-server.html'
+          link 'http://www.hl7.org/fhir/us/core/STU3.1.1/CapabilityStatement-us-core-server.html'
           optional
           description %(
             A server SHOULD support the Observation vread interaction.
@@ -508,7 +508,7 @@ module Inferno
         metadata do
           id '08'
           name 'Server returns correct Observation resource from Observation history interaction'
-          link 'https://www.hl7.org/fhir/us/core/CapabilityStatement-us-core-server.html'
+          link 'http://www.hl7.org/fhir/us/core/STU3.1.1/CapabilityStatement-us-core-server.html'
           optional
           description %(
             A server SHOULD support the Observation history interaction.
@@ -576,7 +576,7 @@ module Inferno
           link 'http://hl7.org/fhir/StructureDefinition/bp'
           description %(
 
-            This test verifies resources returned from the first search conform to the [US Core Observation Profile](http://hl7.org/fhir/StructureDefinition/bp).
+            This test verifies resources returned from the first search conform to the [Observation Blood Pressure Profile](http://hl7.org/fhir/StructureDefinition/bp).
             It verifies the presence of manditory elements and that elements with required bindgings contain appropriate values.
             CodeableConcept element bindings will fail if none of its codings have a code/system that is part of the bound ValueSet.
             Quantity, Coding, and code element bindings will fail if its code/system is not found in the valueset.
@@ -633,7 +633,7 @@ module Inferno
       test 'All must support elements are provided in the Observation resources returned.' do
         metadata do
           id '11'
-          link 'http://www.hl7.org/fhir/us/core/general-guidance.html#must-support'
+          link 'http://www.hl7.org/fhir/us/core/STU3.1.1/general-guidance.html#must-support'
           description %(
 
             US Core Responders SHALL be capable of populating all data elements as part of the query results as specified by the US Core Server Capability Statement.

--- a/lib/modules/uscore_v3.1.1/head_occipital_frontal_circumference_percentile_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/head_occipital_frontal_circumference_percentile_sequence.rb
@@ -52,7 +52,7 @@ module Inferno
         resources found for these elements.
 
         ## Profile Validation
-        Each resource returned from the first search is expected to conform to the [US Core Pediatric Head Occipital-frontal Circumference Percentile Profile](http://hl7.org/fhir/us/core/StructureDefinition/head-occipital-frontal-circumference-percentile).
+        Each resource returned from the first search is expected to conform to the [US Core Pediatric Head Occipital-frontal Circumference Percentile Profile](http://hl7.org/fhir/us/core/STU3.1.1/StructureDefinition/head-occipital-frontal-circumference-percentile).
         Each element is checked against teminology binding and cardinality requirements.
 
         Elements with a required binding is validated against its bound valueset. If the code/system in the element is not part
@@ -160,7 +160,7 @@ module Inferno
         metadata do
           id '01'
           name 'Server returns valid results for Observation search by patient+code.'
-          link 'https://www.hl7.org/fhir/us/core/CapabilityStatement-us-core-server.html'
+          link 'http://www.hl7.org/fhir/us/core/STU3.1.1/CapabilityStatement-us-core-server.html'
           description %(
 
             A server SHALL support searching by patient+code on the Observation resource.
@@ -264,7 +264,7 @@ module Inferno
         metadata do
           id '02'
           name 'Server returns valid results for Observation search by patient+category+date.'
-          link 'https://www.hl7.org/fhir/us/core/CapabilityStatement-us-core-server.html'
+          link 'http://www.hl7.org/fhir/us/core/STU3.1.1/CapabilityStatement-us-core-server.html'
           description %(
 
             A server SHALL support searching by patient+category+date on the Observation resource.
@@ -322,7 +322,7 @@ module Inferno
         metadata do
           id '03'
           name 'Server returns valid results for Observation search by patient+category.'
-          link 'https://www.hl7.org/fhir/us/core/CapabilityStatement-us-core-server.html'
+          link 'http://www.hl7.org/fhir/us/core/STU3.1.1/CapabilityStatement-us-core-server.html'
           description %(
 
             A server SHALL support searching by patient+category on the Observation resource.
@@ -368,7 +368,7 @@ module Inferno
         metadata do
           id '04'
           name 'Server returns valid results for Observation search by patient+category+status.'
-          link 'https://www.hl7.org/fhir/us/core/CapabilityStatement-us-core-server.html'
+          link 'http://www.hl7.org/fhir/us/core/STU3.1.1/CapabilityStatement-us-core-server.html'
           optional
           description %(
 
@@ -414,7 +414,7 @@ module Inferno
         metadata do
           id '05'
           name 'Server returns valid results for Observation search by patient+code+date.'
-          link 'https://www.hl7.org/fhir/us/core/CapabilityStatement-us-core-server.html'
+          link 'http://www.hl7.org/fhir/us/core/STU3.1.1/CapabilityStatement-us-core-server.html'
           optional
           description %(
 
@@ -473,7 +473,7 @@ module Inferno
         metadata do
           id '06'
           name 'Server returns correct Observation resource from Observation read interaction'
-          link 'https://www.hl7.org/fhir/us/core/CapabilityStatement-us-core-server.html'
+          link 'http://www.hl7.org/fhir/us/core/STU3.1.1/CapabilityStatement-us-core-server.html'
           description %(
             A server SHALL support the Observation read interaction.
           )
@@ -490,7 +490,7 @@ module Inferno
         metadata do
           id '07'
           name 'Server returns correct Observation resource from Observation vread interaction'
-          link 'https://www.hl7.org/fhir/us/core/CapabilityStatement-us-core-server.html'
+          link 'http://www.hl7.org/fhir/us/core/STU3.1.1/CapabilityStatement-us-core-server.html'
           optional
           description %(
             A server SHOULD support the Observation vread interaction.
@@ -508,7 +508,7 @@ module Inferno
         metadata do
           id '08'
           name 'Server returns correct Observation resource from Observation history interaction'
-          link 'https://www.hl7.org/fhir/us/core/CapabilityStatement-us-core-server.html'
+          link 'http://www.hl7.org/fhir/us/core/STU3.1.1/CapabilityStatement-us-core-server.html'
           optional
           description %(
             A server SHOULD support the Observation history interaction.
@@ -573,10 +573,10 @@ module Inferno
         metadata do
           id '10'
           name 'Observation resources returned during previous tests conform to the US Core Pediatric Head Occipital-frontal Circumference Percentile Profile.'
-          link 'http://hl7.org/fhir/us/core/StructureDefinition/head-occipital-frontal-circumference-percentile'
+          link 'http://hl7.org/fhir/us/core/STU3.1.1/StructureDefinition/head-occipital-frontal-circumference-percentile'
           description %(
 
-            This test verifies resources returned from the first search conform to the [US Core Observation Profile](http://hl7.org/fhir/us/core/StructureDefinition/head-occipital-frontal-circumference-percentile).
+            This test verifies resources returned from the first search conform to the [US Core Pediatric Head Occipital-frontal Circumference Percentile Profile](http://hl7.org/fhir/us/core/STU3.1.1/StructureDefinition/head-occipital-frontal-circumference-percentile).
             It verifies the presence of manditory elements and that elements with required bindgings contain appropriate values.
             CodeableConcept element bindings will fail if none of its codings have a code/system that is part of the bound ValueSet.
             Quantity, Coding, and code element bindings will fail if its code/system is not found in the valueset.
@@ -633,7 +633,7 @@ module Inferno
       test 'All must support elements are provided in the Observation resources returned.' do
         metadata do
           id '11'
-          link 'http://www.hl7.org/fhir/us/core/general-guidance.html#must-support'
+          link 'http://www.hl7.org/fhir/us/core/STU3.1.1/general-guidance.html#must-support'
           description %(
 
             US Core Responders SHALL be capable of populating all data elements as part of the query results as specified by the US Core Server Capability Statement.

--- a/lib/modules/uscore_v3.1.1/heartrate_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/heartrate_sequence.rb
@@ -160,7 +160,7 @@ module Inferno
         metadata do
           id '01'
           name 'Server returns valid results for Observation search by patient+code.'
-          link 'https://www.hl7.org/fhir/us/core/CapabilityStatement-us-core-server.html'
+          link 'http://www.hl7.org/fhir/us/core/STU3.1.1/CapabilityStatement-us-core-server.html'
           description %(
 
             A server SHALL support searching by patient+code on the Observation resource.
@@ -264,7 +264,7 @@ module Inferno
         metadata do
           id '02'
           name 'Server returns valid results for Observation search by patient+category+date.'
-          link 'https://www.hl7.org/fhir/us/core/CapabilityStatement-us-core-server.html'
+          link 'http://www.hl7.org/fhir/us/core/STU3.1.1/CapabilityStatement-us-core-server.html'
           description %(
 
             A server SHALL support searching by patient+category+date on the Observation resource.
@@ -322,7 +322,7 @@ module Inferno
         metadata do
           id '03'
           name 'Server returns valid results for Observation search by patient+category.'
-          link 'https://www.hl7.org/fhir/us/core/CapabilityStatement-us-core-server.html'
+          link 'http://www.hl7.org/fhir/us/core/STU3.1.1/CapabilityStatement-us-core-server.html'
           description %(
 
             A server SHALL support searching by patient+category on the Observation resource.
@@ -368,7 +368,7 @@ module Inferno
         metadata do
           id '04'
           name 'Server returns valid results for Observation search by patient+category+status.'
-          link 'https://www.hl7.org/fhir/us/core/CapabilityStatement-us-core-server.html'
+          link 'http://www.hl7.org/fhir/us/core/STU3.1.1/CapabilityStatement-us-core-server.html'
           optional
           description %(
 
@@ -414,7 +414,7 @@ module Inferno
         metadata do
           id '05'
           name 'Server returns valid results for Observation search by patient+code+date.'
-          link 'https://www.hl7.org/fhir/us/core/CapabilityStatement-us-core-server.html'
+          link 'http://www.hl7.org/fhir/us/core/STU3.1.1/CapabilityStatement-us-core-server.html'
           optional
           description %(
 
@@ -473,7 +473,7 @@ module Inferno
         metadata do
           id '06'
           name 'Server returns correct Observation resource from Observation read interaction'
-          link 'https://www.hl7.org/fhir/us/core/CapabilityStatement-us-core-server.html'
+          link 'http://www.hl7.org/fhir/us/core/STU3.1.1/CapabilityStatement-us-core-server.html'
           description %(
             A server SHALL support the Observation read interaction.
           )
@@ -490,7 +490,7 @@ module Inferno
         metadata do
           id '07'
           name 'Server returns correct Observation resource from Observation vread interaction'
-          link 'https://www.hl7.org/fhir/us/core/CapabilityStatement-us-core-server.html'
+          link 'http://www.hl7.org/fhir/us/core/STU3.1.1/CapabilityStatement-us-core-server.html'
           optional
           description %(
             A server SHOULD support the Observation vread interaction.
@@ -508,7 +508,7 @@ module Inferno
         metadata do
           id '08'
           name 'Server returns correct Observation resource from Observation history interaction'
-          link 'https://www.hl7.org/fhir/us/core/CapabilityStatement-us-core-server.html'
+          link 'http://www.hl7.org/fhir/us/core/STU3.1.1/CapabilityStatement-us-core-server.html'
           optional
           description %(
             A server SHOULD support the Observation history interaction.
@@ -576,7 +576,7 @@ module Inferno
           link 'http://hl7.org/fhir/StructureDefinition/heartrate'
           description %(
 
-            This test verifies resources returned from the first search conform to the [US Core Observation Profile](http://hl7.org/fhir/StructureDefinition/heartrate).
+            This test verifies resources returned from the first search conform to the [Observation Heart Rate Profile](http://hl7.org/fhir/StructureDefinition/heartrate).
             It verifies the presence of manditory elements and that elements with required bindgings contain appropriate values.
             CodeableConcept element bindings will fail if none of its codings have a code/system that is part of the bound ValueSet.
             Quantity, Coding, and code element bindings will fail if its code/system is not found in the valueset.
@@ -633,7 +633,7 @@ module Inferno
       test 'All must support elements are provided in the Observation resources returned.' do
         metadata do
           id '11'
-          link 'http://www.hl7.org/fhir/us/core/general-guidance.html#must-support'
+          link 'http://www.hl7.org/fhir/us/core/STU3.1.1/general-guidance.html#must-support'
           description %(
 
             US Core Responders SHALL be capable of populating all data elements as part of the query results as specified by the US Core Server Capability Statement.

--- a/lib/modules/uscore_v3.1.1/pediatric_bmi_for_age_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/pediatric_bmi_for_age_sequence.rb
@@ -52,7 +52,7 @@ module Inferno
         resources found for these elements.
 
         ## Profile Validation
-        Each resource returned from the first search is expected to conform to the [US Core Pediatric BMI for Age Observation Profile](http://hl7.org/fhir/us/core/StructureDefinition/pediatric-bmi-for-age).
+        Each resource returned from the first search is expected to conform to the [US Core Pediatric BMI for Age Observation Profile](http://hl7.org/fhir/us/core/STU3.1.1/StructureDefinition/pediatric-bmi-for-age).
         Each element is checked against teminology binding and cardinality requirements.
 
         Elements with a required binding is validated against its bound valueset. If the code/system in the element is not part
@@ -160,7 +160,7 @@ module Inferno
         metadata do
           id '01'
           name 'Server returns valid results for Observation search by patient+code.'
-          link 'https://www.hl7.org/fhir/us/core/CapabilityStatement-us-core-server.html'
+          link 'http://www.hl7.org/fhir/us/core/STU3.1.1/CapabilityStatement-us-core-server.html'
           description %(
 
             A server SHALL support searching by patient+code on the Observation resource.
@@ -264,7 +264,7 @@ module Inferno
         metadata do
           id '02'
           name 'Server returns valid results for Observation search by patient+category+date.'
-          link 'https://www.hl7.org/fhir/us/core/CapabilityStatement-us-core-server.html'
+          link 'http://www.hl7.org/fhir/us/core/STU3.1.1/CapabilityStatement-us-core-server.html'
           description %(
 
             A server SHALL support searching by patient+category+date on the Observation resource.
@@ -322,7 +322,7 @@ module Inferno
         metadata do
           id '03'
           name 'Server returns valid results for Observation search by patient+category.'
-          link 'https://www.hl7.org/fhir/us/core/CapabilityStatement-us-core-server.html'
+          link 'http://www.hl7.org/fhir/us/core/STU3.1.1/CapabilityStatement-us-core-server.html'
           description %(
 
             A server SHALL support searching by patient+category on the Observation resource.
@@ -368,7 +368,7 @@ module Inferno
         metadata do
           id '04'
           name 'Server returns valid results for Observation search by patient+category+status.'
-          link 'https://www.hl7.org/fhir/us/core/CapabilityStatement-us-core-server.html'
+          link 'http://www.hl7.org/fhir/us/core/STU3.1.1/CapabilityStatement-us-core-server.html'
           optional
           description %(
 
@@ -414,7 +414,7 @@ module Inferno
         metadata do
           id '05'
           name 'Server returns valid results for Observation search by patient+code+date.'
-          link 'https://www.hl7.org/fhir/us/core/CapabilityStatement-us-core-server.html'
+          link 'http://www.hl7.org/fhir/us/core/STU3.1.1/CapabilityStatement-us-core-server.html'
           optional
           description %(
 
@@ -473,7 +473,7 @@ module Inferno
         metadata do
           id '06'
           name 'Server returns correct Observation resource from Observation read interaction'
-          link 'https://www.hl7.org/fhir/us/core/CapabilityStatement-us-core-server.html'
+          link 'http://www.hl7.org/fhir/us/core/STU3.1.1/CapabilityStatement-us-core-server.html'
           description %(
             A server SHALL support the Observation read interaction.
           )
@@ -490,7 +490,7 @@ module Inferno
         metadata do
           id '07'
           name 'Server returns correct Observation resource from Observation vread interaction'
-          link 'https://www.hl7.org/fhir/us/core/CapabilityStatement-us-core-server.html'
+          link 'http://www.hl7.org/fhir/us/core/STU3.1.1/CapabilityStatement-us-core-server.html'
           optional
           description %(
             A server SHOULD support the Observation vread interaction.
@@ -508,7 +508,7 @@ module Inferno
         metadata do
           id '08'
           name 'Server returns correct Observation resource from Observation history interaction'
-          link 'https://www.hl7.org/fhir/us/core/CapabilityStatement-us-core-server.html'
+          link 'http://www.hl7.org/fhir/us/core/STU3.1.1/CapabilityStatement-us-core-server.html'
           optional
           description %(
             A server SHOULD support the Observation history interaction.
@@ -573,10 +573,10 @@ module Inferno
         metadata do
           id '10'
           name 'Observation resources returned during previous tests conform to the US Core Pediatric BMI for Age Observation Profile.'
-          link 'http://hl7.org/fhir/us/core/StructureDefinition/pediatric-bmi-for-age'
+          link 'http://hl7.org/fhir/us/core/STU3.1.1/StructureDefinition/pediatric-bmi-for-age'
           description %(
 
-            This test verifies resources returned from the first search conform to the [US Core Observation Profile](http://hl7.org/fhir/us/core/StructureDefinition/pediatric-bmi-for-age).
+            This test verifies resources returned from the first search conform to the [US Core Pediatric BMI for Age Observation Profile](http://hl7.org/fhir/us/core/STU3.1.1/StructureDefinition/pediatric-bmi-for-age).
             It verifies the presence of manditory elements and that elements with required bindgings contain appropriate values.
             CodeableConcept element bindings will fail if none of its codings have a code/system that is part of the bound ValueSet.
             Quantity, Coding, and code element bindings will fail if its code/system is not found in the valueset.
@@ -633,7 +633,7 @@ module Inferno
       test 'All must support elements are provided in the Observation resources returned.' do
         metadata do
           id '11'
-          link 'http://www.hl7.org/fhir/us/core/general-guidance.html#must-support'
+          link 'http://www.hl7.org/fhir/us/core/STU3.1.1/general-guidance.html#must-support'
           description %(
 
             US Core Responders SHALL be capable of populating all data elements as part of the query results as specified by the US Core Server Capability Statement.

--- a/lib/modules/uscore_v3.1.1/pediatric_weight_for_height_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/pediatric_weight_for_height_sequence.rb
@@ -52,7 +52,7 @@ module Inferno
         resources found for these elements.
 
         ## Profile Validation
-        Each resource returned from the first search is expected to conform to the [US Core Pediatric Weight for Height Observation Profile](http://hl7.org/fhir/us/core/StructureDefinition/pediatric-weight-for-height).
+        Each resource returned from the first search is expected to conform to the [US Core Pediatric Weight for Height Observation Profile](http://hl7.org/fhir/us/core/STU3.1.1/StructureDefinition/pediatric-weight-for-height).
         Each element is checked against teminology binding and cardinality requirements.
 
         Elements with a required binding is validated against its bound valueset. If the code/system in the element is not part
@@ -160,7 +160,7 @@ module Inferno
         metadata do
           id '01'
           name 'Server returns valid results for Observation search by patient+code.'
-          link 'https://www.hl7.org/fhir/us/core/CapabilityStatement-us-core-server.html'
+          link 'http://www.hl7.org/fhir/us/core/STU3.1.1/CapabilityStatement-us-core-server.html'
           description %(
 
             A server SHALL support searching by patient+code on the Observation resource.
@@ -264,7 +264,7 @@ module Inferno
         metadata do
           id '02'
           name 'Server returns valid results for Observation search by patient+category+date.'
-          link 'https://www.hl7.org/fhir/us/core/CapabilityStatement-us-core-server.html'
+          link 'http://www.hl7.org/fhir/us/core/STU3.1.1/CapabilityStatement-us-core-server.html'
           description %(
 
             A server SHALL support searching by patient+category+date on the Observation resource.
@@ -322,7 +322,7 @@ module Inferno
         metadata do
           id '03'
           name 'Server returns valid results for Observation search by patient+category.'
-          link 'https://www.hl7.org/fhir/us/core/CapabilityStatement-us-core-server.html'
+          link 'http://www.hl7.org/fhir/us/core/STU3.1.1/CapabilityStatement-us-core-server.html'
           description %(
 
             A server SHALL support searching by patient+category on the Observation resource.
@@ -368,7 +368,7 @@ module Inferno
         metadata do
           id '04'
           name 'Server returns valid results for Observation search by patient+category+status.'
-          link 'https://www.hl7.org/fhir/us/core/CapabilityStatement-us-core-server.html'
+          link 'http://www.hl7.org/fhir/us/core/STU3.1.1/CapabilityStatement-us-core-server.html'
           optional
           description %(
 
@@ -414,7 +414,7 @@ module Inferno
         metadata do
           id '05'
           name 'Server returns valid results for Observation search by patient+code+date.'
-          link 'https://www.hl7.org/fhir/us/core/CapabilityStatement-us-core-server.html'
+          link 'http://www.hl7.org/fhir/us/core/STU3.1.1/CapabilityStatement-us-core-server.html'
           optional
           description %(
 
@@ -473,7 +473,7 @@ module Inferno
         metadata do
           id '06'
           name 'Server returns correct Observation resource from Observation read interaction'
-          link 'https://www.hl7.org/fhir/us/core/CapabilityStatement-us-core-server.html'
+          link 'http://www.hl7.org/fhir/us/core/STU3.1.1/CapabilityStatement-us-core-server.html'
           description %(
             A server SHALL support the Observation read interaction.
           )
@@ -490,7 +490,7 @@ module Inferno
         metadata do
           id '07'
           name 'Server returns correct Observation resource from Observation vread interaction'
-          link 'https://www.hl7.org/fhir/us/core/CapabilityStatement-us-core-server.html'
+          link 'http://www.hl7.org/fhir/us/core/STU3.1.1/CapabilityStatement-us-core-server.html'
           optional
           description %(
             A server SHOULD support the Observation vread interaction.
@@ -508,7 +508,7 @@ module Inferno
         metadata do
           id '08'
           name 'Server returns correct Observation resource from Observation history interaction'
-          link 'https://www.hl7.org/fhir/us/core/CapabilityStatement-us-core-server.html'
+          link 'http://www.hl7.org/fhir/us/core/STU3.1.1/CapabilityStatement-us-core-server.html'
           optional
           description %(
             A server SHOULD support the Observation history interaction.
@@ -573,10 +573,10 @@ module Inferno
         metadata do
           id '10'
           name 'Observation resources returned during previous tests conform to the US Core Pediatric Weight for Height Observation Profile.'
-          link 'http://hl7.org/fhir/us/core/StructureDefinition/pediatric-weight-for-height'
+          link 'http://hl7.org/fhir/us/core/STU3.1.1/StructureDefinition/pediatric-weight-for-height'
           description %(
 
-            This test verifies resources returned from the first search conform to the [US Core Observation Profile](http://hl7.org/fhir/us/core/StructureDefinition/pediatric-weight-for-height).
+            This test verifies resources returned from the first search conform to the [US Core Pediatric Weight for Height Observation Profile](http://hl7.org/fhir/us/core/STU3.1.1/StructureDefinition/pediatric-weight-for-height).
             It verifies the presence of manditory elements and that elements with required bindgings contain appropriate values.
             CodeableConcept element bindings will fail if none of its codings have a code/system that is part of the bound ValueSet.
             Quantity, Coding, and code element bindings will fail if its code/system is not found in the valueset.
@@ -633,7 +633,7 @@ module Inferno
       test 'All must support elements are provided in the Observation resources returned.' do
         metadata do
           id '11'
-          link 'http://www.hl7.org/fhir/us/core/general-guidance.html#must-support'
+          link 'http://www.hl7.org/fhir/us/core/STU3.1.1/general-guidance.html#must-support'
           description %(
 
             US Core Responders SHALL be capable of populating all data elements as part of the query results as specified by the US Core Server Capability Statement.

--- a/lib/modules/uscore_v3.1.1/resprate_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/resprate_sequence.rb
@@ -160,7 +160,7 @@ module Inferno
         metadata do
           id '01'
           name 'Server returns valid results for Observation search by patient+code.'
-          link 'https://www.hl7.org/fhir/us/core/CapabilityStatement-us-core-server.html'
+          link 'http://www.hl7.org/fhir/us/core/STU3.1.1/CapabilityStatement-us-core-server.html'
           description %(
 
             A server SHALL support searching by patient+code on the Observation resource.
@@ -264,7 +264,7 @@ module Inferno
         metadata do
           id '02'
           name 'Server returns valid results for Observation search by patient+category+date.'
-          link 'https://www.hl7.org/fhir/us/core/CapabilityStatement-us-core-server.html'
+          link 'http://www.hl7.org/fhir/us/core/STU3.1.1/CapabilityStatement-us-core-server.html'
           description %(
 
             A server SHALL support searching by patient+category+date on the Observation resource.
@@ -322,7 +322,7 @@ module Inferno
         metadata do
           id '03'
           name 'Server returns valid results for Observation search by patient+category.'
-          link 'https://www.hl7.org/fhir/us/core/CapabilityStatement-us-core-server.html'
+          link 'http://www.hl7.org/fhir/us/core/STU3.1.1/CapabilityStatement-us-core-server.html'
           description %(
 
             A server SHALL support searching by patient+category on the Observation resource.
@@ -368,7 +368,7 @@ module Inferno
         metadata do
           id '04'
           name 'Server returns valid results for Observation search by patient+category+status.'
-          link 'https://www.hl7.org/fhir/us/core/CapabilityStatement-us-core-server.html'
+          link 'http://www.hl7.org/fhir/us/core/STU3.1.1/CapabilityStatement-us-core-server.html'
           optional
           description %(
 
@@ -414,7 +414,7 @@ module Inferno
         metadata do
           id '05'
           name 'Server returns valid results for Observation search by patient+code+date.'
-          link 'https://www.hl7.org/fhir/us/core/CapabilityStatement-us-core-server.html'
+          link 'http://www.hl7.org/fhir/us/core/STU3.1.1/CapabilityStatement-us-core-server.html'
           optional
           description %(
 
@@ -473,7 +473,7 @@ module Inferno
         metadata do
           id '06'
           name 'Server returns correct Observation resource from Observation read interaction'
-          link 'https://www.hl7.org/fhir/us/core/CapabilityStatement-us-core-server.html'
+          link 'http://www.hl7.org/fhir/us/core/STU3.1.1/CapabilityStatement-us-core-server.html'
           description %(
             A server SHALL support the Observation read interaction.
           )
@@ -490,7 +490,7 @@ module Inferno
         metadata do
           id '07'
           name 'Server returns correct Observation resource from Observation vread interaction'
-          link 'https://www.hl7.org/fhir/us/core/CapabilityStatement-us-core-server.html'
+          link 'http://www.hl7.org/fhir/us/core/STU3.1.1/CapabilityStatement-us-core-server.html'
           optional
           description %(
             A server SHOULD support the Observation vread interaction.
@@ -508,7 +508,7 @@ module Inferno
         metadata do
           id '08'
           name 'Server returns correct Observation resource from Observation history interaction'
-          link 'https://www.hl7.org/fhir/us/core/CapabilityStatement-us-core-server.html'
+          link 'http://www.hl7.org/fhir/us/core/STU3.1.1/CapabilityStatement-us-core-server.html'
           optional
           description %(
             A server SHOULD support the Observation history interaction.
@@ -576,7 +576,7 @@ module Inferno
           link 'http://hl7.org/fhir/StructureDefinition/resprate'
           description %(
 
-            This test verifies resources returned from the first search conform to the [US Core Observation Profile](http://hl7.org/fhir/StructureDefinition/resprate).
+            This test verifies resources returned from the first search conform to the [Observation Respiratory Rate Profile](http://hl7.org/fhir/StructureDefinition/resprate).
             It verifies the presence of manditory elements and that elements with required bindgings contain appropriate values.
             CodeableConcept element bindings will fail if none of its codings have a code/system that is part of the bound ValueSet.
             Quantity, Coding, and code element bindings will fail if its code/system is not found in the valueset.
@@ -633,7 +633,7 @@ module Inferno
       test 'All must support elements are provided in the Observation resources returned.' do
         metadata do
           id '11'
-          link 'http://www.hl7.org/fhir/us/core/general-guidance.html#must-support'
+          link 'http://www.hl7.org/fhir/us/core/STU3.1.1/general-guidance.html#must-support'
           description %(
 
             US Core Responders SHALL be capable of populating all data elements as part of the query results as specified by the US Core Server Capability Statement.

--- a/lib/modules/uscore_v3.1.1/us_core_allergyintolerance_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_allergyintolerance_sequence.rb
@@ -50,7 +50,7 @@ module Inferno
         resources found for these elements.
 
         ## Profile Validation
-        Each resource returned from the first search is expected to conform to the [US  Core AllergyIntolerance Profile](http://hl7.org/fhir/us/core/StructureDefinition/us-core-allergyintolerance).
+        Each resource returned from the first search is expected to conform to the [US  Core AllergyIntolerance Profile](http://hl7.org/fhir/us/core/STU3.1.1/StructureDefinition/us-core-allergyintolerance).
         Each element is checked against teminology binding and cardinality requirements.
 
         Elements with a required binding is validated against its bound valueset. If the code/system in the element is not part
@@ -134,7 +134,7 @@ module Inferno
         metadata do
           id '01'
           name 'Server returns valid results for AllergyIntolerance search by patient.'
-          link 'https://www.hl7.org/fhir/us/core/CapabilityStatement-us-core-server.html'
+          link 'http://www.hl7.org/fhir/us/core/STU3.1.1/CapabilityStatement-us-core-server.html'
           description %(
 
             A server SHALL support searching by patient on the AllergyIntolerance resource.
@@ -221,7 +221,7 @@ module Inferno
         metadata do
           id '02'
           name 'Server returns valid results for AllergyIntolerance search by patient+clinical-status.'
-          link 'https://www.hl7.org/fhir/us/core/CapabilityStatement-us-core-server.html'
+          link 'http://www.hl7.org/fhir/us/core/STU3.1.1/CapabilityStatement-us-core-server.html'
           optional
           description %(
 
@@ -266,7 +266,7 @@ module Inferno
         metadata do
           id '03'
           name 'Server returns correct AllergyIntolerance resource from AllergyIntolerance read interaction'
-          link 'https://www.hl7.org/fhir/us/core/CapabilityStatement-us-core-server.html'
+          link 'http://www.hl7.org/fhir/us/core/STU3.1.1/CapabilityStatement-us-core-server.html'
           description %(
             A server SHALL support the AllergyIntolerance read interaction.
           )
@@ -283,7 +283,7 @@ module Inferno
         metadata do
           id '04'
           name 'Server returns correct AllergyIntolerance resource from AllergyIntolerance vread interaction'
-          link 'https://www.hl7.org/fhir/us/core/CapabilityStatement-us-core-server.html'
+          link 'http://www.hl7.org/fhir/us/core/STU3.1.1/CapabilityStatement-us-core-server.html'
           optional
           description %(
             A server SHOULD support the AllergyIntolerance vread interaction.
@@ -301,7 +301,7 @@ module Inferno
         metadata do
           id '05'
           name 'Server returns correct AllergyIntolerance resource from AllergyIntolerance history interaction'
-          link 'https://www.hl7.org/fhir/us/core/CapabilityStatement-us-core-server.html'
+          link 'http://www.hl7.org/fhir/us/core/STU3.1.1/CapabilityStatement-us-core-server.html'
           optional
           description %(
             A server SHOULD support the AllergyIntolerance history interaction.
@@ -359,10 +359,10 @@ module Inferno
         metadata do
           id '07'
           name 'AllergyIntolerance resources returned during previous tests conform to the US  Core AllergyIntolerance Profile.'
-          link 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-allergyintolerance'
+          link 'http://hl7.org/fhir/us/core/STU3.1.1/StructureDefinition/us-core-allergyintolerance'
           description %(
 
-            This test verifies resources returned from the first search conform to the [US Core AllergyIntolerance Profile](http://hl7.org/fhir/us/core/StructureDefinition/us-core-allergyintolerance).
+            This test verifies resources returned from the first search conform to the [US  Core AllergyIntolerance Profile](http://hl7.org/fhir/us/core/STU3.1.1/StructureDefinition/us-core-allergyintolerance).
             It verifies the presence of manditory elements and that elements with required bindgings contain appropriate values.
             CodeableConcept element bindings will fail if none of its codings have a code/system that is part of the bound ValueSet.
             Quantity, Coding, and code element bindings will fail if its code/system is not found in the valueset.
@@ -435,7 +435,7 @@ module Inferno
       test 'All must support elements are provided in the AllergyIntolerance resources returned.' do
         metadata do
           id '08'
-          link 'http://www.hl7.org/fhir/us/core/general-guidance.html#must-support'
+          link 'http://www.hl7.org/fhir/us/core/STU3.1.1/general-guidance.html#must-support'
           description %(
 
             US Core Responders SHALL be capable of populating all data elements as part of the query results as specified by the US Core Server Capability Statement.

--- a/lib/modules/uscore_v3.1.1/us_core_careplan_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_careplan_sequence.rb
@@ -50,7 +50,7 @@ module Inferno
         resources found for these elements.
 
         ## Profile Validation
-        Each resource returned from the first search is expected to conform to the [US Core CarePlan Profile](http://hl7.org/fhir/us/core/StructureDefinition/us-core-careplan).
+        Each resource returned from the first search is expected to conform to the [US Core CarePlan Profile](http://hl7.org/fhir/us/core/STU3.1.1/StructureDefinition/us-core-careplan).
         Each element is checked against teminology binding and cardinality requirements.
 
         Elements with a required binding is validated against its bound valueset. If the code/system in the element is not part
@@ -145,7 +145,7 @@ module Inferno
         metadata do
           id '01'
           name 'Server returns valid results for CarePlan search by patient+category.'
-          link 'https://www.hl7.org/fhir/us/core/CapabilityStatement-us-core-server.html'
+          link 'http://www.hl7.org/fhir/us/core/STU3.1.1/CapabilityStatement-us-core-server.html'
           description %(
 
             A server SHALL support searching by patient+category on the CarePlan resource.
@@ -249,7 +249,7 @@ module Inferno
         metadata do
           id '02'
           name 'Server returns valid results for CarePlan search by patient+category+status.'
-          link 'https://www.hl7.org/fhir/us/core/CapabilityStatement-us-core-server.html'
+          link 'http://www.hl7.org/fhir/us/core/STU3.1.1/CapabilityStatement-us-core-server.html'
           optional
           description %(
 
@@ -295,7 +295,7 @@ module Inferno
         metadata do
           id '03'
           name 'Server returns correct CarePlan resource from CarePlan read interaction'
-          link 'https://www.hl7.org/fhir/us/core/CapabilityStatement-us-core-server.html'
+          link 'http://www.hl7.org/fhir/us/core/STU3.1.1/CapabilityStatement-us-core-server.html'
           description %(
             A server SHALL support the CarePlan read interaction.
           )
@@ -312,7 +312,7 @@ module Inferno
         metadata do
           id '04'
           name 'Server returns correct CarePlan resource from CarePlan vread interaction'
-          link 'https://www.hl7.org/fhir/us/core/CapabilityStatement-us-core-server.html'
+          link 'http://www.hl7.org/fhir/us/core/STU3.1.1/CapabilityStatement-us-core-server.html'
           optional
           description %(
             A server SHOULD support the CarePlan vread interaction.
@@ -330,7 +330,7 @@ module Inferno
         metadata do
           id '05'
           name 'Server returns correct CarePlan resource from CarePlan history interaction'
-          link 'https://www.hl7.org/fhir/us/core/CapabilityStatement-us-core-server.html'
+          link 'http://www.hl7.org/fhir/us/core/STU3.1.1/CapabilityStatement-us-core-server.html'
           optional
           description %(
             A server SHOULD support the CarePlan history interaction.
@@ -395,10 +395,10 @@ module Inferno
         metadata do
           id '07'
           name 'CarePlan resources returned during previous tests conform to the US Core CarePlan Profile.'
-          link 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-careplan'
+          link 'http://hl7.org/fhir/us/core/STU3.1.1/StructureDefinition/us-core-careplan'
           description %(
 
-            This test verifies resources returned from the first search conform to the [US Core CarePlan Profile](http://hl7.org/fhir/us/core/StructureDefinition/us-core-careplan).
+            This test verifies resources returned from the first search conform to the [US Core CarePlan Profile](http://hl7.org/fhir/us/core/STU3.1.1/StructureDefinition/us-core-careplan).
             It verifies the presence of manditory elements and that elements with required bindgings contain appropriate values.
             CodeableConcept element bindings will fail if none of its codings have a code/system that is part of the bound ValueSet.
             Quantity, Coding, and code element bindings will fail if its code/system is not found in the valueset.
@@ -455,7 +455,7 @@ module Inferno
       test 'All must support elements are provided in the CarePlan resources returned.' do
         metadata do
           id '08'
-          link 'http://www.hl7.org/fhir/us/core/general-guidance.html#must-support'
+          link 'http://www.hl7.org/fhir/us/core/STU3.1.1/general-guidance.html#must-support'
           description %(
 
             US Core Responders SHALL be capable of populating all data elements as part of the query results as specified by the US Core Server Capability Statement.

--- a/lib/modules/uscore_v3.1.1/us_core_careteam_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_careteam_sequence.rb
@@ -50,7 +50,7 @@ module Inferno
         resources found for these elements.
 
         ## Profile Validation
-        Each resource returned from the first search is expected to conform to the [US Core CareTeam Profile](http://hl7.org/fhir/us/core/StructureDefinition/us-core-careteam).
+        Each resource returned from the first search is expected to conform to the [US Core CareTeam Profile](http://hl7.org/fhir/us/core/STU3.1.1/StructureDefinition/us-core-careteam).
         Each element is checked against teminology binding and cardinality requirements.
 
         Elements with a required binding is validated against its bound valueset. If the code/system in the element is not part
@@ -127,7 +127,7 @@ module Inferno
         metadata do
           id '01'
           name 'Server returns valid results for CareTeam search by patient+status.'
-          link 'https://www.hl7.org/fhir/us/core/CapabilityStatement-us-core-server.html'
+          link 'http://www.hl7.org/fhir/us/core/STU3.1.1/CapabilityStatement-us-core-server.html'
           description %(
 
             A server SHALL support searching by patient+status on the CareTeam resource.
@@ -220,7 +220,7 @@ module Inferno
         metadata do
           id '02'
           name 'Server returns correct CareTeam resource from CareTeam read interaction'
-          link 'https://www.hl7.org/fhir/us/core/CapabilityStatement-us-core-server.html'
+          link 'http://www.hl7.org/fhir/us/core/STU3.1.1/CapabilityStatement-us-core-server.html'
           description %(
             A server SHALL support the CareTeam read interaction.
           )
@@ -237,7 +237,7 @@ module Inferno
         metadata do
           id '03'
           name 'Server returns correct CareTeam resource from CareTeam vread interaction'
-          link 'https://www.hl7.org/fhir/us/core/CapabilityStatement-us-core-server.html'
+          link 'http://www.hl7.org/fhir/us/core/STU3.1.1/CapabilityStatement-us-core-server.html'
           optional
           description %(
             A server SHOULD support the CareTeam vread interaction.
@@ -255,7 +255,7 @@ module Inferno
         metadata do
           id '04'
           name 'Server returns correct CareTeam resource from CareTeam history interaction'
-          link 'https://www.hl7.org/fhir/us/core/CapabilityStatement-us-core-server.html'
+          link 'http://www.hl7.org/fhir/us/core/STU3.1.1/CapabilityStatement-us-core-server.html'
           optional
           description %(
             A server SHOULD support the CareTeam history interaction.
@@ -318,10 +318,10 @@ module Inferno
         metadata do
           id '06'
           name 'CareTeam resources returned during previous tests conform to the US Core CareTeam Profile.'
-          link 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-careteam'
+          link 'http://hl7.org/fhir/us/core/STU3.1.1/StructureDefinition/us-core-careteam'
           description %(
 
-            This test verifies resources returned from the first search conform to the [US Core CareTeam Profile](http://hl7.org/fhir/us/core/StructureDefinition/us-core-careteam).
+            This test verifies resources returned from the first search conform to the [US Core CareTeam Profile](http://hl7.org/fhir/us/core/STU3.1.1/StructureDefinition/us-core-careteam).
             It verifies the presence of manditory elements and that elements with required bindgings contain appropriate values.
             CodeableConcept element bindings will fail if none of its codings have a code/system that is part of the bound ValueSet.
             Quantity, Coding, and code element bindings will fail if its code/system is not found in the valueset.
@@ -378,7 +378,7 @@ module Inferno
       test 'All must support elements are provided in the CareTeam resources returned.' do
         metadata do
           id '07'
-          link 'http://www.hl7.org/fhir/us/core/general-guidance.html#must-support'
+          link 'http://www.hl7.org/fhir/us/core/STU3.1.1/general-guidance.html#must-support'
           description %(
 
             US Core Responders SHALL be capable of populating all data elements as part of the query results as specified by the US Core Server Capability Statement.

--- a/lib/modules/uscore_v3.1.1/us_core_condition_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_condition_sequence.rb
@@ -50,7 +50,7 @@ module Inferno
         resources found for these elements.
 
         ## Profile Validation
-        Each resource returned from the first search is expected to conform to the [US Core Condition Profile](http://hl7.org/fhir/us/core/StructureDefinition/us-core-condition).
+        Each resource returned from the first search is expected to conform to the [US Core Condition Profile](http://hl7.org/fhir/us/core/STU3.1.1/StructureDefinition/us-core-condition).
         Each element is checked against teminology binding and cardinality requirements.
 
         Elements with a required binding is validated against its bound valueset. If the code/system in the element is not part
@@ -165,7 +165,7 @@ module Inferno
         metadata do
           id '01'
           name 'Server returns valid results for Condition search by patient.'
-          link 'https://www.hl7.org/fhir/us/core/CapabilityStatement-us-core-server.html'
+          link 'http://www.hl7.org/fhir/us/core/STU3.1.1/CapabilityStatement-us-core-server.html'
           description %(
 
             A server SHALL support searching by patient on the Condition resource.
@@ -252,7 +252,7 @@ module Inferno
         metadata do
           id '02'
           name 'Server returns valid results for Condition search by patient+category.'
-          link 'https://www.hl7.org/fhir/us/core/CapabilityStatement-us-core-server.html'
+          link 'http://www.hl7.org/fhir/us/core/STU3.1.1/CapabilityStatement-us-core-server.html'
           optional
           description %(
 
@@ -299,7 +299,7 @@ module Inferno
         metadata do
           id '03'
           name 'Server returns valid results for Condition search by patient+clinical-status.'
-          link 'https://www.hl7.org/fhir/us/core/CapabilityStatement-us-core-server.html'
+          link 'http://www.hl7.org/fhir/us/core/STU3.1.1/CapabilityStatement-us-core-server.html'
           optional
           description %(
 
@@ -344,7 +344,7 @@ module Inferno
         metadata do
           id '04'
           name 'Server returns valid results for Condition search by patient+code.'
-          link 'https://www.hl7.org/fhir/us/core/CapabilityStatement-us-core-server.html'
+          link 'http://www.hl7.org/fhir/us/core/STU3.1.1/CapabilityStatement-us-core-server.html'
           optional
           description %(
 
@@ -391,7 +391,7 @@ module Inferno
         metadata do
           id '05'
           name 'Server returns correct Condition resource from Condition read interaction'
-          link 'https://www.hl7.org/fhir/us/core/CapabilityStatement-us-core-server.html'
+          link 'http://www.hl7.org/fhir/us/core/STU3.1.1/CapabilityStatement-us-core-server.html'
           description %(
             A server SHALL support the Condition read interaction.
           )
@@ -408,7 +408,7 @@ module Inferno
         metadata do
           id '06'
           name 'Server returns correct Condition resource from Condition vread interaction'
-          link 'https://www.hl7.org/fhir/us/core/CapabilityStatement-us-core-server.html'
+          link 'http://www.hl7.org/fhir/us/core/STU3.1.1/CapabilityStatement-us-core-server.html'
           optional
           description %(
             A server SHOULD support the Condition vread interaction.
@@ -426,7 +426,7 @@ module Inferno
         metadata do
           id '07'
           name 'Server returns correct Condition resource from Condition history interaction'
-          link 'https://www.hl7.org/fhir/us/core/CapabilityStatement-us-core-server.html'
+          link 'http://www.hl7.org/fhir/us/core/STU3.1.1/CapabilityStatement-us-core-server.html'
           optional
           description %(
             A server SHOULD support the Condition history interaction.
@@ -484,10 +484,10 @@ module Inferno
         metadata do
           id '09'
           name 'Condition resources returned during previous tests conform to the US Core Condition Profile.'
-          link 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-condition'
+          link 'http://hl7.org/fhir/us/core/STU3.1.1/StructureDefinition/us-core-condition'
           description %(
 
-            This test verifies resources returned from the first search conform to the [US Core Condition Profile](http://hl7.org/fhir/us/core/StructureDefinition/us-core-condition).
+            This test verifies resources returned from the first search conform to the [US Core Condition Profile](http://hl7.org/fhir/us/core/STU3.1.1/StructureDefinition/us-core-condition).
             It verifies the presence of manditory elements and that elements with required bindgings contain appropriate values.
             CodeableConcept element bindings will fail if none of its codings have a code/system that is part of the bound ValueSet.
             Quantity, Coding, and code element bindings will fail if its code/system is not found in the valueset.
@@ -560,7 +560,7 @@ module Inferno
       test 'All must support elements are provided in the Condition resources returned.' do
         metadata do
           id '10'
-          link 'http://www.hl7.org/fhir/us/core/general-guidance.html#must-support'
+          link 'http://www.hl7.org/fhir/us/core/STU3.1.1/general-guidance.html#must-support'
           description %(
 
             US Core Responders SHALL be capable of populating all data elements as part of the query results as specified by the US Core Server Capability Statement.

--- a/lib/modules/uscore_v3.1.1/us_core_diagnosticreport_lab_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_diagnosticreport_lab_sequence.rb
@@ -55,7 +55,7 @@ module Inferno
         resources found for these elements.
 
         ## Profile Validation
-        Each resource returned from the first search is expected to conform to the [US Core DiagnosticReport Profile for Laboratory Results Reporting](http://hl7.org/fhir/us/core/StructureDefinition/us-core-diagnosticreport-lab).
+        Each resource returned from the first search is expected to conform to the [US Core DiagnosticReport Profile for Laboratory Results Reporting](http://hl7.org/fhir/us/core/STU3.1.1/StructureDefinition/us-core-diagnosticreport-lab).
         Each element is checked against teminology binding and cardinality requirements.
 
         Elements with a required binding is validated against its bound valueset. If the code/system in the element is not part
@@ -163,7 +163,7 @@ module Inferno
         metadata do
           id '01'
           name 'Server returns valid results for DiagnosticReport search by patient+category.'
-          link 'https://www.hl7.org/fhir/us/core/CapabilityStatement-us-core-server.html'
+          link 'http://www.hl7.org/fhir/us/core/STU3.1.1/CapabilityStatement-us-core-server.html'
           description %(
 
             A server SHALL support searching by patient+category on the DiagnosticReport resource.
@@ -267,7 +267,7 @@ module Inferno
         metadata do
           id '02'
           name 'Server returns valid results for DiagnosticReport search by patient.'
-          link 'https://www.hl7.org/fhir/us/core/CapabilityStatement-us-core-server.html'
+          link 'http://www.hl7.org/fhir/us/core/STU3.1.1/CapabilityStatement-us-core-server.html'
           description %(
 
             A server SHALL support searching by patient on the DiagnosticReport resource.
@@ -299,7 +299,7 @@ module Inferno
         metadata do
           id '03'
           name 'Server returns valid results for DiagnosticReport search by patient+category+date.'
-          link 'https://www.hl7.org/fhir/us/core/CapabilityStatement-us-core-server.html'
+          link 'http://www.hl7.org/fhir/us/core/STU3.1.1/CapabilityStatement-us-core-server.html'
           description %(
 
             A server SHALL support searching by patient+category+date on the DiagnosticReport resource.
@@ -357,7 +357,7 @@ module Inferno
         metadata do
           id '04'
           name 'Server returns valid results for DiagnosticReport search by patient+code.'
-          link 'https://www.hl7.org/fhir/us/core/CapabilityStatement-us-core-server.html'
+          link 'http://www.hl7.org/fhir/us/core/STU3.1.1/CapabilityStatement-us-core-server.html'
           description %(
 
             A server SHALL support searching by patient+code on the DiagnosticReport resource.
@@ -403,7 +403,7 @@ module Inferno
         metadata do
           id '05'
           name 'Server returns valid results for DiagnosticReport search by patient+status.'
-          link 'https://www.hl7.org/fhir/us/core/CapabilityStatement-us-core-server.html'
+          link 'http://www.hl7.org/fhir/us/core/STU3.1.1/CapabilityStatement-us-core-server.html'
           optional
           description %(
 
@@ -443,7 +443,7 @@ module Inferno
         metadata do
           id '06'
           name 'Server returns valid results for DiagnosticReport search by patient+code+date.'
-          link 'https://www.hl7.org/fhir/us/core/CapabilityStatement-us-core-server.html'
+          link 'http://www.hl7.org/fhir/us/core/STU3.1.1/CapabilityStatement-us-core-server.html'
           optional
           description %(
 
@@ -502,7 +502,7 @@ module Inferno
         metadata do
           id '07'
           name 'Server returns correct DiagnosticReport resource from DiagnosticReport read interaction'
-          link 'https://www.hl7.org/fhir/us/core/CapabilityStatement-us-core-server.html'
+          link 'http://www.hl7.org/fhir/us/core/STU3.1.1/CapabilityStatement-us-core-server.html'
           description %(
             A server SHALL support the DiagnosticReport read interaction.
           )
@@ -519,7 +519,7 @@ module Inferno
         metadata do
           id '08'
           name 'Server returns correct DiagnosticReport resource from DiagnosticReport vread interaction'
-          link 'https://www.hl7.org/fhir/us/core/CapabilityStatement-us-core-server.html'
+          link 'http://www.hl7.org/fhir/us/core/STU3.1.1/CapabilityStatement-us-core-server.html'
           optional
           description %(
             A server SHOULD support the DiagnosticReport vread interaction.
@@ -537,7 +537,7 @@ module Inferno
         metadata do
           id '09'
           name 'Server returns correct DiagnosticReport resource from DiagnosticReport history interaction'
-          link 'https://www.hl7.org/fhir/us/core/CapabilityStatement-us-core-server.html'
+          link 'http://www.hl7.org/fhir/us/core/STU3.1.1/CapabilityStatement-us-core-server.html'
           optional
           description %(
             A server SHOULD support the DiagnosticReport history interaction.
@@ -602,10 +602,10 @@ module Inferno
         metadata do
           id '11'
           name 'DiagnosticReport resources returned during previous tests conform to the US Core DiagnosticReport Profile for Laboratory Results Reporting.'
-          link 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-diagnosticreport-lab'
+          link 'http://hl7.org/fhir/us/core/STU3.1.1/StructureDefinition/us-core-diagnosticreport-lab'
           description %(
 
-            This test verifies resources returned from the first search conform to the [US Core DiagnosticReport Profile](http://hl7.org/fhir/us/core/StructureDefinition/us-core-diagnosticreport-lab).
+            This test verifies resources returned from the first search conform to the [US Core DiagnosticReport Profile for Laboratory Results Reporting](http://hl7.org/fhir/us/core/STU3.1.1/StructureDefinition/us-core-diagnosticreport-lab).
             It verifies the presence of manditory elements and that elements with required bindgings contain appropriate values.
             CodeableConcept element bindings will fail if none of its codings have a code/system that is part of the bound ValueSet.
             Quantity, Coding, and code element bindings will fail if its code/system is not found in the valueset.
@@ -662,7 +662,7 @@ module Inferno
       test 'All must support elements are provided in the DiagnosticReport resources returned.' do
         metadata do
           id '12'
-          link 'http://www.hl7.org/fhir/us/core/general-guidance.html#must-support'
+          link 'http://www.hl7.org/fhir/us/core/STU3.1.1/general-guidance.html#must-support'
           description %(
 
             US Core Responders SHALL be capable of populating all data elements as part of the query results as specified by the US Core Server Capability Statement.

--- a/lib/modules/uscore_v3.1.1/us_core_diagnosticreport_note_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_diagnosticreport_note_sequence.rb
@@ -55,7 +55,7 @@ module Inferno
         resources found for these elements.
 
         ## Profile Validation
-        Each resource returned from the first search is expected to conform to the [US Core DiagnosticReport Profile for Report and Note exchange](http://hl7.org/fhir/us/core/StructureDefinition/us-core-diagnosticreport-note).
+        Each resource returned from the first search is expected to conform to the [US Core DiagnosticReport Profile for Report and Note exchange](http://hl7.org/fhir/us/core/STU3.1.1/StructureDefinition/us-core-diagnosticreport-note).
         Each element is checked against teminology binding and cardinality requirements.
 
         Elements with a required binding is validated against its bound valueset. If the code/system in the element is not part
@@ -163,7 +163,7 @@ module Inferno
         metadata do
           id '01'
           name 'Server returns valid results for DiagnosticReport search by patient+category.'
-          link 'https://www.hl7.org/fhir/us/core/CapabilityStatement-us-core-server.html'
+          link 'http://www.hl7.org/fhir/us/core/STU3.1.1/CapabilityStatement-us-core-server.html'
           description %(
 
             A server SHALL support searching by patient+category on the DiagnosticReport resource.
@@ -267,7 +267,7 @@ module Inferno
         metadata do
           id '02'
           name 'Server returns valid results for DiagnosticReport search by patient.'
-          link 'https://www.hl7.org/fhir/us/core/CapabilityStatement-us-core-server.html'
+          link 'http://www.hl7.org/fhir/us/core/STU3.1.1/CapabilityStatement-us-core-server.html'
           description %(
 
             A server SHALL support searching by patient on the DiagnosticReport resource.
@@ -299,7 +299,7 @@ module Inferno
         metadata do
           id '03'
           name 'Server returns valid results for DiagnosticReport search by patient+category+date.'
-          link 'https://www.hl7.org/fhir/us/core/CapabilityStatement-us-core-server.html'
+          link 'http://www.hl7.org/fhir/us/core/STU3.1.1/CapabilityStatement-us-core-server.html'
           description %(
 
             A server SHALL support searching by patient+category+date on the DiagnosticReport resource.
@@ -357,7 +357,7 @@ module Inferno
         metadata do
           id '04'
           name 'Server returns valid results for DiagnosticReport search by patient+code.'
-          link 'https://www.hl7.org/fhir/us/core/CapabilityStatement-us-core-server.html'
+          link 'http://www.hl7.org/fhir/us/core/STU3.1.1/CapabilityStatement-us-core-server.html'
           description %(
 
             A server SHALL support searching by patient+code on the DiagnosticReport resource.
@@ -403,7 +403,7 @@ module Inferno
         metadata do
           id '05'
           name 'Server returns valid results for DiagnosticReport search by patient+status.'
-          link 'https://www.hl7.org/fhir/us/core/CapabilityStatement-us-core-server.html'
+          link 'http://www.hl7.org/fhir/us/core/STU3.1.1/CapabilityStatement-us-core-server.html'
           optional
           description %(
 
@@ -443,7 +443,7 @@ module Inferno
         metadata do
           id '06'
           name 'Server returns valid results for DiagnosticReport search by patient+code+date.'
-          link 'https://www.hl7.org/fhir/us/core/CapabilityStatement-us-core-server.html'
+          link 'http://www.hl7.org/fhir/us/core/STU3.1.1/CapabilityStatement-us-core-server.html'
           optional
           description %(
 
@@ -502,7 +502,7 @@ module Inferno
         metadata do
           id '07'
           name 'Server returns correct DiagnosticReport resource from DiagnosticReport read interaction'
-          link 'https://www.hl7.org/fhir/us/core/CapabilityStatement-us-core-server.html'
+          link 'http://www.hl7.org/fhir/us/core/STU3.1.1/CapabilityStatement-us-core-server.html'
           description %(
             A server SHALL support the DiagnosticReport read interaction.
           )
@@ -519,7 +519,7 @@ module Inferno
         metadata do
           id '08'
           name 'Server returns correct DiagnosticReport resource from DiagnosticReport vread interaction'
-          link 'https://www.hl7.org/fhir/us/core/CapabilityStatement-us-core-server.html'
+          link 'http://www.hl7.org/fhir/us/core/STU3.1.1/CapabilityStatement-us-core-server.html'
           optional
           description %(
             A server SHOULD support the DiagnosticReport vread interaction.
@@ -537,7 +537,7 @@ module Inferno
         metadata do
           id '09'
           name 'Server returns correct DiagnosticReport resource from DiagnosticReport history interaction'
-          link 'https://www.hl7.org/fhir/us/core/CapabilityStatement-us-core-server.html'
+          link 'http://www.hl7.org/fhir/us/core/STU3.1.1/CapabilityStatement-us-core-server.html'
           optional
           description %(
             A server SHOULD support the DiagnosticReport history interaction.
@@ -602,10 +602,10 @@ module Inferno
         metadata do
           id '11'
           name 'DiagnosticReport resources returned during previous tests conform to the US Core DiagnosticReport Profile for Report and Note exchange.'
-          link 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-diagnosticreport-note'
+          link 'http://hl7.org/fhir/us/core/STU3.1.1/StructureDefinition/us-core-diagnosticreport-note'
           description %(
 
-            This test verifies resources returned from the first search conform to the [US Core DiagnosticReport Profile](http://hl7.org/fhir/us/core/StructureDefinition/us-core-diagnosticreport-note).
+            This test verifies resources returned from the first search conform to the [US Core DiagnosticReport Profile for Report and Note exchange](http://hl7.org/fhir/us/core/STU3.1.1/StructureDefinition/us-core-diagnosticreport-note).
             It verifies the presence of manditory elements and that elements with required bindgings contain appropriate values.
             CodeableConcept element bindings will fail if none of its codings have a code/system that is part of the bound ValueSet.
             Quantity, Coding, and code element bindings will fail if its code/system is not found in the valueset.
@@ -662,7 +662,7 @@ module Inferno
       test 'All must support elements are provided in the DiagnosticReport resources returned.' do
         metadata do
           id '12'
-          link 'http://www.hl7.org/fhir/us/core/general-guidance.html#must-support'
+          link 'http://www.hl7.org/fhir/us/core/STU3.1.1/general-guidance.html#must-support'
           description %(
 
             US Core Responders SHALL be capable of populating all data elements as part of the query results as specified by the US Core Server Capability Statement.

--- a/lib/modules/uscore_v3.1.1/us_core_documentreference_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_documentreference_sequence.rb
@@ -54,7 +54,7 @@ module Inferno
         resources found for these elements.
 
         ## Profile Validation
-        Each resource returned from the first search is expected to conform to the [US Core DocumentReference Profile](http://hl7.org/fhir/us/core/StructureDefinition/us-core-documentreference).
+        Each resource returned from the first search is expected to conform to the [US Core DocumentReference Profile](http://hl7.org/fhir/us/core/STU3.1.1/StructureDefinition/us-core-documentreference).
         Each element is checked against teminology binding and cardinality requirements.
 
         Elements with a required binding is validated against its bound valueset. If the code/system in the element is not part
@@ -174,7 +174,7 @@ module Inferno
         metadata do
           id '01'
           name 'Server returns valid results for DocumentReference search by patient.'
-          link 'https://www.hl7.org/fhir/us/core/CapabilityStatement-us-core-server.html'
+          link 'http://www.hl7.org/fhir/us/core/STU3.1.1/CapabilityStatement-us-core-server.html'
           description %(
 
             A server SHALL support searching by patient on the DocumentReference resource.
@@ -261,7 +261,7 @@ module Inferno
         metadata do
           id '02'
           name 'Server returns valid results for DocumentReference search by _id.'
-          link 'https://www.hl7.org/fhir/us/core/CapabilityStatement-us-core-server.html'
+          link 'http://www.hl7.org/fhir/us/core/STU3.1.1/CapabilityStatement-us-core-server.html'
           description %(
 
             A server SHALL support searching by _id on the DocumentReference resource.
@@ -299,7 +299,7 @@ module Inferno
         metadata do
           id '03'
           name 'Server returns valid results for DocumentReference search by patient+type.'
-          link 'https://www.hl7.org/fhir/us/core/CapabilityStatement-us-core-server.html'
+          link 'http://www.hl7.org/fhir/us/core/STU3.1.1/CapabilityStatement-us-core-server.html'
           description %(
 
             A server SHALL support searching by patient+type on the DocumentReference resource.
@@ -345,7 +345,7 @@ module Inferno
         metadata do
           id '04'
           name 'Server returns valid results for DocumentReference search by patient+category+date.'
-          link 'https://www.hl7.org/fhir/us/core/CapabilityStatement-us-core-server.html'
+          link 'http://www.hl7.org/fhir/us/core/STU3.1.1/CapabilityStatement-us-core-server.html'
           description %(
 
             A server SHALL support searching by patient+category+date on the DocumentReference resource.
@@ -396,7 +396,7 @@ module Inferno
         metadata do
           id '05'
           name 'Server returns valid results for DocumentReference search by patient+category.'
-          link 'https://www.hl7.org/fhir/us/core/CapabilityStatement-us-core-server.html'
+          link 'http://www.hl7.org/fhir/us/core/STU3.1.1/CapabilityStatement-us-core-server.html'
           description %(
 
             A server SHALL support searching by patient+category on the DocumentReference resource.
@@ -442,7 +442,7 @@ module Inferno
         metadata do
           id '06'
           name 'Server returns valid results for DocumentReference search by patient+type+period.'
-          link 'https://www.hl7.org/fhir/us/core/CapabilityStatement-us-core-server.html'
+          link 'http://www.hl7.org/fhir/us/core/STU3.1.1/CapabilityStatement-us-core-server.html'
           optional
           description %(
 
@@ -501,7 +501,7 @@ module Inferno
         metadata do
           id '07'
           name 'Server returns valid results for DocumentReference search by patient+status.'
-          link 'https://www.hl7.org/fhir/us/core/CapabilityStatement-us-core-server.html'
+          link 'http://www.hl7.org/fhir/us/core/STU3.1.1/CapabilityStatement-us-core-server.html'
           optional
           description %(
 
@@ -541,7 +541,7 @@ module Inferno
         metadata do
           id '08'
           name 'Server returns correct DocumentReference resource from DocumentReference read interaction'
-          link 'https://www.hl7.org/fhir/us/core/CapabilityStatement-us-core-server.html'
+          link 'http://www.hl7.org/fhir/us/core/STU3.1.1/CapabilityStatement-us-core-server.html'
           description %(
             A server SHALL support the DocumentReference read interaction.
           )
@@ -558,7 +558,7 @@ module Inferno
         metadata do
           id '09'
           name 'Server returns correct DocumentReference resource from DocumentReference vread interaction'
-          link 'https://www.hl7.org/fhir/us/core/CapabilityStatement-us-core-server.html'
+          link 'http://www.hl7.org/fhir/us/core/STU3.1.1/CapabilityStatement-us-core-server.html'
           optional
           description %(
             A server SHOULD support the DocumentReference vread interaction.
@@ -576,7 +576,7 @@ module Inferno
         metadata do
           id '10'
           name 'Server returns correct DocumentReference resource from DocumentReference history interaction'
-          link 'https://www.hl7.org/fhir/us/core/CapabilityStatement-us-core-server.html'
+          link 'http://www.hl7.org/fhir/us/core/STU3.1.1/CapabilityStatement-us-core-server.html'
           optional
           description %(
             A server SHOULD support the DocumentReference history interaction.
@@ -634,10 +634,10 @@ module Inferno
         metadata do
           id '12'
           name 'DocumentReference resources returned during previous tests conform to the US Core DocumentReference Profile.'
-          link 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-documentreference'
+          link 'http://hl7.org/fhir/us/core/STU3.1.1/StructureDefinition/us-core-documentreference'
           description %(
 
-            This test verifies resources returned from the first search conform to the [US Core DocumentReference Profile](http://hl7.org/fhir/us/core/StructureDefinition/us-core-documentreference).
+            This test verifies resources returned from the first search conform to the [US Core DocumentReference Profile](http://hl7.org/fhir/us/core/STU3.1.1/StructureDefinition/us-core-documentreference).
             It verifies the presence of manditory elements and that elements with required bindgings contain appropriate values.
             CodeableConcept element bindings will fail if none of its codings have a code/system that is part of the bound ValueSet.
             Quantity, Coding, and code element bindings will fail if its code/system is not found in the valueset.
@@ -710,7 +710,7 @@ module Inferno
       test 'All must support elements are provided in the DocumentReference resources returned.' do
         metadata do
           id '13'
-          link 'http://www.hl7.org/fhir/us/core/general-guidance.html#must-support'
+          link 'http://www.hl7.org/fhir/us/core/STU3.1.1/general-guidance.html#must-support'
           description %(
 
             US Core Responders SHALL be capable of populating all data elements as part of the query results as specified by the US Core Server Capability Statement.

--- a/lib/modules/uscore_v3.1.1/us_core_encounter_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_encounter_sequence.rb
@@ -34,7 +34,7 @@ module Inferno
         resources found for these elements.
 
         ## Profile Validation
-        Each resource returned from the first search is expected to conform to the [US Core Encounter Profile](http://hl7.org/fhir/us/core/StructureDefinition/us-core-encounter).
+        Each resource returned from the first search is expected to conform to the [US Core Encounter Profile](http://hl7.org/fhir/us/core/STU3.1.1/StructureDefinition/us-core-encounter).
         Each element is checked against teminology binding and cardinality requirements.
 
         Elements with a required binding is validated against its bound valueset. If the code/system in the element is not part
@@ -151,7 +151,7 @@ module Inferno
         metadata do
           id '01'
           name 'Server returns correct Encounter resource from the Encounter read interaction'
-          link 'https://www.hl7.org/fhir/us/core/CapabilityStatement-us-core-server.html'
+          link 'http://www.hl7.org/fhir/us/core/STU3.1.1/CapabilityStatement-us-core-server.html'
           description %(
             This test will attempt to Reference to Encounter can be resolved and read.
           )
@@ -178,10 +178,10 @@ module Inferno
         metadata do
           id '02'
           name 'Encounter resources returned during previous tests conform to the US Core Encounter Profile.'
-          link 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-encounter'
+          link 'http://hl7.org/fhir/us/core/STU3.1.1/StructureDefinition/us-core-encounter'
           description %(
 
-            This test verifies resources returned from the first search conform to the [US Core Encounter Profile](http://hl7.org/fhir/us/core/StructureDefinition/us-core-encounter).
+            This test verifies resources returned from the first search conform to the [US Core Encounter Profile](http://hl7.org/fhir/us/core/STU3.1.1/StructureDefinition/us-core-encounter).
             It verifies the presence of manditory elements and that elements with required bindgings contain appropriate values.
             CodeableConcept element bindings will fail if none of its codings have a code/system that is part of the bound ValueSet.
             Quantity, Coding, and code element bindings will fail if its code/system is not found in the valueset.
@@ -238,7 +238,7 @@ module Inferno
       test 'All must support elements are provided in the Encounter resources returned.' do
         metadata do
           id '03'
-          link 'http://www.hl7.org/fhir/us/core/general-guidance.html#must-support'
+          link 'http://www.hl7.org/fhir/us/core/STU3.1.1/general-guidance.html#must-support'
           description %(
 
             US Core Responders SHALL be capable of populating all data elements as part of the query results as specified by the US Core Server Capability Statement.

--- a/lib/modules/uscore_v3.1.1/us_core_goal_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_goal_sequence.rb
@@ -50,7 +50,7 @@ module Inferno
         resources found for these elements.
 
         ## Profile Validation
-        Each resource returned from the first search is expected to conform to the [US Core Goal Profile](http://hl7.org/fhir/us/core/StructureDefinition/us-core-goal).
+        Each resource returned from the first search is expected to conform to the [US Core Goal Profile](http://hl7.org/fhir/us/core/STU3.1.1/StructureDefinition/us-core-goal).
         Each element is checked against teminology binding and cardinality requirements.
 
         Elements with a required binding is validated against its bound valueset. If the code/system in the element is not part
@@ -132,7 +132,7 @@ module Inferno
         metadata do
           id '01'
           name 'Server returns valid results for Goal search by patient.'
-          link 'https://www.hl7.org/fhir/us/core/CapabilityStatement-us-core-server.html'
+          link 'http://www.hl7.org/fhir/us/core/STU3.1.1/CapabilityStatement-us-core-server.html'
           description %(
 
             A server SHALL support searching by patient on the Goal resource.
@@ -219,7 +219,7 @@ module Inferno
         metadata do
           id '02'
           name 'Server returns valid results for Goal search by patient+lifecycle-status.'
-          link 'https://www.hl7.org/fhir/us/core/CapabilityStatement-us-core-server.html'
+          link 'http://www.hl7.org/fhir/us/core/STU3.1.1/CapabilityStatement-us-core-server.html'
           optional
           description %(
 
@@ -259,7 +259,7 @@ module Inferno
         metadata do
           id '03'
           name 'Server returns correct Goal resource from Goal read interaction'
-          link 'https://www.hl7.org/fhir/us/core/CapabilityStatement-us-core-server.html'
+          link 'http://www.hl7.org/fhir/us/core/STU3.1.1/CapabilityStatement-us-core-server.html'
           description %(
             A server SHALL support the Goal read interaction.
           )
@@ -276,7 +276,7 @@ module Inferno
         metadata do
           id '04'
           name 'Server returns correct Goal resource from Goal vread interaction'
-          link 'https://www.hl7.org/fhir/us/core/CapabilityStatement-us-core-server.html'
+          link 'http://www.hl7.org/fhir/us/core/STU3.1.1/CapabilityStatement-us-core-server.html'
           optional
           description %(
             A server SHOULD support the Goal vread interaction.
@@ -294,7 +294,7 @@ module Inferno
         metadata do
           id '05'
           name 'Server returns correct Goal resource from Goal history interaction'
-          link 'https://www.hl7.org/fhir/us/core/CapabilityStatement-us-core-server.html'
+          link 'http://www.hl7.org/fhir/us/core/STU3.1.1/CapabilityStatement-us-core-server.html'
           optional
           description %(
             A server SHOULD support the Goal history interaction.
@@ -352,10 +352,10 @@ module Inferno
         metadata do
           id '07'
           name 'Goal resources returned during previous tests conform to the US Core Goal Profile.'
-          link 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-goal'
+          link 'http://hl7.org/fhir/us/core/STU3.1.1/StructureDefinition/us-core-goal'
           description %(
 
-            This test verifies resources returned from the first search conform to the [US Core Goal Profile](http://hl7.org/fhir/us/core/StructureDefinition/us-core-goal).
+            This test verifies resources returned from the first search conform to the [US Core Goal Profile](http://hl7.org/fhir/us/core/STU3.1.1/StructureDefinition/us-core-goal).
             It verifies the presence of manditory elements and that elements with required bindgings contain appropriate values.
             CodeableConcept element bindings will fail if none of its codings have a code/system that is part of the bound ValueSet.
             Quantity, Coding, and code element bindings will fail if its code/system is not found in the valueset.
@@ -412,7 +412,7 @@ module Inferno
       test 'All must support elements are provided in the Goal resources returned.' do
         metadata do
           id '08'
-          link 'http://www.hl7.org/fhir/us/core/general-guidance.html#must-support'
+          link 'http://www.hl7.org/fhir/us/core/STU3.1.1/general-guidance.html#must-support'
           description %(
 
             US Core Responders SHALL be capable of populating all data elements as part of the query results as specified by the US Core Server Capability Statement.

--- a/lib/modules/uscore_v3.1.1/us_core_immunization_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_immunization_sequence.rb
@@ -50,7 +50,7 @@ module Inferno
         resources found for these elements.
 
         ## Profile Validation
-        Each resource returned from the first search is expected to conform to the [US Core Immunization Profile](http://hl7.org/fhir/us/core/StructureDefinition/us-core-immunization).
+        Each resource returned from the first search is expected to conform to the [US Core Immunization Profile](http://hl7.org/fhir/us/core/STU3.1.1/StructureDefinition/us-core-immunization).
         Each element is checked against teminology binding and cardinality requirements.
 
         Elements with a required binding is validated against its bound valueset. If the code/system in the element is not part
@@ -132,7 +132,7 @@ module Inferno
         metadata do
           id '01'
           name 'Server returns valid results for Immunization search by patient.'
-          link 'https://www.hl7.org/fhir/us/core/CapabilityStatement-us-core-server.html'
+          link 'http://www.hl7.org/fhir/us/core/STU3.1.1/CapabilityStatement-us-core-server.html'
           description %(
 
             A server SHALL support searching by patient on the Immunization resource.
@@ -219,7 +219,7 @@ module Inferno
         metadata do
           id '02'
           name 'Server returns valid results for Immunization search by patient+date.'
-          link 'https://www.hl7.org/fhir/us/core/CapabilityStatement-us-core-server.html'
+          link 'http://www.hl7.org/fhir/us/core/STU3.1.1/CapabilityStatement-us-core-server.html'
           optional
           description %(
 
@@ -272,7 +272,7 @@ module Inferno
         metadata do
           id '03'
           name 'Server returns valid results for Immunization search by patient+status.'
-          link 'https://www.hl7.org/fhir/us/core/CapabilityStatement-us-core-server.html'
+          link 'http://www.hl7.org/fhir/us/core/STU3.1.1/CapabilityStatement-us-core-server.html'
           optional
           description %(
 
@@ -312,7 +312,7 @@ module Inferno
         metadata do
           id '04'
           name 'Server returns correct Immunization resource from Immunization read interaction'
-          link 'https://www.hl7.org/fhir/us/core/CapabilityStatement-us-core-server.html'
+          link 'http://www.hl7.org/fhir/us/core/STU3.1.1/CapabilityStatement-us-core-server.html'
           description %(
             A server SHALL support the Immunization read interaction.
           )
@@ -329,7 +329,7 @@ module Inferno
         metadata do
           id '05'
           name 'Server returns correct Immunization resource from Immunization vread interaction'
-          link 'https://www.hl7.org/fhir/us/core/CapabilityStatement-us-core-server.html'
+          link 'http://www.hl7.org/fhir/us/core/STU3.1.1/CapabilityStatement-us-core-server.html'
           optional
           description %(
             A server SHOULD support the Immunization vread interaction.
@@ -347,7 +347,7 @@ module Inferno
         metadata do
           id '06'
           name 'Server returns correct Immunization resource from Immunization history interaction'
-          link 'https://www.hl7.org/fhir/us/core/CapabilityStatement-us-core-server.html'
+          link 'http://www.hl7.org/fhir/us/core/STU3.1.1/CapabilityStatement-us-core-server.html'
           optional
           description %(
             A server SHOULD support the Immunization history interaction.
@@ -405,10 +405,10 @@ module Inferno
         metadata do
           id '08'
           name 'Immunization resources returned during previous tests conform to the US Core Immunization Profile.'
-          link 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-immunization'
+          link 'http://hl7.org/fhir/us/core/STU3.1.1/StructureDefinition/us-core-immunization'
           description %(
 
-            This test verifies resources returned from the first search conform to the [US Core Immunization Profile](http://hl7.org/fhir/us/core/StructureDefinition/us-core-immunization).
+            This test verifies resources returned from the first search conform to the [US Core Immunization Profile](http://hl7.org/fhir/us/core/STU3.1.1/StructureDefinition/us-core-immunization).
             It verifies the presence of manditory elements and that elements with required bindgings contain appropriate values.
             CodeableConcept element bindings will fail if none of its codings have a code/system that is part of the bound ValueSet.
             Quantity, Coding, and code element bindings will fail if its code/system is not found in the valueset.
@@ -465,7 +465,7 @@ module Inferno
       test 'All must support elements are provided in the Immunization resources returned.' do
         metadata do
           id '09'
-          link 'http://www.hl7.org/fhir/us/core/general-guidance.html#must-support'
+          link 'http://www.hl7.org/fhir/us/core/STU3.1.1/general-guidance.html#must-support'
           description %(
 
             US Core Responders SHALL be capable of populating all data elements as part of the query results as specified by the US Core Server Capability Statement.

--- a/lib/modules/uscore_v3.1.1/us_core_implantable_device_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_implantable_device_sequence.rb
@@ -53,7 +53,7 @@ module Inferno
         resources found for these elements.
 
         ## Profile Validation
-        Each resource returned from the first search is expected to conform to the [US Core Implantable Device Profile](http://hl7.org/fhir/us/core/StructureDefinition/us-core-implantable-device).
+        Each resource returned from the first search is expected to conform to the [US Core Implantable Device Profile](http://hl7.org/fhir/us/core/STU3.1.1/StructureDefinition/us-core-implantable-device).
         Each element is checked against teminology binding and cardinality requirements.
 
         Elements with a required binding is validated against its bound valueset. If the code/system in the element is not part
@@ -104,7 +104,7 @@ module Inferno
         metadata do
           id '01'
           name 'Server returns valid results for Device search by patient.'
-          link 'https://www.hl7.org/fhir/us/core/CapabilityStatement-us-core-server.html'
+          link 'http://www.hl7.org/fhir/us/core/STU3.1.1/CapabilityStatement-us-core-server.html'
           description %(
 
             A server SHALL support searching by patient on the Device resource.
@@ -192,7 +192,7 @@ module Inferno
         metadata do
           id '02'
           name 'Server returns valid results for Device search by patient+type.'
-          link 'https://www.hl7.org/fhir/us/core/CapabilityStatement-us-core-server.html'
+          link 'http://www.hl7.org/fhir/us/core/STU3.1.1/CapabilityStatement-us-core-server.html'
           optional
           description %(
 
@@ -237,7 +237,7 @@ module Inferno
         metadata do
           id '03'
           name 'Server returns correct Device resource from Device read interaction'
-          link 'https://www.hl7.org/fhir/us/core/CapabilityStatement-us-core-server.html'
+          link 'http://www.hl7.org/fhir/us/core/STU3.1.1/CapabilityStatement-us-core-server.html'
           description %(
             A server SHALL support the Device read interaction.
           )
@@ -254,7 +254,7 @@ module Inferno
         metadata do
           id '04'
           name 'Server returns correct Device resource from Device vread interaction'
-          link 'https://www.hl7.org/fhir/us/core/CapabilityStatement-us-core-server.html'
+          link 'http://www.hl7.org/fhir/us/core/STU3.1.1/CapabilityStatement-us-core-server.html'
           optional
           description %(
             A server SHOULD support the Device vread interaction.
@@ -272,7 +272,7 @@ module Inferno
         metadata do
           id '05'
           name 'Server returns correct Device resource from Device history interaction'
-          link 'https://www.hl7.org/fhir/us/core/CapabilityStatement-us-core-server.html'
+          link 'http://www.hl7.org/fhir/us/core/STU3.1.1/CapabilityStatement-us-core-server.html'
           optional
           description %(
             A server SHOULD support the Device history interaction.
@@ -328,10 +328,10 @@ module Inferno
         metadata do
           id '07'
           name 'Device resources returned during previous tests conform to the US Core Implantable Device Profile.'
-          link 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-implantable-device'
+          link 'http://hl7.org/fhir/us/core/STU3.1.1/StructureDefinition/us-core-implantable-device'
           description %(
 
-            This test verifies resources returned from the first search conform to the [US Core Device Profile](http://hl7.org/fhir/us/core/StructureDefinition/us-core-implantable-device).
+            This test verifies resources returned from the first search conform to the [US Core Implantable Device Profile](http://hl7.org/fhir/us/core/STU3.1.1/StructureDefinition/us-core-implantable-device).
             It verifies the presence of manditory elements and that elements with required bindgings contain appropriate values.
             CodeableConcept element bindings will fail if none of its codings have a code/system that is part of the bound ValueSet.
             Quantity, Coding, and code element bindings will fail if its code/system is not found in the valueset.
@@ -388,7 +388,7 @@ module Inferno
       test 'All must support elements are provided in the Device resources returned.' do
         metadata do
           id '08'
-          link 'http://www.hl7.org/fhir/us/core/general-guidance.html#must-support'
+          link 'http://www.hl7.org/fhir/us/core/STU3.1.1/general-guidance.html#must-support'
           description %(
 
             US Core Responders SHALL be capable of populating all data elements as part of the query results as specified by the US Core Server Capability Statement.

--- a/lib/modules/uscore_v3.1.1/us_core_location_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_location_sequence.rb
@@ -34,7 +34,7 @@ module Inferno
         resources found for these elements.
 
         ## Profile Validation
-        Each resource returned from the first search is expected to conform to the [US Core Location Profile](http://hl7.org/fhir/us/core/StructureDefinition/us-core-location).
+        Each resource returned from the first search is expected to conform to the [US Core Location Profile](http://hl7.org/fhir/us/core/STU3.1.1/StructureDefinition/us-core-location).
         Each element is checked against teminology binding and cardinality requirements.
 
         Elements with a required binding is validated against its bound valueset. If the code/system in the element is not part
@@ -102,7 +102,7 @@ module Inferno
         metadata do
           id '01'
           name 'Server returns correct Location resource from the Location read interaction'
-          link 'https://www.hl7.org/fhir/us/core/CapabilityStatement-us-core-server.html'
+          link 'http://www.hl7.org/fhir/us/core/STU3.1.1/CapabilityStatement-us-core-server.html'
           description %(
             This test will attempt to Reference to Location can be resolved and read.
           )
@@ -129,10 +129,10 @@ module Inferno
         metadata do
           id '02'
           name 'Location resources returned during previous tests conform to the US Core Location Profile.'
-          link 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-location'
+          link 'http://hl7.org/fhir/us/core/STU3.1.1/StructureDefinition/us-core-location'
           description %(
 
-            This test verifies resources returned from the first search conform to the [US Core Location Profile](http://hl7.org/fhir/us/core/StructureDefinition/us-core-location).
+            This test verifies resources returned from the first search conform to the [US Core Location Profile](http://hl7.org/fhir/us/core/STU3.1.1/StructureDefinition/us-core-location).
             It verifies the presence of manditory elements and that elements with required bindgings contain appropriate values.
             CodeableConcept element bindings will fail if none of its codings have a code/system that is part of the bound ValueSet.
             Quantity, Coding, and code element bindings will fail if its code/system is not found in the valueset.
@@ -189,7 +189,7 @@ module Inferno
       test 'All must support elements are provided in the Location resources returned.' do
         metadata do
           id '03'
-          link 'http://www.hl7.org/fhir/us/core/general-guidance.html#must-support'
+          link 'http://www.hl7.org/fhir/us/core/STU3.1.1/general-guidance.html#must-support'
           description %(
 
             US Core Responders SHALL be capable of populating all data elements as part of the query results as specified by the US Core Server Capability Statement.

--- a/lib/modules/uscore_v3.1.1/us_core_medicationrequest_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_medicationrequest_sequence.rb
@@ -51,7 +51,7 @@ module Inferno
         resources found for these elements.
 
         ## Profile Validation
-        Each resource returned from the first search is expected to conform to the [US Core MedicationRequest Profile](http://hl7.org/fhir/us/core/StructureDefinition/us-core-medicationrequest).
+        Each resource returned from the first search is expected to conform to the [US Core MedicationRequest Profile](http://hl7.org/fhir/us/core/STU3.1.1/StructureDefinition/us-core-medicationrequest).
         Each element is checked against teminology binding and cardinality requirements.
 
         Elements with a required binding is validated against its bound valueset. If the code/system in the element is not part
@@ -176,7 +176,7 @@ module Inferno
         metadata do
           id '01'
           name 'Server returns valid results for MedicationRequest search by patient+intent.'
-          link 'https://www.hl7.org/fhir/us/core/CapabilityStatement-us-core-server.html'
+          link 'http://www.hl7.org/fhir/us/core/STU3.1.1/CapabilityStatement-us-core-server.html'
           description %(
 
             A server SHALL support searching by patient+intent on the MedicationRequest resource.
@@ -281,7 +281,7 @@ module Inferno
         metadata do
           id '02'
           name 'Server returns valid results for MedicationRequest search by patient+intent+status.'
-          link 'https://www.hl7.org/fhir/us/core/CapabilityStatement-us-core-server.html'
+          link 'http://www.hl7.org/fhir/us/core/STU3.1.1/CapabilityStatement-us-core-server.html'
           description %(
 
             A server SHALL support searching by patient+intent+status on the MedicationRequest resource.
@@ -331,7 +331,7 @@ module Inferno
         metadata do
           id '03'
           name 'Server returns valid results for MedicationRequest search by patient+intent+encounter.'
-          link 'https://www.hl7.org/fhir/us/core/CapabilityStatement-us-core-server.html'
+          link 'http://www.hl7.org/fhir/us/core/STU3.1.1/CapabilityStatement-us-core-server.html'
           optional
           description %(
 
@@ -384,7 +384,7 @@ module Inferno
         metadata do
           id '04'
           name 'Server returns valid results for MedicationRequest search by patient+intent+authoredon.'
-          link 'https://www.hl7.org/fhir/us/core/CapabilityStatement-us-core-server.html'
+          link 'http://www.hl7.org/fhir/us/core/STU3.1.1/CapabilityStatement-us-core-server.html'
           optional
           description %(
 
@@ -441,7 +441,7 @@ module Inferno
         metadata do
           id '05'
           name 'Server returns correct MedicationRequest resource from MedicationRequest read interaction'
-          link 'https://www.hl7.org/fhir/us/core/CapabilityStatement-us-core-server.html'
+          link 'http://www.hl7.org/fhir/us/core/STU3.1.1/CapabilityStatement-us-core-server.html'
           description %(
             A server SHALL support the MedicationRequest read interaction.
           )
@@ -458,7 +458,7 @@ module Inferno
         metadata do
           id '06'
           name 'Server returns correct MedicationRequest resource from MedicationRequest vread interaction'
-          link 'https://www.hl7.org/fhir/us/core/CapabilityStatement-us-core-server.html'
+          link 'http://www.hl7.org/fhir/us/core/STU3.1.1/CapabilityStatement-us-core-server.html'
           optional
           description %(
             A server SHOULD support the MedicationRequest vread interaction.
@@ -476,7 +476,7 @@ module Inferno
         metadata do
           id '07'
           name 'Server returns correct MedicationRequest resource from MedicationRequest history interaction'
-          link 'https://www.hl7.org/fhir/us/core/CapabilityStatement-us-core-server.html'
+          link 'http://www.hl7.org/fhir/us/core/STU3.1.1/CapabilityStatement-us-core-server.html'
           optional
           description %(
             A server SHOULD support the MedicationRequest history interaction.
@@ -579,10 +579,10 @@ module Inferno
         metadata do
           id '10'
           name 'MedicationRequest resources returned during previous tests conform to the US Core MedicationRequest Profile.'
-          link 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-medicationrequest'
+          link 'http://hl7.org/fhir/us/core/STU3.1.1/StructureDefinition/us-core-medicationrequest'
           description %(
 
-            This test verifies resources returned from the first search conform to the [US Core MedicationRequest Profile](http://hl7.org/fhir/us/core/StructureDefinition/us-core-medicationrequest).
+            This test verifies resources returned from the first search conform to the [US Core MedicationRequest Profile](http://hl7.org/fhir/us/core/STU3.1.1/StructureDefinition/us-core-medicationrequest).
             It verifies the presence of manditory elements and that elements with required bindgings contain appropriate values.
             CodeableConcept element bindings will fail if none of its codings have a code/system that is part of the bound ValueSet.
             Quantity, Coding, and code element bindings will fail if its code/system is not found in the valueset.
@@ -640,7 +640,7 @@ module Inferno
         metadata do
           id '11'
           name 'Medication resources returned conform to US Core v3.1.1 profiles'
-          link 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-medicationrequest'
+          link 'http://hl7.org/fhir/us/core/STU3.1.1/StructureDefinition-us-core-medicationrequest.html'
           description %(
 
               This test checks if the resources returned from prior searches conform to the US Core profiles.
@@ -660,7 +660,7 @@ module Inferno
       test 'All must support elements are provided in the MedicationRequest resources returned.' do
         metadata do
           id '12'
-          link 'http://www.hl7.org/fhir/us/core/general-guidance.html#must-support'
+          link 'http://www.hl7.org/fhir/us/core/STU3.1.1/general-guidance.html#must-support'
           description %(
 
             US Core Responders SHALL be capable of populating all data elements as part of the query results as specified by the US Core Server Capability Statement.

--- a/lib/modules/uscore_v3.1.1/us_core_observation_lab_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_observation_lab_sequence.rb
@@ -52,7 +52,7 @@ module Inferno
         resources found for these elements.
 
         ## Profile Validation
-        Each resource returned from the first search is expected to conform to the [US Core Laboratory Result Observation Profile](http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-lab).
+        Each resource returned from the first search is expected to conform to the [US Core Laboratory Result Observation Profile](http://hl7.org/fhir/us/core/STU3.1.1/StructureDefinition/us-core-observation-lab).
         Each element is checked against teminology binding and cardinality requirements.
 
         Elements with a required binding is validated against its bound valueset. If the code/system in the element is not part
@@ -160,7 +160,7 @@ module Inferno
         metadata do
           id '01'
           name 'Server returns valid results for Observation search by patient+category.'
-          link 'https://www.hl7.org/fhir/us/core/CapabilityStatement-us-core-server.html'
+          link 'http://www.hl7.org/fhir/us/core/STU3.1.1/CapabilityStatement-us-core-server.html'
           description %(
 
             A server SHALL support searching by patient+category on the Observation resource.
@@ -264,7 +264,7 @@ module Inferno
         metadata do
           id '02'
           name 'Server returns valid results for Observation search by patient+code.'
-          link 'https://www.hl7.org/fhir/us/core/CapabilityStatement-us-core-server.html'
+          link 'http://www.hl7.org/fhir/us/core/STU3.1.1/CapabilityStatement-us-core-server.html'
           description %(
 
             A server SHALL support searching by patient+code on the Observation resource.
@@ -310,7 +310,7 @@ module Inferno
         metadata do
           id '03'
           name 'Server returns valid results for Observation search by patient+category+date.'
-          link 'https://www.hl7.org/fhir/us/core/CapabilityStatement-us-core-server.html'
+          link 'http://www.hl7.org/fhir/us/core/STU3.1.1/CapabilityStatement-us-core-server.html'
           description %(
 
             A server SHALL support searching by patient+category+date on the Observation resource.
@@ -368,7 +368,7 @@ module Inferno
         metadata do
           id '04'
           name 'Server returns valid results for Observation search by patient+category+status.'
-          link 'https://www.hl7.org/fhir/us/core/CapabilityStatement-us-core-server.html'
+          link 'http://www.hl7.org/fhir/us/core/STU3.1.1/CapabilityStatement-us-core-server.html'
           optional
           description %(
 
@@ -414,7 +414,7 @@ module Inferno
         metadata do
           id '05'
           name 'Server returns valid results for Observation search by patient+code+date.'
-          link 'https://www.hl7.org/fhir/us/core/CapabilityStatement-us-core-server.html'
+          link 'http://www.hl7.org/fhir/us/core/STU3.1.1/CapabilityStatement-us-core-server.html'
           optional
           description %(
 
@@ -473,7 +473,7 @@ module Inferno
         metadata do
           id '06'
           name 'Server returns correct Observation resource from Observation read interaction'
-          link 'https://www.hl7.org/fhir/us/core/CapabilityStatement-us-core-server.html'
+          link 'http://www.hl7.org/fhir/us/core/STU3.1.1/CapabilityStatement-us-core-server.html'
           description %(
             A server SHALL support the Observation read interaction.
           )
@@ -490,7 +490,7 @@ module Inferno
         metadata do
           id '07'
           name 'Server returns correct Observation resource from Observation vread interaction'
-          link 'https://www.hl7.org/fhir/us/core/CapabilityStatement-us-core-server.html'
+          link 'http://www.hl7.org/fhir/us/core/STU3.1.1/CapabilityStatement-us-core-server.html'
           optional
           description %(
             A server SHOULD support the Observation vread interaction.
@@ -508,7 +508,7 @@ module Inferno
         metadata do
           id '08'
           name 'Server returns correct Observation resource from Observation history interaction'
-          link 'https://www.hl7.org/fhir/us/core/CapabilityStatement-us-core-server.html'
+          link 'http://www.hl7.org/fhir/us/core/STU3.1.1/CapabilityStatement-us-core-server.html'
           optional
           description %(
             A server SHOULD support the Observation history interaction.
@@ -573,10 +573,10 @@ module Inferno
         metadata do
           id '10'
           name 'Observation resources returned during previous tests conform to the US Core Laboratory Result Observation Profile.'
-          link 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-lab'
+          link 'http://hl7.org/fhir/us/core/STU3.1.1/StructureDefinition/us-core-observation-lab'
           description %(
 
-            This test verifies resources returned from the first search conform to the [US Core Observation Profile](http://hl7.org/fhir/us/core/StructureDefinition/us-core-observation-lab).
+            This test verifies resources returned from the first search conform to the [US Core Laboratory Result Observation Profile](http://hl7.org/fhir/us/core/STU3.1.1/StructureDefinition/us-core-observation-lab).
             It verifies the presence of manditory elements and that elements with required bindgings contain appropriate values.
             CodeableConcept element bindings will fail if none of its codings have a code/system that is part of the bound ValueSet.
             Quantity, Coding, and code element bindings will fail if its code/system is not found in the valueset.
@@ -633,7 +633,7 @@ module Inferno
       test 'All must support elements are provided in the Observation resources returned.' do
         metadata do
           id '11'
-          link 'http://www.hl7.org/fhir/us/core/general-guidance.html#must-support'
+          link 'http://www.hl7.org/fhir/us/core/STU3.1.1/general-guidance.html#must-support'
           description %(
 
             US Core Responders SHALL be capable of populating all data elements as part of the query results as specified by the US Core Server Capability Statement.

--- a/lib/modules/uscore_v3.1.1/us_core_organization_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_organization_sequence.rb
@@ -34,7 +34,7 @@ module Inferno
         resources found for these elements.
 
         ## Profile Validation
-        Each resource returned from the first search is expected to conform to the [US Core Organization Profile](http://hl7.org/fhir/us/core/StructureDefinition/us-core-organization).
+        Each resource returned from the first search is expected to conform to the [US Core Organization Profile](http://hl7.org/fhir/us/core/STU3.1.1/StructureDefinition/us-core-organization).
         Each element is checked against teminology binding and cardinality requirements.
 
         Elements with a required binding is validated against its bound valueset. If the code/system in the element is not part
@@ -84,7 +84,7 @@ module Inferno
         metadata do
           id '01'
           name 'Server returns correct Organization resource from the Organization read interaction'
-          link 'https://www.hl7.org/fhir/us/core/CapabilityStatement-us-core-server.html'
+          link 'http://www.hl7.org/fhir/us/core/STU3.1.1/CapabilityStatement-us-core-server.html'
           description %(
             This test will attempt to Reference to Organization can be resolved and read.
           )
@@ -111,10 +111,10 @@ module Inferno
         metadata do
           id '02'
           name 'Organization resources returned during previous tests conform to the US Core Organization Profile.'
-          link 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-organization'
+          link 'http://hl7.org/fhir/us/core/STU3.1.1/StructureDefinition/us-core-organization'
           description %(
 
-            This test verifies resources returned from the first search conform to the [US Core Organization Profile](http://hl7.org/fhir/us/core/StructureDefinition/us-core-organization).
+            This test verifies resources returned from the first search conform to the [US Core Organization Profile](http://hl7.org/fhir/us/core/STU3.1.1/StructureDefinition/us-core-organization).
             It verifies the presence of manditory elements and that elements with required bindgings contain appropriate values.
             CodeableConcept element bindings will fail if none of its codings have a code/system that is part of the bound ValueSet.
             Quantity, Coding, and code element bindings will fail if its code/system is not found in the valueset.
@@ -171,7 +171,7 @@ module Inferno
       test 'All must support elements are provided in the Organization resources returned.' do
         metadata do
           id '03'
-          link 'http://www.hl7.org/fhir/us/core/general-guidance.html#must-support'
+          link 'http://www.hl7.org/fhir/us/core/STU3.1.1/general-guidance.html#must-support'
           description %(
 
             US Core Responders SHALL be capable of populating all data elements as part of the query results as specified by the US Core Server Capability Statement.

--- a/lib/modules/uscore_v3.1.1/us_core_patient_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_patient_sequence.rb
@@ -54,7 +54,7 @@ module Inferno
         resources found for these elements.
 
         ## Profile Validation
-        Each resource returned from the first search is expected to conform to the [US Core Patient Profile](http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient).
+        Each resource returned from the first search is expected to conform to the [US Core Patient Profile](http://hl7.org/fhir/us/core/STU3.1.1/StructureDefinition/us-core-patient).
         Each element is checked against teminology binding and cardinality requirements.
 
         Elements with a required binding is validated against its bound valueset. If the code/system in the element is not part
@@ -136,7 +136,7 @@ module Inferno
         metadata do
           id '01'
           name 'Server returns valid results for Patient search by _id.'
-          link 'https://www.hl7.org/fhir/us/core/CapabilityStatement-us-core-server.html'
+          link 'http://www.hl7.org/fhir/us/core/STU3.1.1/CapabilityStatement-us-core-server.html'
           description %(
 
             A server SHALL support searching by _id on the Patient resource.
@@ -211,7 +211,7 @@ module Inferno
         metadata do
           id '02'
           name 'Server returns valid results for Patient search by identifier.'
-          link 'https://www.hl7.org/fhir/us/core/CapabilityStatement-us-core-server.html'
+          link 'http://www.hl7.org/fhir/us/core/STU3.1.1/CapabilityStatement-us-core-server.html'
           description %(
 
             A server SHALL support searching by identifier on the Patient resource.
@@ -252,7 +252,7 @@ module Inferno
         metadata do
           id '03'
           name 'Server returns valid results for Patient search by name.'
-          link 'https://www.hl7.org/fhir/us/core/CapabilityStatement-us-core-server.html'
+          link 'http://www.hl7.org/fhir/us/core/STU3.1.1/CapabilityStatement-us-core-server.html'
           description %(
 
             A server SHALL support searching by name on the Patient resource.
@@ -288,7 +288,7 @@ module Inferno
         metadata do
           id '04'
           name 'Server returns valid results for Patient search by birthdate+name.'
-          link 'https://www.hl7.org/fhir/us/core/CapabilityStatement-us-core-server.html'
+          link 'http://www.hl7.org/fhir/us/core/STU3.1.1/CapabilityStatement-us-core-server.html'
           description %(
 
             A server SHALL support searching by birthdate+name on the Patient resource.
@@ -325,7 +325,7 @@ module Inferno
         metadata do
           id '05'
           name 'Server returns valid results for Patient search by gender+name.'
-          link 'https://www.hl7.org/fhir/us/core/CapabilityStatement-us-core-server.html'
+          link 'http://www.hl7.org/fhir/us/core/STU3.1.1/CapabilityStatement-us-core-server.html'
           description %(
 
             A server SHALL support searching by gender+name on the Patient resource.
@@ -362,7 +362,7 @@ module Inferno
         metadata do
           id '06'
           name 'Server returns valid results for Patient search by birthdate+family.'
-          link 'https://www.hl7.org/fhir/us/core/CapabilityStatement-us-core-server.html'
+          link 'http://www.hl7.org/fhir/us/core/STU3.1.1/CapabilityStatement-us-core-server.html'
           optional
           description %(
 
@@ -400,7 +400,7 @@ module Inferno
         metadata do
           id '07'
           name 'Server returns valid results for Patient search by family+gender.'
-          link 'https://www.hl7.org/fhir/us/core/CapabilityStatement-us-core-server.html'
+          link 'http://www.hl7.org/fhir/us/core/STU3.1.1/CapabilityStatement-us-core-server.html'
           optional
           description %(
 
@@ -438,7 +438,7 @@ module Inferno
         metadata do
           id '08'
           name 'Server returns correct Patient resource from Patient read interaction'
-          link 'https://www.hl7.org/fhir/us/core/CapabilityStatement-us-core-server.html'
+          link 'http://www.hl7.org/fhir/us/core/STU3.1.1/CapabilityStatement-us-core-server.html'
           description %(
             A server SHALL support the Patient read interaction.
           )
@@ -455,7 +455,7 @@ module Inferno
         metadata do
           id '09'
           name 'Server returns correct Patient resource from Patient vread interaction'
-          link 'https://www.hl7.org/fhir/us/core/CapabilityStatement-us-core-server.html'
+          link 'http://www.hl7.org/fhir/us/core/STU3.1.1/CapabilityStatement-us-core-server.html'
           optional
           description %(
             A server SHOULD support the Patient vread interaction.
@@ -473,7 +473,7 @@ module Inferno
         metadata do
           id '10'
           name 'Server returns correct Patient resource from Patient history interaction'
-          link 'https://www.hl7.org/fhir/us/core/CapabilityStatement-us-core-server.html'
+          link 'http://www.hl7.org/fhir/us/core/STU3.1.1/CapabilityStatement-us-core-server.html'
           optional
           description %(
             A server SHOULD support the Patient history interaction.
@@ -529,10 +529,10 @@ module Inferno
         metadata do
           id '12'
           name 'Patient resources returned during previous tests conform to the US Core Patient Profile.'
-          link 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient'
+          link 'http://hl7.org/fhir/us/core/STU3.1.1/StructureDefinition/us-core-patient'
           description %(
 
-            This test verifies resources returned from the first search conform to the [US Core Patient Profile](http://hl7.org/fhir/us/core/StructureDefinition/us-core-patient).
+            This test verifies resources returned from the first search conform to the [US Core Patient Profile](http://hl7.org/fhir/us/core/STU3.1.1/StructureDefinition/us-core-patient).
             It verifies the presence of manditory elements and that elements with required bindgings contain appropriate values.
             CodeableConcept element bindings will fail if none of its codings have a code/system that is part of the bound ValueSet.
             Quantity, Coding, and code element bindings will fail if its code/system is not found in the valueset.
@@ -589,7 +589,7 @@ module Inferno
       test 'All must support elements are provided in the Patient resources returned.' do
         metadata do
           id '13'
-          link 'http://www.hl7.org/fhir/us/core/general-guidance.html#must-support'
+          link 'http://www.hl7.org/fhir/us/core/STU3.1.1/general-guidance.html#must-support'
           description %(
 
             US Core Responders SHALL be capable of populating all data elements as part of the query results as specified by the US Core Server Capability Statement.

--- a/lib/modules/uscore_v3.1.1/us_core_practitioner_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_practitioner_sequence.rb
@@ -34,7 +34,7 @@ module Inferno
         resources found for these elements.
 
         ## Profile Validation
-        Each resource returned from the first search is expected to conform to the [US Core Practitioner Profile](http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitioner).
+        Each resource returned from the first search is expected to conform to the [US Core Practitioner Profile](http://hl7.org/fhir/us/core/STU3.1.1/StructureDefinition/us-core-practitioner).
         Each element is checked against teminology binding and cardinality requirements.
 
         Elements with a required binding is validated against its bound valueset. If the code/system in the element is not part
@@ -88,7 +88,7 @@ module Inferno
         metadata do
           id '01'
           name 'Server returns correct Practitioner resource from the Practitioner read interaction'
-          link 'https://www.hl7.org/fhir/us/core/CapabilityStatement-us-core-server.html'
+          link 'http://www.hl7.org/fhir/us/core/STU3.1.1/CapabilityStatement-us-core-server.html'
           description %(
             This test will attempt to Reference to Practitioner can be resolved and read.
           )
@@ -115,10 +115,10 @@ module Inferno
         metadata do
           id '02'
           name 'Practitioner resources returned during previous tests conform to the US Core Practitioner Profile.'
-          link 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitioner'
+          link 'http://hl7.org/fhir/us/core/STU3.1.1/StructureDefinition/us-core-practitioner'
           description %(
 
-            This test verifies resources returned from the first search conform to the [US Core Practitioner Profile](http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitioner).
+            This test verifies resources returned from the first search conform to the [US Core Practitioner Profile](http://hl7.org/fhir/us/core/STU3.1.1/StructureDefinition/us-core-practitioner).
             It verifies the presence of manditory elements and that elements with required bindgings contain appropriate values.
             CodeableConcept element bindings will fail if none of its codings have a code/system that is part of the bound ValueSet.
             Quantity, Coding, and code element bindings will fail if its code/system is not found in the valueset.
@@ -175,7 +175,7 @@ module Inferno
       test 'All must support elements are provided in the Practitioner resources returned.' do
         metadata do
           id '03'
-          link 'http://www.hl7.org/fhir/us/core/general-guidance.html#must-support'
+          link 'http://www.hl7.org/fhir/us/core/STU3.1.1/general-guidance.html#must-support'
           description %(
 
             US Core Responders SHALL be capable of populating all data elements as part of the query results as specified by the US Core Server Capability Statement.

--- a/lib/modules/uscore_v3.1.1/us_core_practitionerrole_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_practitionerrole_sequence.rb
@@ -34,7 +34,7 @@ module Inferno
         resources found for these elements.
 
         ## Profile Validation
-        Each resource returned from the first search is expected to conform to the [US Core PractitionerRole Profile](http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitionerrole).
+        Each resource returned from the first search is expected to conform to the [US Core PractitionerRole Profile](http://hl7.org/fhir/us/core/STU3.1.1/StructureDefinition/us-core-practitionerrole).
         Each element is checked against teminology binding and cardinality requirements.
 
         Elements with a required binding is validated against its bound valueset. If the code/system in the element is not part
@@ -86,7 +86,7 @@ module Inferno
         metadata do
           id '01'
           name 'Server returns correct PractitionerRole resource from the PractitionerRole read interaction'
-          link 'https://www.hl7.org/fhir/us/core/CapabilityStatement-us-core-server.html'
+          link 'http://www.hl7.org/fhir/us/core/STU3.1.1/CapabilityStatement-us-core-server.html'
           description %(
             This test will attempt to Reference to PractitionerRole can be resolved and read.
           )
@@ -113,10 +113,10 @@ module Inferno
         metadata do
           id '02'
           name 'PractitionerRole resources returned during previous tests conform to the US Core PractitionerRole Profile.'
-          link 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitionerrole'
+          link 'http://hl7.org/fhir/us/core/STU3.1.1/StructureDefinition/us-core-practitionerrole'
           description %(
 
-            This test verifies resources returned from the first search conform to the [US Core PractitionerRole Profile](http://hl7.org/fhir/us/core/StructureDefinition/us-core-practitionerrole).
+            This test verifies resources returned from the first search conform to the [US Core PractitionerRole Profile](http://hl7.org/fhir/us/core/STU3.1.1/StructureDefinition/us-core-practitionerrole).
             It verifies the presence of manditory elements and that elements with required bindgings contain appropriate values.
             CodeableConcept element bindings will fail if none of its codings have a code/system that is part of the bound ValueSet.
             Quantity, Coding, and code element bindings will fail if its code/system is not found in the valueset.
@@ -173,7 +173,7 @@ module Inferno
       test 'All must support elements are provided in the PractitionerRole resources returned.' do
         metadata do
           id '03'
-          link 'http://www.hl7.org/fhir/us/core/general-guidance.html#must-support'
+          link 'http://www.hl7.org/fhir/us/core/STU3.1.1/general-guidance.html#must-support'
           description %(
 
             US Core Responders SHALL be capable of populating all data elements as part of the query results as specified by the US Core Server Capability Statement.

--- a/lib/modules/uscore_v3.1.1/us_core_procedure_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_procedure_sequence.rb
@@ -51,7 +51,7 @@ module Inferno
         resources found for these elements.
 
         ## Profile Validation
-        Each resource returned from the first search is expected to conform to the [US Core Procedure Profile](http://hl7.org/fhir/us/core/StructureDefinition/us-core-procedure).
+        Each resource returned from the first search is expected to conform to the [US Core Procedure Profile](http://hl7.org/fhir/us/core/STU3.1.1/StructureDefinition/us-core-procedure).
         Each element is checked against teminology binding and cardinality requirements.
 
         Elements with a required binding is validated against its bound valueset. If the code/system in the element is not part
@@ -146,7 +146,7 @@ module Inferno
         metadata do
           id '01'
           name 'Server returns valid results for Procedure search by patient.'
-          link 'https://www.hl7.org/fhir/us/core/CapabilityStatement-us-core-server.html'
+          link 'http://www.hl7.org/fhir/us/core/STU3.1.1/CapabilityStatement-us-core-server.html'
           description %(
 
             A server SHALL support searching by patient on the Procedure resource.
@@ -233,7 +233,7 @@ module Inferno
         metadata do
           id '02'
           name 'Server returns valid results for Procedure search by patient+date.'
-          link 'https://www.hl7.org/fhir/us/core/CapabilityStatement-us-core-server.html'
+          link 'http://www.hl7.org/fhir/us/core/STU3.1.1/CapabilityStatement-us-core-server.html'
           description %(
 
             A server SHALL support searching by patient+date on the Procedure resource.
@@ -285,7 +285,7 @@ module Inferno
         metadata do
           id '03'
           name 'Server returns valid results for Procedure search by patient+status.'
-          link 'https://www.hl7.org/fhir/us/core/CapabilityStatement-us-core-server.html'
+          link 'http://www.hl7.org/fhir/us/core/STU3.1.1/CapabilityStatement-us-core-server.html'
           optional
           description %(
 
@@ -325,7 +325,7 @@ module Inferno
         metadata do
           id '04'
           name 'Server returns valid results for Procedure search by patient+code+date.'
-          link 'https://www.hl7.org/fhir/us/core/CapabilityStatement-us-core-server.html'
+          link 'http://www.hl7.org/fhir/us/core/STU3.1.1/CapabilityStatement-us-core-server.html'
           optional
           description %(
 
@@ -384,7 +384,7 @@ module Inferno
         metadata do
           id '05'
           name 'Server returns correct Procedure resource from Procedure read interaction'
-          link 'https://www.hl7.org/fhir/us/core/CapabilityStatement-us-core-server.html'
+          link 'http://www.hl7.org/fhir/us/core/STU3.1.1/CapabilityStatement-us-core-server.html'
           description %(
             A server SHALL support the Procedure read interaction.
           )
@@ -401,7 +401,7 @@ module Inferno
         metadata do
           id '06'
           name 'Server returns correct Procedure resource from Procedure vread interaction'
-          link 'https://www.hl7.org/fhir/us/core/CapabilityStatement-us-core-server.html'
+          link 'http://www.hl7.org/fhir/us/core/STU3.1.1/CapabilityStatement-us-core-server.html'
           optional
           description %(
             A server SHOULD support the Procedure vread interaction.
@@ -419,7 +419,7 @@ module Inferno
         metadata do
           id '07'
           name 'Server returns correct Procedure resource from Procedure history interaction'
-          link 'https://www.hl7.org/fhir/us/core/CapabilityStatement-us-core-server.html'
+          link 'http://www.hl7.org/fhir/us/core/STU3.1.1/CapabilityStatement-us-core-server.html'
           optional
           description %(
             A server SHOULD support the Procedure history interaction.
@@ -477,10 +477,10 @@ module Inferno
         metadata do
           id '09'
           name 'Procedure resources returned during previous tests conform to the US Core Procedure Profile.'
-          link 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-procedure'
+          link 'http://hl7.org/fhir/us/core/STU3.1.1/StructureDefinition/us-core-procedure'
           description %(
 
-            This test verifies resources returned from the first search conform to the [US Core Procedure Profile](http://hl7.org/fhir/us/core/StructureDefinition/us-core-procedure).
+            This test verifies resources returned from the first search conform to the [US Core Procedure Profile](http://hl7.org/fhir/us/core/STU3.1.1/StructureDefinition/us-core-procedure).
             It verifies the presence of manditory elements and that elements with required bindgings contain appropriate values.
             CodeableConcept element bindings will fail if none of its codings have a code/system that is part of the bound ValueSet.
             Quantity, Coding, and code element bindings will fail if its code/system is not found in the valueset.
@@ -537,7 +537,7 @@ module Inferno
       test 'All must support elements are provided in the Procedure resources returned.' do
         metadata do
           id '10'
-          link 'http://www.hl7.org/fhir/us/core/general-guidance.html#must-support'
+          link 'http://www.hl7.org/fhir/us/core/STU3.1.1/general-guidance.html#must-support'
           description %(
 
             US Core Responders SHALL be capable of populating all data elements as part of the query results as specified by the US Core Server Capability Statement.

--- a/lib/modules/uscore_v3.1.1/us_core_provenance_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_provenance_sequence.rb
@@ -33,7 +33,7 @@ module Inferno
         resources found for these elements.
 
         ## Profile Validation
-        Each resource returned from the first search is expected to conform to the [US Core Provenance Profile](http://hl7.org/fhir/us/core/StructureDefinition/us-core-provenance).
+        Each resource returned from the first search is expected to conform to the [US Core Provenance Profile](http://hl7.org/fhir/us/core/STU3.1.1/StructureDefinition/us-core-provenance).
         Each element is checked against teminology binding and cardinality requirements.
 
         Elements with a required binding is validated against its bound valueset. If the code/system in the element is not part
@@ -60,7 +60,7 @@ module Inferno
         metadata do
           id '01'
           name 'Server returns correct Provenance resource from the Provenance read interaction'
-          link 'https://www.hl7.org/fhir/us/core/CapabilityStatement-us-core-server.html'
+          link 'http://www.hl7.org/fhir/us/core/STU3.1.1/CapabilityStatement-us-core-server.html'
           description %(
             This test will attempt to Reference to Provenance can be resolved and read.
           )
@@ -87,10 +87,10 @@ module Inferno
         metadata do
           id '02'
           name 'Provenance resources returned during previous tests conform to the US Core Provenance Profile.'
-          link 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-provenance'
+          link 'http://hl7.org/fhir/us/core/STU3.1.1/StructureDefinition/us-core-provenance'
           description %(
 
-            This test verifies resources returned from the first search conform to the [US Core Provenance Profile](http://hl7.org/fhir/us/core/StructureDefinition/us-core-provenance).
+            This test verifies resources returned from the first search conform to the [US Core Provenance Profile](http://hl7.org/fhir/us/core/STU3.1.1/StructureDefinition/us-core-provenance).
             It verifies the presence of manditory elements and that elements with required bindgings contain appropriate values.
             CodeableConcept element bindings will fail if none of its codings have a code/system that is part of the bound ValueSet.
             Quantity, Coding, and code element bindings will fail if its code/system is not found in the valueset.
@@ -147,7 +147,7 @@ module Inferno
       test 'All must support elements are provided in the Provenance resources returned.' do
         metadata do
           id '03'
-          link 'http://www.hl7.org/fhir/us/core/general-guidance.html#must-support'
+          link 'http://www.hl7.org/fhir/us/core/STU3.1.1/general-guidance.html#must-support'
           description %(
 
             US Core Responders SHALL be capable of populating all data elements as part of the query results as specified by the US Core Server Capability Statement.

--- a/lib/modules/uscore_v3.1.1/us_core_pulse_oximetry_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_pulse_oximetry_sequence.rb
@@ -52,7 +52,7 @@ module Inferno
         resources found for these elements.
 
         ## Profile Validation
-        Each resource returned from the first search is expected to conform to the [US Core Pulse Oximetry Profile](http://hl7.org/fhir/us/core/StructureDefinition/us-core-pulse-oximetry).
+        Each resource returned from the first search is expected to conform to the [US Core Pulse Oximetry Profile](http://hl7.org/fhir/us/core/STU3.1.1/StructureDefinition/us-core-pulse-oximetry).
         Each element is checked against teminology binding and cardinality requirements.
 
         Elements with a required binding is validated against its bound valueset. If the code/system in the element is not part
@@ -160,7 +160,7 @@ module Inferno
         metadata do
           id '01'
           name 'Server returns valid results for Observation search by patient+code.'
-          link 'https://www.hl7.org/fhir/us/core/CapabilityStatement-us-core-server.html'
+          link 'http://www.hl7.org/fhir/us/core/STU3.1.1/CapabilityStatement-us-core-server.html'
           description %(
 
             A server SHALL support searching by patient+code on the Observation resource.
@@ -264,7 +264,7 @@ module Inferno
         metadata do
           id '02'
           name 'Server returns valid results for Observation search by patient+category+date.'
-          link 'https://www.hl7.org/fhir/us/core/CapabilityStatement-us-core-server.html'
+          link 'http://www.hl7.org/fhir/us/core/STU3.1.1/CapabilityStatement-us-core-server.html'
           description %(
 
             A server SHALL support searching by patient+category+date on the Observation resource.
@@ -322,7 +322,7 @@ module Inferno
         metadata do
           id '03'
           name 'Server returns valid results for Observation search by patient+category.'
-          link 'https://www.hl7.org/fhir/us/core/CapabilityStatement-us-core-server.html'
+          link 'http://www.hl7.org/fhir/us/core/STU3.1.1/CapabilityStatement-us-core-server.html'
           description %(
 
             A server SHALL support searching by patient+category on the Observation resource.
@@ -368,7 +368,7 @@ module Inferno
         metadata do
           id '04'
           name 'Server returns valid results for Observation search by patient+category+status.'
-          link 'https://www.hl7.org/fhir/us/core/CapabilityStatement-us-core-server.html'
+          link 'http://www.hl7.org/fhir/us/core/STU3.1.1/CapabilityStatement-us-core-server.html'
           optional
           description %(
 
@@ -414,7 +414,7 @@ module Inferno
         metadata do
           id '05'
           name 'Server returns valid results for Observation search by patient+code+date.'
-          link 'https://www.hl7.org/fhir/us/core/CapabilityStatement-us-core-server.html'
+          link 'http://www.hl7.org/fhir/us/core/STU3.1.1/CapabilityStatement-us-core-server.html'
           optional
           description %(
 
@@ -473,7 +473,7 @@ module Inferno
         metadata do
           id '06'
           name 'Server returns correct Observation resource from Observation read interaction'
-          link 'https://www.hl7.org/fhir/us/core/CapabilityStatement-us-core-server.html'
+          link 'http://www.hl7.org/fhir/us/core/STU3.1.1/CapabilityStatement-us-core-server.html'
           description %(
             A server SHALL support the Observation read interaction.
           )
@@ -490,7 +490,7 @@ module Inferno
         metadata do
           id '07'
           name 'Server returns correct Observation resource from Observation vread interaction'
-          link 'https://www.hl7.org/fhir/us/core/CapabilityStatement-us-core-server.html'
+          link 'http://www.hl7.org/fhir/us/core/STU3.1.1/CapabilityStatement-us-core-server.html'
           optional
           description %(
             A server SHOULD support the Observation vread interaction.
@@ -508,7 +508,7 @@ module Inferno
         metadata do
           id '08'
           name 'Server returns correct Observation resource from Observation history interaction'
-          link 'https://www.hl7.org/fhir/us/core/CapabilityStatement-us-core-server.html'
+          link 'http://www.hl7.org/fhir/us/core/STU3.1.1/CapabilityStatement-us-core-server.html'
           optional
           description %(
             A server SHOULD support the Observation history interaction.
@@ -573,10 +573,10 @@ module Inferno
         metadata do
           id '10'
           name 'Observation resources returned during previous tests conform to the US Core Pulse Oximetry Profile.'
-          link 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-pulse-oximetry'
+          link 'http://hl7.org/fhir/us/core/STU3.1.1/StructureDefinition/us-core-pulse-oximetry'
           description %(
 
-            This test verifies resources returned from the first search conform to the [US Core Observation Profile](http://hl7.org/fhir/us/core/StructureDefinition/us-core-pulse-oximetry).
+            This test verifies resources returned from the first search conform to the [US Core Pulse Oximetry Profile](http://hl7.org/fhir/us/core/STU3.1.1/StructureDefinition/us-core-pulse-oximetry).
             It verifies the presence of manditory elements and that elements with required bindgings contain appropriate values.
             CodeableConcept element bindings will fail if none of its codings have a code/system that is part of the bound ValueSet.
             Quantity, Coding, and code element bindings will fail if its code/system is not found in the valueset.
@@ -633,7 +633,7 @@ module Inferno
       test 'All must support elements are provided in the Observation resources returned.' do
         metadata do
           id '11'
-          link 'http://www.hl7.org/fhir/us/core/general-guidance.html#must-support'
+          link 'http://www.hl7.org/fhir/us/core/STU3.1.1/general-guidance.html#must-support'
           description %(
 
             US Core Responders SHALL be capable of populating all data elements as part of the query results as specified by the US Core Server Capability Statement.

--- a/lib/modules/uscore_v3.1.1/us_core_smokingstatus_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_smokingstatus_sequence.rb
@@ -56,7 +56,7 @@ module Inferno
         resources found for these elements.
 
         ## Profile Validation
-        Each resource returned from the first search is expected to conform to the [US Core Smoking Status Observation Profile](http://hl7.org/fhir/us/core/StructureDefinition/us-core-smokingstatus).
+        Each resource returned from the first search is expected to conform to the [US Core Smoking Status Observation Profile](http://hl7.org/fhir/us/core/STU3.1.1/StructureDefinition/us-core-smokingstatus).
         Each element is checked against teminology binding and cardinality requirements.
 
         Elements with a required binding is validated against its bound valueset. If the code/system in the element is not part
@@ -164,7 +164,7 @@ module Inferno
         metadata do
           id '01'
           name 'Server returns valid results for Observation search by patient+code.'
-          link 'https://www.hl7.org/fhir/us/core/CapabilityStatement-us-core-server.html'
+          link 'http://www.hl7.org/fhir/us/core/STU3.1.1/CapabilityStatement-us-core-server.html'
           description %(
 
             A server SHALL support searching by patient+code on the Observation resource.
@@ -268,7 +268,7 @@ module Inferno
         metadata do
           id '02'
           name 'Server returns correct Observation resource from Observation read interaction'
-          link 'https://www.hl7.org/fhir/us/core/CapabilityStatement-us-core-server.html'
+          link 'http://www.hl7.org/fhir/us/core/STU3.1.1/CapabilityStatement-us-core-server.html'
           description %(
             A server SHALL support the Observation read interaction.
           )
@@ -285,7 +285,7 @@ module Inferno
         metadata do
           id '03'
           name 'Server returns correct Observation resource from Observation vread interaction'
-          link 'https://www.hl7.org/fhir/us/core/CapabilityStatement-us-core-server.html'
+          link 'http://www.hl7.org/fhir/us/core/STU3.1.1/CapabilityStatement-us-core-server.html'
           optional
           description %(
             A server SHOULD support the Observation vread interaction.
@@ -303,7 +303,7 @@ module Inferno
         metadata do
           id '04'
           name 'Server returns correct Observation resource from Observation history interaction'
-          link 'https://www.hl7.org/fhir/us/core/CapabilityStatement-us-core-server.html'
+          link 'http://www.hl7.org/fhir/us/core/STU3.1.1/CapabilityStatement-us-core-server.html'
           optional
           description %(
             A server SHOULD support the Observation history interaction.
@@ -368,10 +368,10 @@ module Inferno
         metadata do
           id '06'
           name 'Observation resources returned during previous tests conform to the US Core Smoking Status Observation Profile.'
-          link 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-smokingstatus'
+          link 'http://hl7.org/fhir/us/core/STU3.1.1/StructureDefinition/us-core-smokingstatus'
           description %(
 
-            This test verifies resources returned from the first search conform to the [US Core Observation Profile](http://hl7.org/fhir/us/core/StructureDefinition/us-core-smokingstatus).
+            This test verifies resources returned from the first search conform to the [US Core Smoking Status Observation Profile](http://hl7.org/fhir/us/core/STU3.1.1/StructureDefinition/us-core-smokingstatus).
             It verifies the presence of manditory elements and that elements with required bindgings contain appropriate values.
             CodeableConcept element bindings will fail if none of its codings have a code/system that is part of the bound ValueSet.
             Quantity, Coding, and code element bindings will fail if its code/system is not found in the valueset.
@@ -428,7 +428,7 @@ module Inferno
       test 'All must support elements are provided in the Observation resources returned.' do
         metadata do
           id '07'
-          link 'http://www.hl7.org/fhir/us/core/general-guidance.html#must-support'
+          link 'http://www.hl7.org/fhir/us/core/STU3.1.1/general-guidance.html#must-support'
           description %(
 
             US Core Responders SHALL be capable of populating all data elements as part of the query results as specified by the US Core Server Capability Statement.


### PR DESCRIPTION
# Summary
US Core points the default url `http://hl7.org/fhir/us/core/... points` to latest published version
After UScore 4.0.0 release, Inferno need to change its quoted url to v3.1.1 profiles

## New behavior
Add `/STU3.1.1` to browserable url link while keep the profile uri unchanged.

## Code changes
Update medata_extractor to build a "versioned_profile" by inserting `/STU3.1.1` in the middle of profile url
Update uscore_generator to generator test detail and link section to have the correct browserable url

## Testing guidance
Open Single Patient and Multi Patient test and verify that links in the test are redirect to US Core v3.1.1 profiles
Only urls in the text area (links, details) are changed. This PR does not affect any testing steps.