### PR TITLE
FI-1316 Call bundle.next_bundle to get next page of search result

### DIFF
--- a/lib/app/sequence_base.rb
+++ b/lib/app/sequence_base.rb
@@ -886,6 +886,7 @@ module Inferno
           reply = @client.raw_read_url(next_bundle_link)
           error_message = "Could not resolve next bundle. #{next_bundle_link}"
           assert_response_ok(reply, error_message)
+          assert_bundle_response(reply)
 
           bundle = @client.parse_reply(FHIR::Bundle, @client.default_format, reply)
 

--- a/lib/app/sequence_base.rb
+++ b/lib/app/sequence_base.rb
@@ -878,17 +878,8 @@ module Inferno
         bundle = reply.resource
         until bundle.nil? || page_count == 20
           resources += bundle&.entry&.map { |entry| entry&.resource }
-          next_bundle_link = bundle&.link&.find { |link| link.relation == 'next' }&.url
           reply_handler&.call(reply)
-          break if next_bundle_link.blank?
-
-          reply = @client.raw_read_url(next_bundle_link)
-          error_message = "Could not resolve next bundle. #{next_bundle_link}"
-          assert_response_ok(reply, error_message)
-          assert_valid_json(reply.body, error_message)
-
-          bundle = FHIR.from_contents(reply.body)
-
+          bundle = bundle.next_bundle
           page_count += 1
         end
         resources

--- a/lib/app/sequence_base.rb
+++ b/lib/app/sequence_base.rb
@@ -886,7 +886,7 @@ module Inferno
           reply = @client.raw_read_url(next_bundle_link)
           error_message = "Could not resolve next bundle. #{next_bundle_link}"
           assert_response_ok(reply, error_message)
-          assert_bundle_response(reply)
+          assert_valid_json(reply.body, error_message)
 
           bundle = @client.parse_reply(FHIR::Bundle, @client.default_format, reply)
 

--- a/test/unit/sequence_base_test.rb
+++ b/test/unit/sequence_base_test.rb
@@ -333,6 +333,15 @@ class SequenceBaseTest < MiniTest::Test
       assert all_resources.map(&:id) == ['1', '2']
     end
 
+    it 'fails on 404' do
+      stub_request(:get, @bundle1.link.first.url)
+        .to_return(body: '', status: 404)
+
+      assert_raises Inferno::AssertionException do
+        @sequence.fetch_all_bundled_resources(OpenStruct.new(resource: @bundle1))
+      end
+    end
+
     it 'returns resources when no next page' do
       all_resources = @sequence.fetch_all_bundled_resources(
         OpenStruct.new(resource: FHIR.from_contents(@bundle2))

--- a/test/unit/sequence_base_test.rb
+++ b/test/unit/sequence_base_test.rb
@@ -333,15 +333,6 @@ class SequenceBaseTest < MiniTest::Test
       assert all_resources.map(&:id) == ['1', '2']
     end
 
-    it 'fails on 404' do
-      stub_request(:get, @bundle1.link.first.url)
-        .to_return(body: '', status: 404)
-
-      assert_raises Inferno::AssertionException do
-        @sequence.fetch_all_bundled_resources(OpenStruct.new(resource: @bundle1))
-      end
-    end
-
     it 'returns resources when no next page' do
       all_resources = @sequence.fetch_all_bundled_resources(
         OpenStruct.new(resource: FHIR.from_contents(@bundle2))


### PR DESCRIPTION
# Summary
USCMR-14 failed because the resources from the 2nd page of search result don't have fhir client reference.
The root cause is on the SequenceBase.fetch_all_bundled_resources() function which does not use parse_reply for the response from "next" link.

## New behavior
Use bundle.next_bundle to get next page of search result.
bundle.next_bundle return nil if there is no next page or unable to read next page.

Remove one unit test on status 404 since bundle.next_bundle does not throw exception on status 404. Instead it returns nil.

## Code changes

## Testing guidance
Run Single Patient test on Reference Server to verify that USCMR-14 is passed.