### PR TITLE
FI-1304 Adding Observation.component MS check for BP profile. Remove dataAbsentReason MS check from all vital sign profiles

### DIFF
--- a/generator/uscore/metadata_extractor.rb
+++ b/generator/uscore/metadata_extractor.rb
@@ -566,17 +566,13 @@ module Inferno
         # ONC clarified that health IT developers that always provide HL7 FHIR "observation" values
         # are not required to demonstrate Health IT Module support for "dataAbsentReason" elements.
         # Remove MS check for dataAbsentReason and component.dataAbsentReason from vital sign profiles
-        vital_sign_sequences = metadata[:sequences].select do |sequence|
-          base_path = get_base_path(sequence[:profile])
-          profile_definition = @resource_by_path[base_path]
-          ['http://hl7.org/fhir/StructureDefinition/vitalsigns', 'http://hl7.org/fhir/StructureDefinition/oxygensat'].include?(profile_definition['baseDefinition'])
-        end
-
-        vital_sign_sequences.each do |sequence|
-          sequence[:must_supports][:elements].delete_if do |element|
-            ['dataAbsentReason', 'component.dataAbsentReason'].include?(element[:path])
+        metadata[:sequences]
+          .select { |sequence| sequence[:resource] == 'Observation' }
+          .each do |sequence|
+            sequence[:must_supports][:elements].delete_if do |element|
+              ['dataAbsentReason', 'component.dataAbsentReason'].include?(element[:path])
+            end
           end
-        end
 
         metadata
       end

--- a/generator/uscore/metadata_extractor.rb
+++ b/generator/uscore/metadata_extractor.rb
@@ -557,10 +557,10 @@ module Inferno
         # Observation-bp profile uses Observation.component.value for Systolic and Diastolic pressures
         bp_sequence = metadata[:sequences].find { |sequence| sequence[:profile] == 'http://hl7.org/fhir/StructureDefinition/bp' }
         bp_sequence[:must_supports][:elements].delete_if do |element|
-          element[:path].start_with?('value[x]')
+          element[:path] == 'value[x]'
         end
         bp_sequence[:must_supports][:slices].delete_if do |slice|
-          slice[:path].start_with?('value[x]')
+          slice[:path] == 'value[x]'
         end
 
         # ONC clarified that health IT developers that always provide HL7 FHIR "observation" values

--- a/generator/uscore/metadata_extractor.rb
+++ b/generator/uscore/metadata_extractor.rb
@@ -275,7 +275,10 @@ module Inferno
         profile_elements = profile_definition['snapshot']['element']
         profile_elements.select { |el| el['mustSupport'] }.each do |element|
           # not including components in vital-sign profiles because they don't make sense outside of BP
-          next if profile_definition['baseDefinition'] == 'http://hl7.org/fhir/StructureDefinition/vitalsigns' && element['path'].include?('component')
+          is_vital_sign = profile_definition['baseDefinition'] == 'http://hl7.org/fhir/StructureDefinition/vitalsigns'
+          is_component_element = element['path'].include?('component')
+          profile_changes_component = profile_definition['differential']['element'].any? { |el| el['path'] == 'Observation.component' }
+          next if is_vital_sign && is_component_element && !profile_changes_component
           next if profile_definition['name'] == 'observation-bp' && element['path'].include?('Observation.value[x]')
           next if profile_definition['name'].include?('Pediatric') && element['path'] == 'Observation.dataAbsentReason'
 

--- a/generator/uscore/metadata_extractor.rb
+++ b/generator/uscore/metadata_extractor.rb
@@ -552,9 +552,9 @@ module Inferno
           profile_changes_component = profile_definition['differential']['element'].any? { |el| el['path'] == 'Observation.component' }
           is_vital_sign && !profile_changes_component
         end
-        
+
         unchanged_vital_sign_sequences.each do |sequence|
-          sequence[:must_supports][:elements].reject! {|el| el[:path].include?('component')}
+          sequence[:must_supports][:elements].reject! { |el| el[:path].include?('component') }
         end
         metadata
       end

