### PR TITLE
FI-1313: Add 401 as expected status to BDA-06

### DIFF
--- a/lib/modules/onc_program/bulk_data_authorization_sequence.rb
+++ b/lib/modules/onc_program/bulk_data_authorization_sequence.rb
@@ -216,7 +216,7 @@ module Inferno
         end
 
         response = authorize(iss: 'not_a_iss')
-        assert_response_bad(response)
+        assert_response_bad_or_unauthorized(response)
       end
 
       test :authorization_success do

--- a/lib/modules/onc_program/test/bulk_authorization_sequence_test.rb
+++ b/lib/modules/onc_program/test/bulk_authorization_sequence_test.rb
@@ -68,11 +68,19 @@ describe Inferno::Sequence::BulkDataAuthorizationSequence do
     jwt_token[parameter[:name]] == parameter[:value]
   end
 
-  def self.it_tests_required_parameter(request_headers: nil, request_parameter: nil, jwt_token_parameter: nil)
+  def self.it_tests_required_parameter(request_headers: nil, request_parameter: nil, jwt_token_parameter: nil, allow_unauthorized: false)
     it 'passes with status code 400' do
       build_request(400, request_headers, request_parameter, jwt_token_parameter)
 
       @sequence.run_test(@test)
+    end
+
+    it 'passes with status code 401' do
+      if allow_unauthorized
+        build_request(401, request_headers, request_parameter, jwt_token_parameter)
+
+        @sequence.run_test(@test)
+      end
     end
 
     it 'fail with status code 200' do
@@ -146,7 +154,7 @@ describe Inferno::Sequence::BulkDataAuthorizationSequence do
       @sequence = @sequence_class.new(@instance, @client)
     end
 
-    it_tests_required_parameter(jwt_token_parameter: { name: 'iss', value: 'not_a_iss' })
+    it_tests_required_parameter(jwt_token_parameter: { name: 'iss', value: 'not_a_iss', allow_unauthorized: true })
   end
 
   describe 'return access token tests' do

--- a/lib/modules/onc_program/test/bulk_authorization_sequence_test.rb
+++ b/lib/modules/onc_program/test/bulk_authorization_sequence_test.rb
@@ -75,7 +75,7 @@ describe Inferno::Sequence::BulkDataAuthorizationSequence do
       @sequence.run_test(@test)
     end
 
-    it 'passes with status code 401' do
+    it 'passes with status code 401 if unauthorized (401) is allowed' do
       if allow_unauthorized
         build_request(401, request_headers, request_parameter, jwt_token_parameter)
 


### PR DESCRIPTION
# Summary
This PR addresses GitHub Issue: #348 

BDA-06 should accept server response with status code 401

## New behavior

## Code changes
change BDA-06 to use `assert_response_bad_or_unauthorized`

## Testing guidance
Test in unit test