### PR TITLE
FI-1315 Add "usg: sig" to bulk data's public key

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -63,6 +63,7 @@ bulk_data_jwks:
       crv: P-384
       x: JQKTsV6PT5Szf4QtDA1qrs0EJ1pbimQmM2SKvzOlIAqlph3h1OHmZ2i7MXahIF2C
       y: bRWWQRJBgDa6CTgwofYrHjVGcO-A7WNEnu4oJA5OUJPPPpczgx1g2NsfinK-D2Rw
+      use: sig
       key_ops:
         - verify
       ext: true
@@ -82,6 +83,7 @@ bulk_data_jwks:
       alg: RS384
       n: vjbIzTqiY8K8zApeNng5ekNNIxJfXAue9BjoMrZ9Qy9m7yIA-tf6muEupEXWhq70tC7vIGLqJJ4O8m7yiH8H2qklX2mCAMg3xG3nbykY2X7JXtW9P8VIdG0sAMt5aZQnUGCgSS3n0qaooGn2LUlTGIR88Qi-4Nrao9_3Ki3UCiICeCiAE224jGCg0OlQU6qj2gEB3o-DWJFlG_dz1y-Mxo5ivaeM0vWuodjDrp-aiabJcSF_dx26sdC9dZdBKXFDq0t19I9S9AyGpGDJwzGRtWHY6LsskNHLvo8Zb5AsJ9eRZKpnh30SYBZI9WHtzU85M9WQqdScR69Vyp-6Uhfbvw
       e: AQAB
+      use: sig
       key_ops:
         - verify
       ext: true


### PR DESCRIPTION
# Summary
This PR addresses GitHub Issue #344 

## New behavior
The JWKS  at [base]/inferno/.well-known/jwks.json contains both key_ops and use in public key.

Example:

```
            "use": "sig",
            "key_ops": [
                "verify"
            ], 
```
## Code changes
Updated public keys in config.yml

## Testing guidance
Verify [base]/inferno/.well-known/jwks.json contains `"use": "sig",`
Verify Bulk Data Authorization sequence runs without error