--- a/generator/uscore/metadata_extractor.rb
+++ b/generator/uscore/metadata_extractor.rb
@@ -544,7 +544,11 @@ module Inferno
         document_reference_sequence = metadata[:sequences].find { |sequence| sequence[:profile] == 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-documentreference' }
         document_reference_sequence[:must_supports][:elements].delete_if do |element|
           ['content.attachment.data', 'content.attachment.url'].include? element[:path]
+        end
 
+        # exclude component from vital sign profiles except observation-bp and observation-pulse-ox
+        # observation-bp is excluded by profile_definition['differential']['element'].any? { |el| el['path'] == 'Observation.component' }
+        # observation-plux-ox is excluded by profile_definition['baseDefinition'] == 'http://hl7.org/fhir/StructureDefinition/vitalsigns'
         unchanged_vital_sign_sequences = metadata[:sequences].select do |sequence|
           base_path = get_base_path(sequence[:profile])
           profile_definition = @resource_by_path[base_path]
@@ -556,6 +560,8 @@ module Inferno
         unchanged_vital_sign_sequences.each do |sequence|
           sequence[:must_supports][:elements].reject! { |el| el[:path].include?('component') }
         end
+
+        
         metadata
       end
 

--- a/lib/modules/uscore_v3.1.1/bodyheight_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/bodyheight_sequence.rb
@@ -658,7 +658,6 @@ module Inferno
             * category.coding.code
             * category.coding.system
             * code
-            * dataAbsentReason
             * effective[x]
             * status
             * subject

--- a/lib/modules/uscore_v3.1.1/bodytemp_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/bodytemp_sequence.rb
@@ -658,7 +658,6 @@ module Inferno
             * category.coding.code
             * category.coding.system
             * code
-            * dataAbsentReason
             * effective[x]
             * status
             * subject

--- a/lib/modules/uscore_v3.1.1/bodyweight_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/bodyweight_sequence.rb
@@ -658,7 +658,6 @@ module Inferno
             * category.coding.code
             * category.coding.system
             * code
-            * dataAbsentReason
             * effective[x]
             * status
             * subject

--- a/lib/modules/uscore_v3.1.1/bp_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/bp_sequence.rb
@@ -661,13 +661,11 @@ module Inferno
             * code
             * component
             * component.code
-            * component.dataAbsentReason
             * component.value[x]
             * component.value[x].code
             * component.value[x].system
             * component.value[x].unit
             * component.value[x].value
-            * dataAbsentReason
             * effective[x]
             * status
             * subject

--- a/lib/modules/uscore_v3.1.1/bp_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/bp_sequence.rb
@@ -652,11 +652,21 @@ module Inferno
             This will look through the Observation resources found previously for the following must support elements:
 
             * Observation.category:VSCat
+            * Observation.component:DiastolicBP
+            * Observation.component:SystolicBP
             * category
             * category.coding
             * category.coding.code
             * category.coding.system
             * code
+            * component
+            * component.code
+            * component.dataAbsentReason
+            * component.value[x]
+            * component.value[x].code
+            * component.value[x].system
+            * component.value[x].unit
+            * component.value[x].value
             * dataAbsentReason
             * effective[x]
             * status

--- a/lib/modules/uscore_v3.1.1/heartrate_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/heartrate_sequence.rb
@@ -658,7 +658,6 @@ module Inferno
             * category.coding.code
             * category.coding.system
             * code
-            * dataAbsentReason
             * effective[x]
             * status
             * subject

--- a/lib/modules/uscore_v3.1.1/profile_definitions/bodyheight_definitions.rb
+++ b/lib/modules/uscore_v3.1.1/profile_definitions/bodyheight_definitions.rb
@@ -74,9 +74,6 @@ module Inferno
           }.freeze,
           {
             path: 'value.code'
-          }.freeze,
-          {
-            path: 'dataAbsentReason'
           }.freeze
         ].freeze
       }.freeze

--- a/lib/modules/uscore_v3.1.1/profile_definitions/bodytemp_definitions.rb
+++ b/lib/modules/uscore_v3.1.1/profile_definitions/bodytemp_definitions.rb
@@ -74,9 +74,6 @@ module Inferno
           }.freeze,
           {
             path: 'value.code'
-          }.freeze,
-          {
-            path: 'dataAbsentReason'
           }.freeze
         ].freeze
       }.freeze

--- a/lib/modules/uscore_v3.1.1/profile_definitions/bodyweight_definitions.rb
+++ b/lib/modules/uscore_v3.1.1/profile_definitions/bodyweight_definitions.rb
@@ -74,9 +74,6 @@ module Inferno
           }.freeze,
           {
             path: 'value.code'
-          }.freeze,
-          {
-            path: 'dataAbsentReason'
           }.freeze
         ].freeze
       }.freeze

--- a/lib/modules/uscore_v3.1.1/profile_definitions/bp_definitions.rb
+++ b/lib/modules/uscore_v3.1.1/profile_definitions/bp_definitions.rb
@@ -22,6 +22,40 @@ module Inferno
                 }.freeze
               ].freeze
             }.freeze
+          }.freeze,
+          {
+            name: 'Observation.component:SystolicBP',
+            path: 'component',
+            discriminator: {
+              type: 'value',
+              values: [
+                {
+                  path: 'code.coding.code',
+                  value: '8480-6'
+                }.freeze,
+                {
+                  path: 'code.coding.system',
+                  value: 'http://loinc.org'
+                }.freeze
+              ].freeze
+            }.freeze
+          }.freeze,
+          {
+            name: 'Observation.component:DiastolicBP',
+            path: 'component',
+            discriminator: {
+              type: 'value',
+              values: [
+                {
+                  path: 'code.coding.code',
+                  value: '8462-4'
+                }.freeze,
+                {
+                  path: 'code.coding.system',
+                  value: 'http://loinc.org'
+                }.freeze
+              ].freeze
+            }.freeze
           }.freeze
         ].freeze,
         elements: [
@@ -53,6 +87,32 @@ module Inferno
           }.freeze,
           {
             path: 'dataAbsentReason'
+          }.freeze,
+          {
+            path: 'component'
+          }.freeze,
+          {
+            path: 'component.value.system',
+            fixed_value: 'http://unitsofmeasure.org'
+          }.freeze,
+          {
+            path: 'component.value.code',
+            fixed_value: 'mm[Hg]'
+          }.freeze,
+          {
+            path: 'component.code'
+          }.freeze,
+          {
+            path: 'component.value'
+          }.freeze,
+          {
+            path: 'component.value.value'
+          }.freeze,
+          {
+            path: 'component.value.unit'
+          }.freeze,
+          {
+            path: 'component.dataAbsentReason'
           }.freeze
         ].freeze
       }.freeze

