### PR TITLE
FI-1308: deprecate BED-04/05

### DIFF
--- a/lib/modules/onc_program/bulk_data_export_sequence.rb
+++ b/lib/modules/onc_program/bulk_data_export_sequence.rb
@@ -1,8 +1,12 @@
 # frozen_string_literal: true
 
+require_relative '../core/shared_tests'
+
 module Inferno
   module Sequence
     class BulkDataExportSequence < SequenceBase
+      include Inferno::Sequence::SharedTests
+
       group 'Bulk Data Export'
 
       title 'Bulk Data Export Tests'
@@ -182,33 +186,9 @@ module Inferno
         assert_response_bad_or_unauthorized(reply)
       end
 
-      test 'Bulk Data Server rejects $export operation with invalid Accept header' do
-        metadata do
-          id '04'
-          link 'http://hl7.org/fhir/uv/bulkdata/export/index.html#headers'
-          description %(
-            Accept (string, required)
+      test_is_deprecated(index: '04', name: 'Bulk Data Server rejects $export operation with invalid Accept header', version: '1.6.2')
 
-            * Specifies the format of the optional OperationOutcome resource response to the kick-off request. Currently, only application/fhir+json is supported.
-          )
-        end
-
-        check_export_kick_off_fail_invalid_accept
-      end
-
-      test 'Bulk Data Server rejects $export operation with invalid Prefer header' do
-        metadata do
-          id '05'
-          link 'http://hl7.org/fhir/uv/bulkdata/export/index.html#headers'
-          description %(
-            Prefer (string, required)
-
-            * Specifies whether the response is immediate or asynchronous. The header SHALL be set to respond-async https://tools.ietf.org/html/rfc7240.
-          )
-        end
-
-        check_export_kick_off_fail_invalid_prefer
-      end
+      test_is_deprecated(index: '05', name: 'Bulk Data Server rejects $export operation with invalid Prefer header', version: '1.6.2')
 
       test 'Bulk Data Server returns "202 Accepted" and "Content-location" for $export operation' do
         metadata do

--- a/lib/modules/onc_program/test/bulk_patient_export_sequence_test.rb
+++ b/lib/modules/onc_program/test/bulk_patient_export_sequence_test.rb
@@ -302,32 +302,6 @@ class BulkDataPatientExportSequenceTest < MiniTest::Test
       )
   end
 
-  def include_export_stub_invalid_accept
-    headers = @export_request_headers.clone
-    headers[:accept] = 'application/fhir+xml'
-
-    stub_request(:get, 'https://www.example.com/bulk/Patient/$export')
-      .with(headers: headers)
-      .to_return(
-        status: 400,
-        headers: { content_type: 'application/json' },
-        body: @operation_outcome.to_json
-      )
-  end
-
-  def include_export_stub_invalid_prefer
-    headers = @export_request_headers.clone
-    headers[:prefer] = 'return=representation'
-
-    stub_request(:get, 'https://www.example.com/bulk/Patient/$export')
-      .with(headers: headers)
-      .to_return(
-        status: 400,
-        headers: { content_type: 'application/json' },
-        body: @operation_outcome.to_json
-      )
-  end
-
   def include_status_check_stub(status_code: 200,
                                 response_headers: { content_type: 'application/json' },
                                 response_body: @complete_status)
@@ -355,8 +329,6 @@ class BulkDataPatientExportSequenceTest < MiniTest::Test
     include_metadata_stub
     include_export_stub_no_token
     include_export_stub
-    include_export_stub_invalid_accept
-    include_export_stub_invalid_prefer
     include_status_check_stub
     include_delete_stub
 


### PR DESCRIPTION
# Summary
This PR addresses Github Issue #279 

BDE-04 and BDE-05 are client requirements and should not be tested using server's responses

## New behavior
Deprecate BDE-04 and BDE-05

## Code changes

## Testing guidance
Verify that Multi Patient Group Compartment Export Tests does not include BDE-04 and BDE-05