--- a/lib/modules/uscore_v3.1.1/profile_definitions/bp_definitions.rb
+++ b/lib/modules/uscore_v3.1.1/profile_definitions/bp_definitions.rb
@@ -86,9 +86,6 @@ module Inferno
             path: 'effective'
           }.freeze,
           {
-            path: 'dataAbsentReason'
-          }.freeze,
-          {
             path: 'component'
           }.freeze,
           {
@@ -110,9 +107,6 @@ module Inferno
           }.freeze,
           {
             path: 'component.value.unit'
-          }.freeze,
-          {
-            path: 'component.dataAbsentReason'
           }.freeze
         ].freeze
       }.freeze

--- a/lib/modules/uscore_v3.1.1/profile_definitions/heartrate_definitions.rb
+++ b/lib/modules/uscore_v3.1.1/profile_definitions/heartrate_definitions.rb
@@ -75,9 +75,6 @@ module Inferno
           {
             path: 'value.code',
             fixed_value: '/min'
-          }.freeze,
-          {
-            path: 'dataAbsentReason'
           }.freeze
         ].freeze
       }.freeze

--- a/lib/modules/uscore_v3.1.1/profile_definitions/resprate_definitions.rb
+++ b/lib/modules/uscore_v3.1.1/profile_definitions/resprate_definitions.rb
@@ -75,9 +75,6 @@ module Inferno
           {
             path: 'value.code',
             fixed_value: '/min'
-          }.freeze,
-          {
-            path: 'dataAbsentReason'
           }.freeze
         ].freeze
       }.freeze

--- a/lib/modules/uscore_v3.1.1/profile_definitions/us_core_observation_lab_definitions.rb
+++ b/lib/modules/uscore_v3.1.1/profile_definitions/us_core_observation_lab_definitions.rb
@@ -35,9 +35,6 @@ module Inferno
           }.freeze,
           {
             path: 'value'
-          }.freeze,
-          {
-            path: 'dataAbsentReason'
           }.freeze
         ].freeze
       }.freeze

--- a/lib/modules/uscore_v3.1.1/profile_definitions/us_core_pulse_oximetry_definitions.rb
+++ b/lib/modules/uscore_v3.1.1/profile_definitions/us_core_pulse_oximetry_definitions.rb
@@ -125,9 +125,6 @@ module Inferno
             fixed_value: '%'
           }.freeze,
           {
-            path: 'dataAbsentReason'
-          }.freeze,
-          {
             path: 'component'
           }.freeze,
           {
@@ -161,9 +158,6 @@ module Inferno
           {
             path: 'component.value.code',
             fixed_value: '%'
-          }.freeze,
-          {
-            path: 'component.dataAbsentReason'
           }.freeze
         ].freeze
       }.freeze

--- a/lib/modules/uscore_v3.1.1/resprate_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/resprate_sequence.rb
@@ -658,7 +658,6 @@ module Inferno
             * category.coding.code
             * category.coding.system
             * code
-            * dataAbsentReason
             * effective[x]
             * status
             * subject

--- a/lib/modules/uscore_v3.1.1/us_core_observation_lab_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_observation_lab_sequence.rb
@@ -654,7 +654,6 @@ module Inferno
             * Observation.category:Laboratory
             * category
             * code
-            * dataAbsentReason
             * effective[x]
             * status
             * subject

--- a/lib/modules/uscore_v3.1.1/us_core_pulse_oximetry_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_pulse_oximetry_sequence.rb
@@ -668,14 +668,12 @@ module Inferno
             * component.code
             * component.code.coding.code
             * component.code.coding.code
-            * component.dataAbsentReason
             * component.value[x]
             * component.value[x].code
             * component.value[x].code
             * component.value[x].system
             * component.value[x].unit
             * component.value[x].value
-            * dataAbsentReason
             * effective[x]
             * status
             * subject


### PR DESCRIPTION
# Summary
This PR fixes GitHub issue #385, #364

Inferno decides to remove MustSupport check for Observation.dataAbsentResent and relies on invariant vs-2 to validate that "If there is no component or hasMember element then either a value[x] or a data absent reason must be present."

## New behavior
Add Observation.component MS check for observation-bp profile
Remove Observation.dataAbsentReason MS check from vital sign profile

## Code changes
add logic to remove dataAbsentReason to metadata_extractor

## Testing guidance
Check if tests still pass
