### PR TITLE
FI-1321: Fix Must Support tests incorrectly passing

### DIFF
--- a/generator/uscore/uscore_generator.rb
+++ b/generator/uscore/uscore_generator.rb
@@ -133,7 +133,7 @@ module Inferno
             }
             delayed_profile_intersection
           end
-          sequence[:delayed_references_constant] = "DELAYED_REFERENCES = #{structure_to_string(delayed_sequence_references)}.freeze"
+          sequence[:delayed_references_constant] = "DELAYED_REFERENCES = #{structure_to_string(delayed_sequence_references)}"
         end
       end
 
@@ -711,7 +711,7 @@ module Inferno
         sequence[:tests] << test
 
         sequence[:must_support_constants] = %(
-          MUST_SUPPORTS = #{structure_to_string(sequence[:must_supports])}.freeze
+          MUST_SUPPORTS = #{structure_to_string(sequence[:must_supports])}
         )
       end
 
@@ -719,15 +719,15 @@ module Inferno
         if struct.is_a? Hash
           %({
             #{struct.map { |k, v| "#{k}: #{structure_to_string(v)}" }.join(",\n")}
-          })
+          }.freeze)
         elsif struct.is_a? Array
           %([
             #{struct.map { |el| structure_to_string(el) }.join(",\n")}
-          ])
+          ].freeze)
         elsif struct.is_a? String
           "'#{struct}'"
         else
-          "''"
+          "''.freeze"
         end
       end
 
@@ -781,7 +781,7 @@ module Inferno
         end
         resources_ary_str = sequence[:delayed_sequence] ? "@#{sequence[:resource].underscore}_ary" : "@#{sequence[:resource].underscore}_ary&.values&.flatten"
         if bindings.present?
-          sequence[:bindings_constants] = "BINDINGS = #{structure_to_string(bindings)}.freeze"
+          sequence[:bindings_constants] = "BINDINGS = #{structure_to_string(bindings)}"
           test[:test_code] += %(
             bindings = #{sequence[:class_name]}Definitions::BINDINGS
             invalid_binding_messages = []

--- a/lib/modules/onc_program/bulk_data_group_validation_sequence.rb
+++ b/lib/modules/onc_program/bulk_data_group_validation_sequence.rb
@@ -471,8 +471,8 @@ module Inferno
         profile_definitions = [
           {
             profile: nil,
-            must_support_info: USCore311PatientSequenceDefinitions::MUST_SUPPORTS.dup,
-            binding_info: USCore311PatientSequenceDefinitions::BINDINGS.dup
+            must_support_info: USCore311PatientSequenceDefinitions::MUST_SUPPORTS.deep_dup,
+            binding_info: USCore311PatientSequenceDefinitions::BINDINGS.deep_dup
           }
         ]
 
@@ -527,8 +527,8 @@ module Inferno
         profile_definitions = [
           {
             profile: nil,
-            must_support_info: USCore311AllergyintoleranceSequenceDefinitions::MUST_SUPPORTS.dup,
-            binding_info: USCore311AllergyintoleranceSequenceDefinitions::BINDINGS.dup
+            must_support_info: USCore311AllergyintoleranceSequenceDefinitions::MUST_SUPPORTS.deep_dup,
+            binding_info: USCore311AllergyintoleranceSequenceDefinitions::BINDINGS.deep_dup
           }
         ]
         test_output_against_profile('AllergyIntolerance', profile_definitions)
@@ -547,8 +547,8 @@ module Inferno
         profile_definitions = [
           {
             profile: nil,
-            must_support_info: USCore311CareplanSequenceDefinitions::MUST_SUPPORTS.dup,
-            binding_info: USCore311CareplanSequenceDefinitions::BINDINGS.dup
+            must_support_info: USCore311CareplanSequenceDefinitions::MUST_SUPPORTS.deep_dup,
+            binding_info: USCore311CareplanSequenceDefinitions::BINDINGS.deep_dup
           }
         ]
         test_output_against_profile('CarePlan', profile_definitions)
@@ -567,8 +567,8 @@ module Inferno
         profile_definitions = [
           {
             profile: nil,
-            must_support_info: USCore311CareteamSequenceDefinitions::MUST_SUPPORTS.dup,
-            binding_info: USCore311CareteamSequenceDefinitions::BINDINGS.dup
+            must_support_info: USCore311CareteamSequenceDefinitions::MUST_SUPPORTS.deep_dup,
+            binding_info: USCore311CareteamSequenceDefinitions::BINDINGS.deep_dup
           }
         ]
         test_output_against_profile('CareTeam', profile_definitions)
@@ -587,8 +587,8 @@ module Inferno
         profile_definitions = [
           {
             profile: nil,
-            must_support_info: USCore311ConditionSequenceDefinitions::MUST_SUPPORTS.dup,
-            binding_info: USCore311ConditionSequenceDefinitions::BINDINGS.dup
+            must_support_info: USCore311ConditionSequenceDefinitions::MUST_SUPPORTS.deep_dup,
+            binding_info: USCore311ConditionSequenceDefinitions::BINDINGS.deep_dup
           }
         ]
         test_output_against_profile('Condition', profile_definitions)
@@ -607,8 +607,8 @@ module Inferno
         must_supports = [
           {
             profile: nil,
-            must_support_info: USCore311ImplantableDeviceSequenceDefinitions::MUST_SUPPORTS.dup,
-            binding_info: USCore311ImplantableDeviceSequenceDefinitions::BINDINGS.dup
+            must_support_info: USCore311ImplantableDeviceSequenceDefinitions::MUST_SUPPORTS.deep_dup,
+            binding_info: USCore311ImplantableDeviceSequenceDefinitions::BINDINGS.deep_dup
           }
         ]
 
@@ -631,13 +631,13 @@ module Inferno
         profile_definitions = [
           {
             profile: US_CORE_R4_URIS[:diagnostic_report_lab],
-            must_support_info: USCore311DiagnosticreportLabSequenceDefinitions::MUST_SUPPORTS.dup,
-            binding_info: USCore311DiagnosticreportLabSequenceDefinitions::BINDINGS.dup
+            must_support_info: USCore311DiagnosticreportLabSequenceDefinitions::MUST_SUPPORTS.deep_dup,
+            binding_info: USCore311DiagnosticreportLabSequenceDefinitions::BINDINGS.deep_dup
           },
           {
             profile: US_CORE_R4_URIS[:diagnostic_report_note],
-            must_support_info: USCore311DiagnosticreportNoteSequenceDefinitions::MUST_SUPPORTS.dup,
-            binding_info: USCore311DiagnosticreportNoteSequenceDefinitions::BINDINGS.dup
+            must_support_info: USCore311DiagnosticreportNoteSequenceDefinitions::MUST_SUPPORTS.deep_dup,
+            binding_info: USCore311DiagnosticreportNoteSequenceDefinitions::BINDINGS.deep_dup
           }
         ]
         test_output_against_profile('DiagnosticReport', profile_definitions)
@@ -656,8 +656,8 @@ module Inferno
         profile_definitions = [
           {
             profile: nil,
-            must_support_info: USCore311DocumentreferenceSequenceDefinitions::MUST_SUPPORTS.dup,
-            binding_info: USCore311DocumentreferenceSequenceDefinitions::BINDINGS.dup
+            must_support_info: USCore311DocumentreferenceSequenceDefinitions::MUST_SUPPORTS.deep_dup,
+            binding_info: USCore311DocumentreferenceSequenceDefinitions::BINDINGS.deep_dup
           }
         ]
         test_output_against_profile('DocumentReference', profile_definitions)
@@ -676,8 +676,8 @@ module Inferno
         profile_definitions = [
           {
             profile: nil,
-            must_support_info: USCore311GoalSequenceDefinitions::MUST_SUPPORTS.dup,
-            binding_info: USCore311GoalSequenceDefinitions::BINDINGS.dup
+            must_support_info: USCore311GoalSequenceDefinitions::MUST_SUPPORTS.deep_dup,
+            binding_info: USCore311GoalSequenceDefinitions::BINDINGS.deep_dup
           }
         ]
         test_output_against_profile('Goal', profile_definitions)
@@ -696,8 +696,8 @@ module Inferno
         profile_definitions = [
           {
             profile: nil,
-            must_support_info: USCore311ImmunizationSequenceDefinitions::MUST_SUPPORTS.dup,
-            binding_info: USCore311ImmunizationSequenceDefinitions::BINDINGS.dup
+            must_support_info: USCore311ImmunizationSequenceDefinitions::MUST_SUPPORTS.deep_dup,
+            binding_info: USCore311ImmunizationSequenceDefinitions::BINDINGS.deep_dup
           }
         ]
         test_output_against_profile('Immunization', profile_definitions)
@@ -716,8 +716,8 @@ module Inferno
         profile_definitions = [
           {
             profile: nil,
-            must_support_info: USCore311MedicationrequestSequenceDefinitions::MUST_SUPPORTS.dup,
-            binding_info: USCore311MedicationrequestSequenceDefinitions::BINDINGS.dup
+            must_support_info: USCore311MedicationrequestSequenceDefinitions::MUST_SUPPORTS.deep_dup,
+            binding_info: USCore311MedicationrequestSequenceDefinitions::BINDINGS.deep_dup
           }
         ]
         test_output_against_profile('MedicationRequest', profile_definitions)
@@ -751,63 +751,63 @@ module Inferno
         profile_definitions = [
           {
             profile: US_CORE_R4_URIS[:pediatric_bmi_age],
-            must_support_info: USCore311PediatricBmiForAgeSequenceDefinitions::MUST_SUPPORTS.dup,
-            binding_info: USCore311PediatricBmiForAgeSequenceDefinitions::BINDINGS.dup
+            must_support_info: USCore311PediatricBmiForAgeSequenceDefinitions::MUST_SUPPORTS.deep_dup,
+            binding_info: USCore311PediatricBmiForAgeSequenceDefinitions::BINDINGS.deep_dup
           },
           {
             profile: US_CORE_R4_URIS[:pediatric_weight_height],
-            must_support_info: USCore311PediatricWeightForHeightSequenceDefinitions::MUST_SUPPORTS.dup,
-            binding_info: USCore311PediatricWeightForHeightSequenceDefinitions::BINDINGS.dup
+            must_support_info: USCore311PediatricWeightForHeightSequenceDefinitions::MUST_SUPPORTS.deep_dup,
+            binding_info: USCore311PediatricWeightForHeightSequenceDefinitions::BINDINGS.deep_dup
           },
           {
             profile: US_CORE_R4_URIS[:pulse_oximetry],
-            must_support_info: USCore311PulseOximetrySequenceDefinitions::MUST_SUPPORTS.dup,
-            binding_info: USCore311PulseOximetrySequenceDefinitions::BINDINGS.dup
+            must_support_info: USCore311PulseOximetrySequenceDefinitions::MUST_SUPPORTS.deep_dup,
+            binding_info: USCore311PulseOximetrySequenceDefinitions::BINDINGS.deep_dup
           },
           {
             profile: US_CORE_R4_URIS[:lab_results],
-            must_support_info: USCore311ObservationLabSequenceDefinitions::MUST_SUPPORTS.dup,
-            binding_info: USCore311ObservationLabSequenceDefinitions::BINDINGS.dup
+            must_support_info: USCore311ObservationLabSequenceDefinitions::MUST_SUPPORTS.deep_dup,
+            binding_info: USCore311ObservationLabSequenceDefinitions::BINDINGS.deep_dup
           },
           {
             profile: US_CORE_R4_URIS[:smoking_status],
-            must_support_info: USCore311SmokingstatusSequenceDefinitions::MUST_SUPPORTS.dup,
-            binding_info: USCore311SmokingstatusSequenceDefinitions::BINDINGS.dup
+            must_support_info: USCore311SmokingstatusSequenceDefinitions::MUST_SUPPORTS.deep_dup,
+            binding_info: USCore311SmokingstatusSequenceDefinitions::BINDINGS.deep_dup
           },
           {
             profile: US_CORE_R4_URIS[:blood_pressure],
-            must_support_info: USCore311BpSequenceDefinitions::MUST_SUPPORTS.dup,
-            binding_info: USCore311BpSequenceDefinitions::BINDINGS.dup
+            must_support_info: USCore311BpSequenceDefinitions::MUST_SUPPORTS.deep_dup,
+            binding_info: USCore311BpSequenceDefinitions::BINDINGS.deep_dup
           },
           {
             profile: US_CORE_R4_URIS[:body_height],
-            must_support_info: USCore311BodyheightSequenceDefinitions::MUST_SUPPORTS.dup,
-            binding_info: USCore311BodyheightSequenceDefinitions::BINDINGS.dup
+            must_support_info: USCore311BodyheightSequenceDefinitions::MUST_SUPPORTS.deep_dup,
+            binding_info: USCore311BodyheightSequenceDefinitions::BINDINGS.deep_dup
           },
           {
             profile: US_CORE_R4_URIS[:body_temperature],
-            must_support_info: USCore311BodytempSequenceDefinitions::MUST_SUPPORTS.dup,
-            binding_info: USCore311BodytempSequenceDefinitions::BINDINGS.dup
+            must_support_info: USCore311BodytempSequenceDefinitions::MUST_SUPPORTS.deep_dup,
+            binding_info: USCore311BodytempSequenceDefinitions::BINDINGS.deep_dup
           },
           {
             profile: US_CORE_R4_URIS[:body_weight],
-            must_support_info: USCore311BodyweightSequenceDefinitions::MUST_SUPPORTS.dup,
-            binding_info: USCore311BodyweightSequenceDefinitions::BINDINGS.dup
+            must_support_info: USCore311BodyweightSequenceDefinitions::MUST_SUPPORTS.deep_dup,
+            binding_info: USCore311BodyweightSequenceDefinitions::BINDINGS.deep_dup
           },
           {
             profile: US_CORE_R4_URIS[:head_circumference_percentile],
-            must_support_info: USCore311HeadOccipitalFrontalCircumferencePercentileSequenceDefinitions::MUST_SUPPORTS.dup,
-            binding_info: USCore311HeadOccipitalFrontalCircumferencePercentileSequenceDefinitions::BINDINGS.dup
+            must_support_info: USCore311HeadOccipitalFrontalCircumferencePercentileSequenceDefinitions::MUST_SUPPORTS.deep_dup,
+            binding_info: USCore311HeadOccipitalFrontalCircumferencePercentileSequenceDefinitions::BINDINGS.deep_dup
           },
           {
             profile: US_CORE_R4_URIS[:heart_rate],
-            must_support_info: USCore311HeartrateSequenceDefinitions::MUST_SUPPORTS.dup,
-            binding_info: USCore311HeartrateSequenceDefinitions::BINDINGS.dup
+            must_support_info: USCore311HeartrateSequenceDefinitions::MUST_SUPPORTS.deep_dup,
+            binding_info: USCore311HeartrateSequenceDefinitions::BINDINGS.deep_dup
           },
           {
             profile: US_CORE_R4_URIS[:resp_rate],
-            must_support_info: USCore311ResprateSequenceDefinitions::MUST_SUPPORTS.dup,
-            binding_info: USCore311ResprateSequenceDefinitions::BINDINGS.dup
+            must_support_info: USCore311ResprateSequenceDefinitions::MUST_SUPPORTS.deep_dup,
+            binding_info: USCore311ResprateSequenceDefinitions::BINDINGS.deep_dup
           }
         ]
 
@@ -827,8 +827,8 @@ module Inferno
         profile_definitions = [
           {
             profile: nil,
-            must_support_info: USCore311ProcedureSequenceDefinitions::MUST_SUPPORTS.dup,
-            binding_info: USCore311ProcedureSequenceDefinitions::BINDINGS.dup
+            must_support_info: USCore311ProcedureSequenceDefinitions::MUST_SUPPORTS.deep_dup,
+            binding_info: USCore311ProcedureSequenceDefinitions::BINDINGS.deep_dup
           }
         ]
         test_output_against_profile('Procedure', profile_definitions)
@@ -852,8 +852,8 @@ module Inferno
         profile_definitions = [
           {
             profile: nil,
-            must_support_info: USCore311EncounterSequenceDefinitions::MUST_SUPPORTS.dup,
-            binding_info: USCore311EncounterSequenceDefinitions::BINDINGS.dup
+            must_support_info: USCore311EncounterSequenceDefinitions::MUST_SUPPORTS.deep_dup,
+            binding_info: USCore311EncounterSequenceDefinitions::BINDINGS.deep_dup
           }
         ]
         test_output_against_profile('Encounter', profile_definitions)
@@ -883,8 +883,8 @@ module Inferno
         profile_definitions = [
           {
             profile: nil,
-            must_support_info: USCore311OrganizationSequenceDefinitions::MUST_SUPPORTS.dup,
-            binding_info: USCore311OrganizationSequenceDefinitions::BINDINGS.dup
+            must_support_info: USCore311OrganizationSequenceDefinitions::MUST_SUPPORTS.deep_dup,
+            binding_info: USCore311OrganizationSequenceDefinitions::BINDINGS.deep_dup
           }
         ]
         test_output_against_profile('Organization', profile_definitions)
@@ -913,8 +913,8 @@ module Inferno
         profile_definitions = [
           {
             profile: nil,
-            must_support_info: USCore311PractitionerSequenceDefinitions::MUST_SUPPORTS.dup,
-            binding_info: USCore311PractitionerSequenceDefinitions::BINDINGS.dup
+            must_support_info: USCore311PractitionerSequenceDefinitions::MUST_SUPPORTS.deep_dup,
+            binding_info: USCore311PractitionerSequenceDefinitions::BINDINGS.deep_dup
           }
         ]
         test_output_against_profile('Practitioner', profile_definitions)
@@ -933,8 +933,8 @@ module Inferno
         profile_definitions = [
           {
             profile: nil,
-            must_support_info: USCore311ProvenanceSequenceDefinitions::MUST_SUPPORTS.dup,
-            binding_info: USCore311ProvenanceSequenceDefinitions::BINDINGS.dup
+            must_support_info: USCore311ProvenanceSequenceDefinitions::MUST_SUPPORTS.deep_dup,
+            binding_info: USCore311ProvenanceSequenceDefinitions::BINDINGS.deep_dup
           }
         ]
         test_output_against_profile('Provenance', profile_definitions)

--- a/lib/modules/uscore_v3.1.1/profile_definitions/bodyheight_definitions.rb
+++ b/lib/modules/uscore_v3.1.1/profile_definitions/bodyheight_definitions.rb
@@ -4,7 +4,7 @@ module Inferno
   module USCore311ProfileDefinitions
     class USCore311BodyheightSequenceDefinitions
       MUST_SUPPORTS = {
-        extensions: [],
+        extensions: [].freeze,
         slices: [
           {
             name: 'Observation.category:VSCat',
@@ -15,70 +15,70 @@ module Inferno
                 {
                   path: 'coding.code',
                   value: 'vital-signs'
-                },
+                }.freeze,
                 {
                   path: 'coding.system',
                   value: 'http://terminology.hl7.org/CodeSystem/observation-category'
-                }
-              ]
-            }
-          },
+                }.freeze
+              ].freeze
+            }.freeze
+          }.freeze,
           {
             name: 'Observation.value[x]:valueQuantity',
             path: 'value',
             discriminator: {
               type: 'type',
               code: 'Quantity'
-            }
-          }
-        ],
+            }.freeze
+          }.freeze
+        ].freeze,
         elements: [
           {
             path: 'status'
-          },
+          }.freeze,
           {
             path: 'category'
-          },
+          }.freeze,
           {
             path: 'category.coding'
-          },
+          }.freeze,
           {
             path: 'category.coding.system',
             fixed_value: 'http://terminology.hl7.org/CodeSystem/observation-category'
-          },
+          }.freeze,
           {
             path: 'category.coding.code',
             fixed_value: 'vital-signs'
-          },
+          }.freeze,
           {
             path: 'code'
-          },
+          }.freeze,
           {
             path: 'subject'
-          },
+          }.freeze,
           {
             path: 'effective'
-          },
+          }.freeze,
           {
             path: 'value'
-          },
+          }.freeze,
           {
             path: 'value.value'
-          },
+          }.freeze,
           {
             path: 'value.unit'
-          },
+          }.freeze,
           {
             path: 'value.system',
             fixed_value: 'http://unitsofmeasure.org'
-          },
+          }.freeze,
           {
             path: 'value.code'
-          },
+          }.freeze,
           {
             path: 'dataAbsentReason'
-          }
-        ]
+          }.freeze
+        ].freeze
       }.freeze
 
       DELAYED_REFERENCES = [].freeze
@@ -89,61 +89,61 @@ module Inferno
           strength: 'required',
           system: 'http://hl7.org/fhir/ValueSet/observation-status',
           path: 'status'
-        },
+        }.freeze,
         {
           type: 'CodeableConcept',
           strength: 'extensible',
           system: 'http://hl7.org/fhir/ValueSet/observation-vitalsignresult',
           path: 'code'
-        },
+        }.freeze,
         {
           type: 'code',
           strength: 'required',
           system: 'http://hl7.org/fhir/ValueSet/quantity-comparator',
           path: 'value.comparator'
-        },
+        }.freeze,
         {
           type: 'code',
           strength: 'required',
           system: 'http://hl7.org/fhir/ValueSet/ucum-bodylength',
           path: 'value.code'
-        },
+        }.freeze,
         {
           type: 'CodeableConcept',
           strength: 'extensible',
           system: 'http://hl7.org/fhir/ValueSet/data-absent-reason',
           path: 'dataAbsentReason'
-        },
+        }.freeze,
         {
           type: 'CodeableConcept',
           strength: 'extensible',
           system: 'http://hl7.org/fhir/ValueSet/observation-interpretation',
           path: 'interpretation'
-        },
+        }.freeze,
         {
           type: 'CodeableConcept',
           strength: 'extensible',
           system: 'http://hl7.org/fhir/ValueSet/observation-vitalsignresult',
           path: 'component.code'
-        },
+        }.freeze,
         {
           type: 'Quantity',
           strength: 'required',
           system: 'http://hl7.org/fhir/ValueSet/ucum-vitals-common',
           path: 'component.value'
-        },
+        }.freeze,
         {
           type: 'CodeableConcept',
           strength: 'extensible',
           system: 'http://hl7.org/fhir/ValueSet/data-absent-reason',
           path: 'component.dataAbsentReason'
-        },
+        }.freeze,
         {
           type: 'CodeableConcept',
           strength: 'extensible',
           system: 'http://hl7.org/fhir/ValueSet/observation-interpretation',
           path: 'component.interpretation'
-        }
+        }.freeze
       ].freeze
     end
   end

--- a/lib/modules/uscore_v3.1.1/profile_definitions/bodytemp_definitions.rb
+++ b/lib/modules/uscore_v3.1.1/profile_definitions/bodytemp_definitions.rb
@@ -4,7 +4,7 @@ module Inferno
   module USCore311ProfileDefinitions
     class USCore311BodytempSequenceDefinitions
       MUST_SUPPORTS = {
-        extensions: [],
+        extensions: [].freeze,
         slices: [
           {
             name: 'Observation.category:VSCat',
@@ -15,70 +15,70 @@ module Inferno
                 {
                   path: 'coding.code',
                   value: 'vital-signs'
-                },
+                }.freeze,
                 {
                   path: 'coding.system',
                   value: 'http://terminology.hl7.org/CodeSystem/observation-category'
-                }
-              ]
-            }
-          },
+                }.freeze
+              ].freeze
+            }.freeze
+          }.freeze,
           {
             name: 'Observation.value[x]:valueQuantity',
             path: 'value',
             discriminator: {
               type: 'type',
               code: 'Quantity'
-            }
-          }
-        ],
+            }.freeze
+          }.freeze
+        ].freeze,
         elements: [
           {
             path: 'status'
-          },
+          }.freeze,
           {
             path: 'category'
-          },
+          }.freeze,
           {
             path: 'category.coding'
-          },
+          }.freeze,
           {
             path: 'category.coding.system',
             fixed_value: 'http://terminology.hl7.org/CodeSystem/observation-category'
-          },
+          }.freeze,
           {
             path: 'category.coding.code',
             fixed_value: 'vital-signs'
-          },
+          }.freeze,
           {
             path: 'code'
-          },
+          }.freeze,
           {
             path: 'subject'
-          },
+          }.freeze,
           {
             path: 'effective'
-          },
+          }.freeze,
           {
             path: 'value'
-          },
+          }.freeze,
           {
             path: 'value.value'
-          },
+          }.freeze,
           {
             path: 'value.unit'
-          },
+          }.freeze,
           {
             path: 'value.system',
             fixed_value: 'http://unitsofmeasure.org'
-          },
+          }.freeze,
           {
             path: 'value.code'
-          },
+          }.freeze,
           {
             path: 'dataAbsentReason'
-          }
-        ]
+          }.freeze
+        ].freeze
       }.freeze
 
       DELAYED_REFERENCES = [].freeze
@@ -89,61 +89,61 @@ module Inferno
           strength: 'required',
           system: 'http://hl7.org/fhir/ValueSet/observation-status',
           path: 'status'
-        },
+        }.freeze,
         {
           type: 'CodeableConcept',
           strength: 'extensible',
           system: 'http://hl7.org/fhir/ValueSet/observation-vitalsignresult',
           path: 'code'
-        },
+        }.freeze,
         {
           type: 'code',
           strength: 'required',
           system: 'http://hl7.org/fhir/ValueSet/quantity-comparator',
           path: 'value.comparator'
-        },
+        }.freeze,
         {
           type: 'code',
           strength: 'required',
           system: 'http://hl7.org/fhir/ValueSet/ucum-bodytemp',
           path: 'value.code'
-        },
+        }.freeze,
         {
           type: 'CodeableConcept',
           strength: 'extensible',
           system: 'http://hl7.org/fhir/ValueSet/data-absent-reason',
           path: 'dataAbsentReason'
-        },
+        }.freeze,
         {
           type: 'CodeableConcept',
           strength: 'extensible',
           system: 'http://hl7.org/fhir/ValueSet/observation-interpretation',
           path: 'interpretation'
-        },
+        }.freeze,
         {
           type: 'CodeableConcept',
           strength: 'extensible',
           system: 'http://hl7.org/fhir/ValueSet/observation-vitalsignresult',
           path: 'component.code'
-        },
+        }.freeze,
         {
           type: 'Quantity',
           strength: 'required',
           system: 'http://hl7.org/fhir/ValueSet/ucum-vitals-common',
           path: 'component.value'
-        },
+        }.freeze,
         {
           type: 'CodeableConcept',
           strength: 'extensible',
           system: 'http://hl7.org/fhir/ValueSet/data-absent-reason',
           path: 'component.dataAbsentReason'
-        },
+        }.freeze,
         {
           type: 'CodeableConcept',
           strength: 'extensible',
           system: 'http://hl7.org/fhir/ValueSet/observation-interpretation',
           path: 'component.interpretation'
-        }
+        }.freeze
       ].freeze
     end
   end

--- a/lib/modules/uscore_v3.1.1/profile_definitions/bodyweight_definitions.rb
+++ b/lib/modules/uscore_v3.1.1/profile_definitions/bodyweight_definitions.rb
@@ -4,7 +4,7 @@ module Inferno
   module USCore311ProfileDefinitions
     class USCore311BodyweightSequenceDefinitions
       MUST_SUPPORTS = {
-        extensions: [],
+        extensions: [].freeze,
         slices: [
           {
             name: 'Observation.category:VSCat',
@@ -15,70 +15,70 @@ module Inferno
                 {
                   path: 'coding.code',
                   value: 'vital-signs'
-                },
+                }.freeze,
                 {
                   path: 'coding.system',
                   value: 'http://terminology.hl7.org/CodeSystem/observation-category'
-                }
-              ]
-            }
-          },
+                }.freeze
+              ].freeze
+            }.freeze
+          }.freeze,
           {
             name: 'Observation.value[x]:valueQuantity',
             path: 'value',
             discriminator: {
               type: 'type',
               code: 'Quantity'
-            }
-          }
-        ],
+            }.freeze
+          }.freeze
+        ].freeze,
         elements: [
           {
             path: 'status'
-          },
+          }.freeze,
           {
             path: 'category'
-          },
+          }.freeze,
           {
             path: 'category.coding'
-          },
+          }.freeze,
           {
             path: 'category.coding.system',
             fixed_value: 'http://terminology.hl7.org/CodeSystem/observation-category'
-          },
+          }.freeze,
           {
             path: 'category.coding.code',
             fixed_value: 'vital-signs'
-          },
+          }.freeze,
           {
             path: 'code'
-          },
+          }.freeze,
           {
             path: 'subject'
-          },
+          }.freeze,
           {
             path: 'effective'
-          },
+          }.freeze,
           {
             path: 'value'
-          },
+          }.freeze,
           {
             path: 'value.value'
-          },
+          }.freeze,
           {
             path: 'value.unit'
-          },
+          }.freeze,
           {
             path: 'value.system',
             fixed_value: 'http://unitsofmeasure.org'
-          },
+          }.freeze,
           {
             path: 'value.code'
-          },
+          }.freeze,
           {
             path: 'dataAbsentReason'
-          }
-        ]
+          }.freeze
+        ].freeze
       }.freeze
 
       DELAYED_REFERENCES = [].freeze
@@ -89,61 +89,61 @@ module Inferno
           strength: 'required',
           system: 'http://hl7.org/fhir/ValueSet/observation-status',
           path: 'status'
-        },
+        }.freeze,
         {
           type: 'CodeableConcept',
           strength: 'extensible',
           system: 'http://hl7.org/fhir/ValueSet/observation-vitalsignresult',
           path: 'code'
-        },
+        }.freeze,
         {
           type: 'code',
           strength: 'required',
           system: 'http://hl7.org/fhir/ValueSet/quantity-comparator',
           path: 'value.comparator'
-        },
+        }.freeze,
         {
           type: 'code',
           strength: 'required',
           system: 'http://hl7.org/fhir/ValueSet/ucum-bodyweight',
           path: 'value.code'
-        },
+        }.freeze,
         {
           type: 'CodeableConcept',
           strength: 'extensible',
           system: 'http://hl7.org/fhir/ValueSet/data-absent-reason',
           path: 'dataAbsentReason'
-        },
+        }.freeze,
         {
           type: 'CodeableConcept',
           strength: 'extensible',
           system: 'http://hl7.org/fhir/ValueSet/observation-interpretation',
           path: 'interpretation'
-        },
+        }.freeze,
         {
           type: 'CodeableConcept',
           strength: 'extensible',
           system: 'http://hl7.org/fhir/ValueSet/observation-vitalsignresult',
           path: 'component.code'
-        },
+        }.freeze,
         {
           type: 'Quantity',
           strength: 'required',
           system: 'http://hl7.org/fhir/ValueSet/ucum-vitals-common',
           path: 'component.value'
-        },
+        }.freeze,
         {
           type: 'CodeableConcept',
           strength: 'extensible',
           system: 'http://hl7.org/fhir/ValueSet/data-absent-reason',
           path: 'component.dataAbsentReason'
-        },
+        }.freeze,
         {
           type: 'CodeableConcept',
           strength: 'extensible',
           system: 'http://hl7.org/fhir/ValueSet/observation-interpretation',
           path: 'component.interpretation'
-        }
+        }.freeze
       ].freeze
     end
   end

--- a/lib/modules/uscore_v3.1.1/profile_definitions/bp_definitions.rb
+++ b/lib/modules/uscore_v3.1.1/profile_definitions/bp_definitions.rb
@@ -4,7 +4,7 @@ module Inferno
   module USCore311ProfileDefinitions
     class USCore311BpSequenceDefinitions
       MUST_SUPPORTS = {
-        extensions: [],
+        extensions: [].freeze,
         slices: [
           {
             name: 'Observation.category:VSCat',
@@ -15,46 +15,46 @@ module Inferno
                 {
                   path: 'coding.code',
                   value: 'vital-signs'
-                },
+                }.freeze,
                 {
                   path: 'coding.system',
                   value: 'http://terminology.hl7.org/CodeSystem/observation-category'
-                }
-              ]
-            }
-          }
-        ],
+                }.freeze
+              ].freeze
+            }.freeze
+          }.freeze
+        ].freeze,
         elements: [
           {
             path: 'status'
-          },
+          }.freeze,
           {
             path: 'category'
-          },
+          }.freeze,
           {
             path: 'category.coding'
-          },
+          }.freeze,
           {
             path: 'category.coding.system',
             fixed_value: 'http://terminology.hl7.org/CodeSystem/observation-category'
-          },
+          }.freeze,
           {
             path: 'category.coding.code',
             fixed_value: 'vital-signs'
-          },
+          }.freeze,
           {
             path: 'code'
-          },
+          }.freeze,
           {
             path: 'subject'
-          },
+          }.freeze,
           {
             path: 'effective'
-          },
+          }.freeze,
           {
             path: 'dataAbsentReason'
-          }
-        ]
+          }.freeze
+        ].freeze
       }.freeze
 
       DELAYED_REFERENCES = [].freeze
@@ -65,91 +65,91 @@ module Inferno
           strength: 'required',
           system: 'http://hl7.org/fhir/ValueSet/observation-status',
           path: 'status'
-        },
+        }.freeze,
         {
           type: 'CodeableConcept',
           strength: 'extensible',
           system: 'http://hl7.org/fhir/ValueSet/observation-vitalsignresult',
           path: 'code'
-        },
+        }.freeze,
         {
           type: 'CodeableConcept',
           strength: 'extensible',
           system: 'http://hl7.org/fhir/ValueSet/data-absent-reason',
           path: 'dataAbsentReason'
-        },
+        }.freeze,
         {
           type: 'CodeableConcept',
           strength: 'extensible',
           system: 'http://hl7.org/fhir/ValueSet/observation-interpretation',
           path: 'interpretation'
-        },
+        }.freeze,
         {
           type: 'CodeableConcept',
           strength: 'extensible',
           system: 'http://hl7.org/fhir/ValueSet/observation-vitalsignresult',
           path: 'component.code'
-        },
+        }.freeze,
         {
           type: 'CodeableConcept',
           strength: 'extensible',
           system: 'http://hl7.org/fhir/ValueSet/data-absent-reason',
           path: 'component.dataAbsentReason'
-        },
+        }.freeze,
         {
           type: 'CodeableConcept',
           strength: 'extensible',
           system: 'http://hl7.org/fhir/ValueSet/observation-interpretation',
           path: 'component.interpretation'
-        },
+        }.freeze,
         {
           type: 'CodeableConcept',
           strength: 'extensible',
           system: 'http://hl7.org/fhir/ValueSet/observation-vitalsignresult',
           path: 'component.code'
-        },
+        }.freeze,
         {
           type: 'code',
           strength: 'required',
           system: 'http://hl7.org/fhir/ValueSet/quantity-comparator',
           path: 'component.value.comparator'
-        },
+        }.freeze,
         {
           type: 'CodeableConcept',
           strength: 'extensible',
           system: 'http://hl7.org/fhir/ValueSet/data-absent-reason',
           path: 'component.dataAbsentReason'
-        },
+        }.freeze,
         {
           type: 'CodeableConcept',
           strength: 'extensible',
           system: 'http://hl7.org/fhir/ValueSet/observation-interpretation',
           path: 'component.interpretation'
-        },
+        }.freeze,
         {
           type: 'CodeableConcept',
           strength: 'extensible',
           system: 'http://hl7.org/fhir/ValueSet/observation-vitalsignresult',
           path: 'component.code'
-        },
+        }.freeze,
         {
           type: 'code',
           strength: 'required',
           system: 'http://hl7.org/fhir/ValueSet/quantity-comparator',
           path: 'component.value.comparator'
-        },
+        }.freeze,
         {
           type: 'CodeableConcept',
           strength: 'extensible',
           system: 'http://hl7.org/fhir/ValueSet/data-absent-reason',
           path: 'component.dataAbsentReason'
-        },
+        }.freeze,
         {
           type: 'CodeableConcept',
           strength: 'extensible',
           system: 'http://hl7.org/fhir/ValueSet/observation-interpretation',
           path: 'component.interpretation'
-        }
+        }.freeze
       ].freeze
     end
   end

--- a/lib/modules/uscore_v3.1.1/profile_definitions/head_occipital_frontal_circumference_percentile_definitions.rb
+++ b/lib/modules/uscore_v3.1.1/profile_definitions/head_occipital_frontal_circumference_percentile_definitions.rb
@@ -4,7 +4,7 @@ module Inferno
   module USCore311ProfileDefinitions
     class USCore311HeadOccipitalFrontalCircumferencePercentileSequenceDefinitions
       MUST_SUPPORTS = {
-        extensions: [],
+        extensions: [].freeze,
         slices: [
           {
             name: 'Observation.category:VSCat',
@@ -15,69 +15,69 @@ module Inferno
                 {
                   path: 'coding.code',
                   value: 'vital-signs'
-                },
+                }.freeze,
                 {
                   path: 'coding.system',
                   value: 'http://terminology.hl7.org/CodeSystem/observation-category'
-                }
-              ]
-            }
-          },
+                }.freeze
+              ].freeze
+            }.freeze
+          }.freeze,
           {
             name: 'Observation.value[x]:valueQuantity',
             path: 'value',
             discriminator: {
               type: 'type',
               code: 'Quantity'
-            }
-          }
-        ],
+            }.freeze
+          }.freeze
+        ].freeze,
         elements: [
           {
             path: 'status'
-          },
+          }.freeze,
           {
             path: 'category'
-          },
+          }.freeze,
           {
             path: 'category.coding'
-          },
+          }.freeze,
           {
             path: 'category.coding.system',
             fixed_value: 'http://terminology.hl7.org/CodeSystem/observation-category'
-          },
+          }.freeze,
           {
             path: 'category.coding.code',
             fixed_value: 'vital-signs'
-          },
+          }.freeze,
           {
             path: 'code.coding.code',
             fixed_value: '8289-1'
-          },
+          }.freeze,
           {
             path: 'subject'
-          },
+          }.freeze,
           {
             path: 'effective'
-          },
+          }.freeze,
           {
             path: 'value'
-          },
+          }.freeze,
           {
             path: 'value.value'
-          },
+          }.freeze,
           {
             path: 'value.unit'
-          },
+          }.freeze,
           {
             path: 'value.system',
             fixed_value: 'http://unitsofmeasure.org'
-          },
+          }.freeze,
           {
             path: 'value.code',
             fixed_value: '%'
-          }
-        ]
+          }.freeze
+        ].freeze
       }.freeze
 
       DELAYED_REFERENCES = [].freeze
@@ -88,55 +88,55 @@ module Inferno
           strength: 'required',
           system: 'http://hl7.org/fhir/ValueSet/observation-status',
           path: 'status'
-        },
+        }.freeze,
         {
           type: 'CodeableConcept',
           strength: 'extensible',
           system: 'http://hl7.org/fhir/ValueSet/observation-vitalsignresult',
           path: 'code'
-        },
+        }.freeze,
         {
           type: 'code',
           strength: 'required',
           system: 'http://hl7.org/fhir/ValueSet/quantity-comparator',
           path: 'value.comparator'
-        },
+        }.freeze,
         {
           type: 'CodeableConcept',
           strength: 'extensible',
           system: 'http://hl7.org/fhir/ValueSet/data-absent-reason',
           path: 'dataAbsentReason'
-        },
+        }.freeze,
         {
           type: 'CodeableConcept',
           strength: 'extensible',
           system: 'http://hl7.org/fhir/ValueSet/observation-interpretation',
           path: 'interpretation'
-        },
+        }.freeze,
         {
           type: 'CodeableConcept',
           strength: 'extensible',
           system: 'http://hl7.org/fhir/ValueSet/observation-vitalsignresult',
           path: 'component.code'
-        },
+        }.freeze,
         {
           type: 'Quantity',
           strength: 'required',
           system: 'http://hl7.org/fhir/ValueSet/ucum-vitals-common',
           path: 'component.value'
-        },
+        }.freeze,
         {
           type: 'CodeableConcept',
           strength: 'extensible',
           system: 'http://hl7.org/fhir/ValueSet/data-absent-reason',
           path: 'component.dataAbsentReason'
-        },
+        }.freeze,
         {
           type: 'CodeableConcept',
           strength: 'extensible',
           system: 'http://hl7.org/fhir/ValueSet/observation-interpretation',
           path: 'component.interpretation'
-        }
+        }.freeze
       ].freeze
     end
   end

--- a/lib/modules/uscore_v3.1.1/profile_definitions/heartrate_definitions.rb
+++ b/lib/modules/uscore_v3.1.1/profile_definitions/heartrate_definitions.rb
@@ -4,7 +4,7 @@ module Inferno
   module USCore311ProfileDefinitions
     class USCore311HeartrateSequenceDefinitions
       MUST_SUPPORTS = {
-        extensions: [],
+        extensions: [].freeze,
         slices: [
           {
             name: 'Observation.category:VSCat',
@@ -15,71 +15,71 @@ module Inferno
                 {
                   path: 'coding.code',
                   value: 'vital-signs'
-                },
+                }.freeze,
                 {
                   path: 'coding.system',
                   value: 'http://terminology.hl7.org/CodeSystem/observation-category'
-                }
-              ]
-            }
-          },
+                }.freeze
+              ].freeze
+            }.freeze
+          }.freeze,
           {
             name: 'Observation.value[x]:valueQuantity',
             path: 'value',
             discriminator: {
               type: 'type',
               code: 'Quantity'
-            }
-          }
-        ],
+            }.freeze
+          }.freeze
+        ].freeze,
         elements: [
           {
             path: 'status'
-          },
+          }.freeze,
           {
             path: 'category'
-          },
+          }.freeze,
           {
             path: 'category.coding'
-          },
+          }.freeze,
           {
             path: 'category.coding.system',
             fixed_value: 'http://terminology.hl7.org/CodeSystem/observation-category'
-          },
+          }.freeze,
           {
             path: 'category.coding.code',
             fixed_value: 'vital-signs'
-          },
+          }.freeze,
           {
             path: 'code'
-          },
+          }.freeze,
           {
             path: 'subject'
-          },
+          }.freeze,
           {
             path: 'effective'
-          },
+          }.freeze,
           {
             path: 'value'
-          },
+          }.freeze,
           {
             path: 'value.value'
-          },
+          }.freeze,
           {
             path: 'value.unit'
-          },
+          }.freeze,
           {
             path: 'value.system',
             fixed_value: 'http://unitsofmeasure.org'
-          },
+          }.freeze,
           {
             path: 'value.code',
             fixed_value: '/min'
-          },
+          }.freeze,
           {
             path: 'dataAbsentReason'
-          }
-        ]
+          }.freeze
+        ].freeze
       }.freeze
 
       DELAYED_REFERENCES = [].freeze
@@ -90,55 +90,55 @@ module Inferno
           strength: 'required',
           system: 'http://hl7.org/fhir/ValueSet/observation-status',
           path: 'status'
-        },
+        }.freeze,
         {
           type: 'CodeableConcept',
           strength: 'extensible',
           system: 'http://hl7.org/fhir/ValueSet/observation-vitalsignresult',
           path: 'code'
-        },
+        }.freeze,
         {
           type: 'code',
           strength: 'required',
           system: 'http://hl7.org/fhir/ValueSet/quantity-comparator',
           path: 'value.comparator'
-        },
+        }.freeze,
         {
           type: 'CodeableConcept',
           strength: 'extensible',
           system: 'http://hl7.org/fhir/ValueSet/data-absent-reason',
           path: 'dataAbsentReason'
-        },
+        }.freeze,
         {
           type: 'CodeableConcept',
           strength: 'extensible',
           system: 'http://hl7.org/fhir/ValueSet/observation-interpretation',
           path: 'interpretation'
-        },
+        }.freeze,
         {
           type: 'CodeableConcept',
           strength: 'extensible',
           system: 'http://hl7.org/fhir/ValueSet/observation-vitalsignresult',
           path: 'component.code'
-        },
+        }.freeze,
         {
           type: 'Quantity',
           strength: 'required',
           system: 'http://hl7.org/fhir/ValueSet/ucum-vitals-common',
           path: 'component.value'
-        },
+        }.freeze,
         {
           type: 'CodeableConcept',
           strength: 'extensible',
           system: 'http://hl7.org/fhir/ValueSet/data-absent-reason',
           path: 'component.dataAbsentReason'
-        },
+        }.freeze,
         {
           type: 'CodeableConcept',
           strength: 'extensible',
           system: 'http://hl7.org/fhir/ValueSet/observation-interpretation',
           path: 'component.interpretation'
-        }
+        }.freeze
       ].freeze
     end
   end

--- a/lib/modules/uscore_v3.1.1/profile_definitions/pediatric_bmi_for_age_definitions.rb
+++ b/lib/modules/uscore_v3.1.1/profile_definitions/pediatric_bmi_for_age_definitions.rb
@@ -4,7 +4,7 @@ module Inferno
   module USCore311ProfileDefinitions
     class USCore311PediatricBmiForAgeSequenceDefinitions
       MUST_SUPPORTS = {
-        extensions: [],
+        extensions: [].freeze,
         slices: [
           {
             name: 'Observation.category:VSCat',
@@ -15,69 +15,69 @@ module Inferno
                 {
                   path: 'coding.code',
                   value: 'vital-signs'
-                },
+                }.freeze,
                 {
                   path: 'coding.system',
                   value: 'http://terminology.hl7.org/CodeSystem/observation-category'
-                }
-              ]
-            }
-          },
+                }.freeze
+              ].freeze
+            }.freeze
+          }.freeze,
           {
             name: 'Observation.value[x]:valueQuantity',
             path: 'value',
             discriminator: {
               type: 'type',
               code: 'Quantity'
-            }
-          }
-        ],
+            }.freeze
+          }.freeze
+        ].freeze,
         elements: [
           {
             path: 'status'
-          },
+          }.freeze,
           {
             path: 'category'
-          },
+          }.freeze,
           {
             path: 'category.coding'
-          },
+          }.freeze,
           {
             path: 'category.coding.system',
             fixed_value: 'http://terminology.hl7.org/CodeSystem/observation-category'
-          },
+          }.freeze,
           {
             path: 'category.coding.code',
             fixed_value: 'vital-signs'
-          },
+          }.freeze,
           {
             path: 'code.coding.code',
             fixed_value: '59576-9'
-          },
+          }.freeze,
           {
             path: 'subject'
-          },
+          }.freeze,
           {
             path: 'effective'
-          },
+          }.freeze,
           {
             path: 'value'
-          },
+          }.freeze,
           {
             path: 'value.value'
-          },
+          }.freeze,
           {
             path: 'value.unit'
-          },
+          }.freeze,
           {
             path: 'value.system',
             fixed_value: 'http://unitsofmeasure.org'
-          },
+          }.freeze,
           {
             path: 'value.code',
             fixed_value: '%'
-          }
-        ]
+          }.freeze
+        ].freeze
       }.freeze
 
       DELAYED_REFERENCES = [].freeze
@@ -88,55 +88,55 @@ module Inferno
           strength: 'required',
           system: 'http://hl7.org/fhir/ValueSet/observation-status',
           path: 'status'
-        },
+        }.freeze,
         {
           type: 'CodeableConcept',
           strength: 'extensible',
           system: 'http://hl7.org/fhir/ValueSet/observation-vitalsignresult',
           path: 'code'
-        },
+        }.freeze,
         {
           type: 'code',
           strength: 'required',
           system: 'http://hl7.org/fhir/ValueSet/quantity-comparator',
           path: 'value.comparator'
-        },
+        }.freeze,
         {
           type: 'CodeableConcept',
           strength: 'extensible',
           system: 'http://hl7.org/fhir/ValueSet/data-absent-reason',
           path: 'dataAbsentReason'
-        },
+        }.freeze,
         {
           type: 'CodeableConcept',
           strength: 'extensible',
           system: 'http://hl7.org/fhir/ValueSet/observation-interpretation',
           path: 'interpretation'
-        },
+        }.freeze,
         {
           type: 'CodeableConcept',
           strength: 'extensible',
           system: 'http://hl7.org/fhir/ValueSet/observation-vitalsignresult',
           path: 'component.code'
-        },
+        }.freeze,
         {
           type: 'Quantity',
           strength: 'required',
           system: 'http://hl7.org/fhir/ValueSet/ucum-vitals-common',
           path: 'component.value'
-        },
+        }.freeze,
         {
           type: 'CodeableConcept',
           strength: 'extensible',
           system: 'http://hl7.org/fhir/ValueSet/data-absent-reason',
           path: 'component.dataAbsentReason'
-        },
+        }.freeze,
         {
           type: 'CodeableConcept',
           strength: 'extensible',
           system: 'http://hl7.org/fhir/ValueSet/observation-interpretation',
           path: 'component.interpretation'
-        }
+        }.freeze
       ].freeze
     end
   end

--- a/lib/modules/uscore_v3.1.1/profile_definitions/pediatric_weight_for_height_definitions.rb
+++ b/lib/modules/uscore_v3.1.1/profile_definitions/pediatric_weight_for_height_definitions.rb
@@ -4,7 +4,7 @@ module Inferno
   module USCore311ProfileDefinitions
     class USCore311PediatricWeightForHeightSequenceDefinitions
       MUST_SUPPORTS = {
-        extensions: [],
+        extensions: [].freeze,
         slices: [
           {
             name: 'Observation.category:VSCat',
@@ -15,69 +15,69 @@ module Inferno
                 {
                   path: 'coding.code',
                   value: 'vital-signs'
-                },
+                }.freeze,
                 {
                   path: 'coding.system',
                   value: 'http://terminology.hl7.org/CodeSystem/observation-category'
-                }
-              ]
-            }
-          },
+                }.freeze
+              ].freeze
+            }.freeze
+          }.freeze,
           {
             name: 'Observation.value[x]:valueQuantity',
             path: 'value',
             discriminator: {
               type: 'type',
               code: 'Quantity'
-            }
-          }
-        ],
+            }.freeze
+          }.freeze
+        ].freeze,
         elements: [
           {
             path: 'status'
-          },
+          }.freeze,
           {
             path: 'category'
-          },
+          }.freeze,
           {
             path: 'category.coding'
-          },
+          }.freeze,
           {
             path: 'category.coding.system',
             fixed_value: 'http://terminology.hl7.org/CodeSystem/observation-category'
-          },
+          }.freeze,
           {
             path: 'category.coding.code',
             fixed_value: 'vital-signs'
-          },
+          }.freeze,
           {
             path: 'code.coding.code',
             fixed_value: '77606-2'
-          },
+          }.freeze,
           {
             path: 'subject'
-          },
+          }.freeze,
           {
             path: 'effective'
-          },
+          }.freeze,
           {
             path: 'value'
-          },
+          }.freeze,
           {
             path: 'value.value'
-          },
+          }.freeze,
           {
             path: 'value.unit'
-          },
+          }.freeze,
           {
             path: 'value.system',
             fixed_value: 'http://unitsofmeasure.org'
-          },
+          }.freeze,
           {
             path: 'value.code',
             fixed_value: '%'
-          }
-        ]
+          }.freeze
+        ].freeze
       }.freeze
 
       DELAYED_REFERENCES = [].freeze
@@ -88,55 +88,55 @@ module Inferno
           strength: 'required',
           system: 'http://hl7.org/fhir/ValueSet/observation-status',
           path: 'status'
-        },
+        }.freeze,
         {
           type: 'CodeableConcept',
           strength: 'extensible',
           system: 'http://hl7.org/fhir/ValueSet/observation-vitalsignresult',
           path: 'code'
-        },
+        }.freeze,
         {
           type: 'code',
           strength: 'required',
           system: 'http://hl7.org/fhir/ValueSet/quantity-comparator',
           path: 'value.comparator'
-        },
+        }.freeze,
         {
           type: 'CodeableConcept',
           strength: 'extensible',
           system: 'http://hl7.org/fhir/ValueSet/data-absent-reason',
           path: 'dataAbsentReason'
-        },
+        }.freeze,
         {
           type: 'CodeableConcept',
           strength: 'extensible',
           system: 'http://hl7.org/fhir/ValueSet/observation-interpretation',
           path: 'interpretation'
-        },
+        }.freeze,
         {
           type: 'CodeableConcept',
           strength: 'extensible',
           system: 'http://hl7.org/fhir/ValueSet/observation-vitalsignresult',
           path: 'component.code'
-        },
+        }.freeze,
         {
           type: 'Quantity',
           strength: 'required',
           system: 'http://hl7.org/fhir/ValueSet/ucum-vitals-common',
           path: 'component.value'
-        },
+        }.freeze,
         {
           type: 'CodeableConcept',
           strength: 'extensible',
           system: 'http://hl7.org/fhir/ValueSet/data-absent-reason',
           path: 'component.dataAbsentReason'
-        },
+        }.freeze,
         {
           type: 'CodeableConcept',
           strength: 'extensible',
           system: 'http://hl7.org/fhir/ValueSet/observation-interpretation',
           path: 'component.interpretation'
-        }
+        }.freeze
       ].freeze
     end
   end

--- a/lib/modules/uscore_v3.1.1/profile_definitions/resprate_definitions.rb
+++ b/lib/modules/uscore_v3.1.1/profile_definitions/resprate_definitions.rb
@@ -4,7 +4,7 @@ module Inferno
   module USCore311ProfileDefinitions
     class USCore311ResprateSequenceDefinitions
       MUST_SUPPORTS = {
-        extensions: [],
+        extensions: [].freeze,
         slices: [
           {
             name: 'Observation.category:VSCat',
@@ -15,71 +15,71 @@ module Inferno
                 {
                   path: 'coding.code',
                   value: 'vital-signs'
-                },
+                }.freeze,
                 {
                   path: 'coding.system',
                   value: 'http://terminology.hl7.org/CodeSystem/observation-category'
-                }
-              ]
-            }
-          },
+                }.freeze
+              ].freeze
+            }.freeze
+          }.freeze,
           {
             name: 'Observation.value[x]:valueQuantity',
             path: 'value',
             discriminator: {
               type: 'type',
               code: 'Quantity'
-            }
-          }
-        ],
+            }.freeze
+          }.freeze
+        ].freeze,
         elements: [
           {
             path: 'status'
-          },
+          }.freeze,
           {
             path: 'category'
-          },
+          }.freeze,
           {
             path: 'category.coding'
-          },
+          }.freeze,
           {
             path: 'category.coding.system',
             fixed_value: 'http://terminology.hl7.org/CodeSystem/observation-category'
-          },
+          }.freeze,
           {
             path: 'category.coding.code',
             fixed_value: 'vital-signs'
-          },
+          }.freeze,
           {
             path: 'code'
-          },
+          }.freeze,
           {
             path: 'subject'
-          },
+          }.freeze,
           {
             path: 'effective'
-          },
+          }.freeze,
           {
             path: 'value'
-          },
+          }.freeze,
           {
             path: 'value.value'
-          },
+          }.freeze,
           {
             path: 'value.unit'
-          },
+          }.freeze,
           {
             path: 'value.system',
             fixed_value: 'http://unitsofmeasure.org'
-          },
+          }.freeze,
           {
             path: 'value.code',
             fixed_value: '/min'
-          },
+          }.freeze,
           {
             path: 'dataAbsentReason'
-          }
-        ]
+          }.freeze
+        ].freeze
       }.freeze
 
       DELAYED_REFERENCES = [].freeze
@@ -90,55 +90,55 @@ module Inferno
           strength: 'required',
           system: 'http://hl7.org/fhir/ValueSet/observation-status',
           path: 'status'
-        },
+        }.freeze,
         {
           type: 'CodeableConcept',
           strength: 'extensible',
           system: 'http://hl7.org/fhir/ValueSet/observation-vitalsignresult',
           path: 'code'
-        },
+        }.freeze,
         {
           type: 'code',
           strength: 'required',
           system: 'http://hl7.org/fhir/ValueSet/quantity-comparator',
           path: 'value.comparator'
-        },
+        }.freeze,
         {
           type: 'CodeableConcept',
           strength: 'extensible',
           system: 'http://hl7.org/fhir/ValueSet/data-absent-reason',
           path: 'dataAbsentReason'
-        },
+        }.freeze,
         {
           type: 'CodeableConcept',
           strength: 'extensible',
           system: 'http://hl7.org/fhir/ValueSet/observation-interpretation',
           path: 'interpretation'
-        },
+        }.freeze,
         {
           type: 'CodeableConcept',
           strength: 'extensible',
           system: 'http://hl7.org/fhir/ValueSet/observation-vitalsignresult',
           path: 'component.code'
-        },
+        }.freeze,
         {
           type: 'Quantity',
           strength: 'required',
           system: 'http://hl7.org/fhir/ValueSet/ucum-vitals-common',
           path: 'component.value'
-        },
+        }.freeze,
         {
           type: 'CodeableConcept',
           strength: 'extensible',
           system: 'http://hl7.org/fhir/ValueSet/data-absent-reason',
           path: 'component.dataAbsentReason'
-        },
+        }.freeze,
         {
           type: 'CodeableConcept',
           strength: 'extensible',
           system: 'http://hl7.org/fhir/ValueSet/observation-interpretation',
           path: 'component.interpretation'
-        }
+        }.freeze
       ].freeze
     end
   end

--- a/lib/modules/uscore_v3.1.1/profile_definitions/us_core_allergyintolerance_definitions.rb
+++ b/lib/modules/uscore_v3.1.1/profile_definitions/us_core_allergyintolerance_definitions.rb
@@ -4,28 +4,28 @@ module Inferno
   module USCore311ProfileDefinitions
     class USCore311AllergyintoleranceSequenceDefinitions
       MUST_SUPPORTS = {
-        extensions: [],
-        slices: [],
+        extensions: [].freeze,
+        slices: [].freeze,
         elements: [
           {
             path: 'clinicalStatus'
-          },
+          }.freeze,
           {
             path: 'verificationStatus'
-          },
+          }.freeze,
           {
             path: 'code'
-          },
+          }.freeze,
           {
             path: 'patient'
-          },
+          }.freeze,
           {
             path: 'reaction'
-          },
+          }.freeze,
           {
             path: 'reaction.manifestation'
-          }
-        ]
+          }.freeze
+        ].freeze
       }.freeze
 
       DELAYED_REFERENCES = [].freeze
@@ -36,49 +36,49 @@ module Inferno
           strength: 'required',
           system: 'http://hl7.org/fhir/ValueSet/allergyintolerance-clinical',
           path: 'clinicalStatus'
-        },
+        }.freeze,
         {
           type: 'CodeableConcept',
           strength: 'required',
           system: 'http://hl7.org/fhir/ValueSet/allergyintolerance-verification',
           path: 'verificationStatus'
-        },
+        }.freeze,
         {
           type: 'code',
           strength: 'required',
           system: 'http://hl7.org/fhir/ValueSet/allergy-intolerance-type',
           path: 'type'
-        },
+        }.freeze,
         {
           type: 'code',
           strength: 'required',
           system: 'http://hl7.org/fhir/ValueSet/allergy-intolerance-category',
           path: 'category'
-        },
+        }.freeze,
         {
           type: 'code',
           strength: 'required',
           system: 'http://hl7.org/fhir/ValueSet/allergy-intolerance-criticality',
           path: 'criticality'
-        },
+        }.freeze,
         {
           type: 'CodeableConcept',
           strength: 'extensible',
           system: 'http://hl7.org/fhir/us/core/ValueSet/us-core-allergy-substance',
           path: 'code'
-        },
+        }.freeze,
         {
           type: 'CodeableConcept',
           strength: 'extensible',
           system: 'http://hl7.org/fhir/ValueSet/clinical-findings',
           path: 'reaction.manifestation'
-        },
+        }.freeze,
         {
           type: 'code',
           strength: 'required',
           system: 'http://hl7.org/fhir/ValueSet/reaction-event-severity',
           path: 'reaction.severity'
-        }
+        }.freeze
       ].freeze
     end
   end

--- a/lib/modules/uscore_v3.1.1/profile_definitions/us_core_careplan_definitions.rb
+++ b/lib/modules/uscore_v3.1.1/profile_definitions/us_core_careplan_definitions.rb
@@ -4,7 +4,7 @@ module Inferno
   module USCore311ProfileDefinitions
     class USCore311CareplanSequenceDefinitions
       MUST_SUPPORTS = {
-        extensions: [],
+        extensions: [].freeze,
         slices: [
           {
             name: 'CarePlan.category:AssessPlan',
@@ -14,29 +14,29 @@ module Inferno
               path: '',
               code: 'assess-plan',
               system: 'http://hl7.org/fhir/us/core/CodeSystem/careplan-category'
-            }
-          }
-        ],
+            }.freeze
+          }.freeze
+        ].freeze,
         elements: [
           {
             path: 'text'
-          },
+          }.freeze,
           {
             path: 'text.status'
-          },
+          }.freeze,
           {
             path: 'status'
-          },
+          }.freeze,
           {
             path: 'intent'
-          },
+          }.freeze,
           {
             path: 'category'
-          },
+          }.freeze,
           {
             path: 'subject'
-          }
-        ]
+          }.freeze
+        ].freeze
       }.freeze
 
       DELAYED_REFERENCES = [].freeze
@@ -47,31 +47,31 @@ module Inferno
           strength: 'required',
           system: 'http://hl7.org/fhir/us/core/ValueSet/us-core-narrative-status',
           path: 'text.status'
-        },
+        }.freeze,
         {
           type: 'code',
           strength: 'required',
           system: 'http://hl7.org/fhir/ValueSet/request-status',
           path: 'status'
-        },
+        }.freeze,
         {
           type: 'code',
           strength: 'required',
           system: 'http://hl7.org/fhir/ValueSet/care-plan-intent',
           path: 'intent'
-        },
+        }.freeze,
         {
           type: 'code',
           strength: 'required',
           system: 'http://hl7.org/fhir/ValueSet/care-plan-activity-kind',
           path: 'activity.detail.kind'
-        },
+        }.freeze,
         {
           type: 'code',
           strength: 'required',
           system: 'http://hl7.org/fhir/ValueSet/care-plan-activity-status',
           path: 'activity.detail.status'
-        }
+        }.freeze
       ].freeze
     end
   end

--- a/lib/modules/uscore_v3.1.1/profile_definitions/us_core_careteam_definitions.rb
+++ b/lib/modules/uscore_v3.1.1/profile_definitions/us_core_careteam_definitions.rb
@@ -4,25 +4,25 @@ module Inferno
   module USCore311ProfileDefinitions
     class USCore311CareteamSequenceDefinitions
       MUST_SUPPORTS = {
-        extensions: [],
-        slices: [],
+        extensions: [].freeze,
+        slices: [].freeze,
         elements: [
           {
             path: 'status'
-          },
+          }.freeze,
           {
             path: 'subject'
-          },
+          }.freeze,
           {
             path: 'participant'
-          },
+          }.freeze,
           {
             path: 'participant.role'
-          },
+          }.freeze,
           {
             path: 'participant.member'
-          }
-        ]
+          }.freeze
+        ].freeze
       }.freeze
 
       DELAYED_REFERENCES = [
@@ -31,8 +31,8 @@ module Inferno
           resources: [
             'Practitioner',
             'Organization'
-          ]
-        }
+          ].freeze
+        }.freeze
       ].freeze
 
       BINDINGS = [
@@ -41,13 +41,13 @@ module Inferno
           strength: 'required',
           system: 'http://hl7.org/fhir/ValueSet/care-team-status',
           path: 'status'
-        },
+        }.freeze,
         {
           type: 'CodeableConcept',
           strength: 'extensible',
           system: 'http://hl7.org/fhir/us/core/ValueSet/us-core-careteam-provider-roles',
           path: 'participant.role'
-        }
+        }.freeze
       ].freeze
     end
   end

--- a/lib/modules/uscore_v3.1.1/profile_definitions/us_core_condition_definitions.rb
+++ b/lib/modules/uscore_v3.1.1/profile_definitions/us_core_condition_definitions.rb
@@ -4,25 +4,25 @@ module Inferno
   module USCore311ProfileDefinitions
     class USCore311ConditionSequenceDefinitions
       MUST_SUPPORTS = {
-        extensions: [],
-        slices: [],
+        extensions: [].freeze,
+        slices: [].freeze,
         elements: [
           {
             path: 'clinicalStatus'
-          },
+          }.freeze,
           {
             path: 'verificationStatus'
-          },
+          }.freeze,
           {
             path: 'category'
-          },
+          }.freeze,
           {
             path: 'code'
-          },
+          }.freeze,
           {
             path: 'subject'
-          }
-        ]
+          }.freeze
+        ].freeze
       }.freeze
 
       DELAYED_REFERENCES = [].freeze
@@ -33,25 +33,25 @@ module Inferno
           strength: 'required',
           system: 'http://hl7.org/fhir/ValueSet/condition-clinical',
           path: 'clinicalStatus'
-        },
+        }.freeze,
         {
           type: 'CodeableConcept',
           strength: 'required',
           system: 'http://hl7.org/fhir/ValueSet/condition-ver-status',
           path: 'verificationStatus'
-        },
+        }.freeze,
         {
           type: 'CodeableConcept',
           strength: 'extensible',
           system: 'http://hl7.org/fhir/us/core/ValueSet/us-core-condition-category',
           path: 'category'
-        },
+        }.freeze,
         {
           type: 'CodeableConcept',
           strength: 'extensible',
           system: 'http://hl7.org/fhir/us/core/ValueSet/us-core-condition-code',
           path: 'code'
-        }
+        }.freeze
       ].freeze
     end
   end

--- a/lib/modules/uscore_v3.1.1/profile_definitions/us_core_diagnosticreport_lab_definitions.rb
+++ b/lib/modules/uscore_v3.1.1/profile_definitions/us_core_diagnosticreport_lab_definitions.rb
@@ -4,7 +4,7 @@ module Inferno
   module USCore311ProfileDefinitions
     class USCore311DiagnosticreportLabSequenceDefinitions
       MUST_SUPPORTS = {
-        extensions: [],
+        extensions: [].freeze,
         slices: [
           {
             name: 'DiagnosticReport.category:LaboratorySlice',
@@ -14,35 +14,35 @@ module Inferno
               path: '',
               code: 'LAB',
               system: 'http://terminology.hl7.org/CodeSystem/v2-0074'
-            }
-          }
-        ],
+            }.freeze
+          }.freeze
+        ].freeze,
         elements: [
           {
             path: 'status'
-          },
+          }.freeze,
           {
             path: 'category'
-          },
+          }.freeze,
           {
             path: 'code'
-          },
+          }.freeze,
           {
             path: 'subject'
-          },
+          }.freeze,
           {
             path: 'effective'
-          },
+          }.freeze,
           {
             path: 'issued'
-          },
+          }.freeze,
           {
             path: 'performer'
-          },
+          }.freeze,
           {
             path: 'result'
-          }
-        ]
+          }.freeze
+        ].freeze
       }.freeze
 
       DELAYED_REFERENCES = [
@@ -51,8 +51,8 @@ module Inferno
           resources: [
             'Practitioner',
             'Organization'
-          ]
-        }
+          ].freeze
+        }.freeze
       ].freeze
 
       BINDINGS = [
@@ -61,13 +61,13 @@ module Inferno
           strength: 'required',
           system: 'http://hl7.org/fhir/ValueSet/diagnostic-report-status',
           path: 'status'
-        },
+        }.freeze,
         {
           type: 'CodeableConcept',
           strength: 'extensible',
           system: 'http://hl7.org/fhir/us/core/ValueSet/us-core-diagnosticreport-lab-codes',
           path: 'code'
-        }
+        }.freeze
       ].freeze
     end
   end

--- a/lib/modules/uscore_v3.1.1/profile_definitions/us_core_diagnosticreport_note_definitions.rb
+++ b/lib/modules/uscore_v3.1.1/profile_definitions/us_core_diagnosticreport_note_definitions.rb
@@ -4,37 +4,37 @@ module Inferno
   module USCore311ProfileDefinitions
     class USCore311DiagnosticreportNoteSequenceDefinitions
       MUST_SUPPORTS = {
-        extensions: [],
-        slices: [],
+        extensions: [].freeze,
+        slices: [].freeze,
         elements: [
           {
             path: 'status'
-          },
+          }.freeze,
           {
             path: 'category'
-          },
+          }.freeze,
           {
             path: 'code'
-          },
+          }.freeze,
           {
             path: 'subject'
-          },
+          }.freeze,
           {
             path: 'encounter'
-          },
+          }.freeze,
           {
             path: 'effective'
-          },
+          }.freeze,
           {
             path: 'issued'
-          },
+          }.freeze,
           {
             path: 'performer'
-          },
+          }.freeze,
           {
             path: 'presentedForm'
-          }
-        ]
+          }.freeze
+        ].freeze
       }.freeze
 
       DELAYED_REFERENCES = [
@@ -42,15 +42,15 @@ module Inferno
           path: 'encounter',
           resources: [
             'Encounter'
-          ]
-        },
+          ].freeze
+        }.freeze,
         {
           path: 'performer',
           resources: [
             'Practitioner',
             'Organization'
-          ]
-        }
+          ].freeze
+        }.freeze
       ].freeze
 
       BINDINGS = [
@@ -59,19 +59,19 @@ module Inferno
           strength: 'required',
           system: 'http://hl7.org/fhir/ValueSet/diagnostic-report-status',
           path: 'status'
-        },
+        }.freeze,
         {
           type: 'CodeableConcept',
           strength: 'extensible',
           system: 'http://hl7.org/fhir/us/core/ValueSet/us-core-diagnosticreport-category',
           path: 'category'
-        },
+        }.freeze,
         {
           type: 'CodeableConcept',
           strength: 'extensible',
           system: 'http://hl7.org/fhir/us/core/ValueSet/us-core-diagnosticreport-report-and-note-codes',
           path: 'code'
-        }
+        }.freeze
       ].freeze
     end
   end

--- a/lib/modules/uscore_v3.1.1/profile_definitions/us_core_documentreference_definitions.rb
+++ b/lib/modules/uscore_v3.1.1/profile_definitions/us_core_documentreference_definitions.rb
@@ -4,61 +4,61 @@ module Inferno
   module USCore311ProfileDefinitions
     class USCore311DocumentreferenceSequenceDefinitions
       MUST_SUPPORTS = {
-        extensions: [],
-        slices: [],
+        extensions: [].freeze,
+        slices: [].freeze,
         elements: [
           {
             path: 'identifier'
-          },
+          }.freeze,
           {
             path: 'status'
-          },
+          }.freeze,
           {
             path: 'type'
-          },
+          }.freeze,
           {
             path: 'category'
-          },
+          }.freeze,
           {
             path: 'subject'
-          },
+          }.freeze,
           {
             path: 'date'
-          },
+          }.freeze,
           {
             path: 'author'
-          },
+          }.freeze,
           {
             path: 'custodian'
-          },
+          }.freeze,
           {
             path: 'content'
-          },
+          }.freeze,
           {
             path: 'content.attachment'
-          },
+          }.freeze,
           {
             path: 'content.attachment.contentType'
-          },
+          }.freeze,
           {
             path: 'content.attachment.data'
-          },
+          }.freeze,
           {
             path: 'content.attachment.url'
-          },
+          }.freeze,
           {
             path: 'content.format'
-          },
+          }.freeze,
           {
             path: 'context'
-          },
+          }.freeze,
           {
             path: 'context.encounter'
-          },
+          }.freeze,
           {
             path: 'context.period'
-          }
-        ]
+          }.freeze
+        ].freeze
       }.freeze
 
       DELAYED_REFERENCES = [
@@ -67,20 +67,20 @@ module Inferno
           resources: [
             'Practitioner',
             'Organization'
-          ]
-        },
+          ].freeze
+        }.freeze,
         {
           path: 'custodian',
           resources: [
             'Organization'
-          ]
-        },
+          ].freeze
+        }.freeze,
         {
           path: 'context.encounter',
           resources: [
             'Encounter'
-          ]
-        }
+          ].freeze
+        }.freeze
       ].freeze
 
       BINDINGS = [
@@ -89,49 +89,49 @@ module Inferno
           strength: 'required',
           system: 'http://hl7.org/fhir/ValueSet/document-reference-status',
           path: 'status'
-        },
+        }.freeze,
         {
           type: 'code',
           strength: 'required',
           system: 'http://hl7.org/fhir/ValueSet/composition-status',
           path: 'docStatus'
-        },
+        }.freeze,
         {
           type: 'CodeableConcept',
           strength: 'required',
           system: 'http://hl7.org/fhir/us/core/ValueSet/us-core-documentreference-type',
           path: 'type'
-        },
+        }.freeze,
         {
           type: 'CodeableConcept',
           strength: 'extensible',
           system: 'http://hl7.org/fhir/us/core/ValueSet/us-core-documentreference-category',
           path: 'category'
-        },
+        }.freeze,
         {
           type: 'code',
           strength: 'required',
           system: 'http://hl7.org/fhir/ValueSet/document-relationship-type',
           path: 'relatesTo.code'
-        },
+        }.freeze,
         {
           type: 'CodeableConcept',
           strength: 'extensible',
           system: 'http://hl7.org/fhir/ValueSet/security-labels',
           path: 'securityLabel'
-        },
+        }.freeze,
         {
           type: 'code',
           strength: 'required',
           system: 'http://hl7.org/fhir/ValueSet/mimetypes',
           path: 'content.attachment.contentType'
-        },
+        }.freeze,
         {
           type: 'Coding',
           strength: 'extensible',
           system: 'http://hl7.org/fhir/ValueSet/formatcodes',
           path: 'content.format'
-        }
+        }.freeze
       ].freeze
     end
   end

--- a/lib/modules/uscore_v3.1.1/profile_definitions/us_core_encounter_definitions.rb
+++ b/lib/modules/uscore_v3.1.1/profile_definitions/us_core_encounter_definitions.rb
@@ -4,61 +4,61 @@ module Inferno
   module USCore311ProfileDefinitions
     class USCore311EncounterSequenceDefinitions
       MUST_SUPPORTS = {
-        extensions: [],
-        slices: [],
+        extensions: [].freeze,
+        slices: [].freeze,
         elements: [
           {
             path: 'identifier'
-          },
+          }.freeze,
           {
             path: 'identifier.system'
-          },
+          }.freeze,
           {
             path: 'identifier.value'
-          },
+          }.freeze,
           {
             path: 'status'
-          },
+          }.freeze,
           {
             path: 'class'
-          },
+          }.freeze,
           {
             path: 'type'
-          },
+          }.freeze,
           {
             path: 'subject'
-          },
+          }.freeze,
           {
             path: 'participant'
-          },
+          }.freeze,
           {
             path: 'participant.type'
-          },
+          }.freeze,
           {
             path: 'participant.period'
-          },
+          }.freeze,
           {
             path: 'participant.individual'
-          },
+          }.freeze,
           {
             path: 'period'
-          },
+          }.freeze,
           {
             path: 'reasonCode'
-          },
+          }.freeze,
           {
             path: 'hospitalization'
-          },
+          }.freeze,
           {
             path: 'hospitalization.dischargeDisposition'
-          },
+          }.freeze,
           {
             path: 'location'
-          },
+          }.freeze,
           {
             path: 'location.location'
-          }
-        ]
+          }.freeze
+        ].freeze
       }.freeze
 
       DELAYED_REFERENCES = [
@@ -66,8 +66,8 @@ module Inferno
           path: 'participant.individual',
           resources: [
             'Practitioner'
-          ]
-        }
+          ].freeze
+        }.freeze
       ].freeze
 
       BINDINGS = [
@@ -76,55 +76,55 @@ module Inferno
           strength: 'required',
           system: 'http://hl7.org/fhir/ValueSet/identifier-use',
           path: 'identifier.use'
-        },
+        }.freeze,
         {
           type: 'CodeableConcept',
           strength: 'extensible',
           system: 'http://hl7.org/fhir/ValueSet/identifier-type',
           path: 'identifier.type'
-        },
+        }.freeze,
         {
           type: 'code',
           strength: 'required',
           system: 'http://hl7.org/fhir/ValueSet/encounter-status',
           path: 'status'
-        },
+        }.freeze,
         {
           type: 'code',
           strength: 'required',
           system: 'http://hl7.org/fhir/ValueSet/encounter-status',
           path: 'statusHistory.status'
-        },
+        }.freeze,
         {
           type: 'Coding',
           strength: 'extensible',
           system: 'http://terminology.hl7.org/ValueSet/v3-ActEncounterCode',
           path: 'local_class'
-        },
+        }.freeze,
         {
           type: 'Coding',
           strength: 'extensible',
           system: 'http://terminology.hl7.org/ValueSet/v3-ActEncounterCode',
           path: 'classHistory.local_class'
-        },
+        }.freeze,
         {
           type: 'CodeableConcept',
           strength: 'extensible',
           system: 'http://hl7.org/fhir/us/core/ValueSet/us-core-encounter-type',
           path: 'type'
-        },
+        }.freeze,
         {
           type: 'CodeableConcept',
           strength: 'extensible',
           system: 'http://hl7.org/fhir/ValueSet/encounter-participant-type',
           path: 'participant.type'
-        },
+        }.freeze,
         {
           type: 'code',
           strength: 'required',
           system: 'http://hl7.org/fhir/ValueSet/encounter-location-status',
           path: 'location.status'
-        }
+        }.freeze
       ].freeze
     end
   end

--- a/lib/modules/uscore_v3.1.1/profile_definitions/us_core_goal_definitions.rb
+++ b/lib/modules/uscore_v3.1.1/profile_definitions/us_core_goal_definitions.rb
@@ -4,7 +4,7 @@ module Inferno
   module USCore311ProfileDefinitions
     class USCore311GoalSequenceDefinitions
       MUST_SUPPORTS = {
-        extensions: [],
+        extensions: [].freeze,
         slices: [
           {
             name: 'Goal.target.due[x]:dueDate',
@@ -12,23 +12,23 @@ module Inferno
             discriminator: {
               type: 'type',
               code: 'Date'
-            }
-          }
-        ],
+            }.freeze
+          }.freeze
+        ].freeze,
         elements: [
           {
             path: 'lifecycleStatus'
-          },
+          }.freeze,
           {
             path: 'description'
-          },
+          }.freeze,
           {
             path: 'subject'
-          },
+          }.freeze,
           {
             path: 'target'
-          }
-        ]
+          }.freeze
+        ].freeze
       }.freeze
 
       DELAYED_REFERENCES = [].freeze
@@ -39,7 +39,7 @@ module Inferno
           strength: 'required',
           system: 'http://hl7.org/fhir/ValueSet/goal-status',
           path: 'lifecycleStatus'
-        }
+        }.freeze
       ].freeze
     end
   end

--- a/lib/modules/uscore_v3.1.1/profile_definitions/us_core_immunization_definitions.rb
+++ b/lib/modules/uscore_v3.1.1/profile_definitions/us_core_immunization_definitions.rb
@@ -4,28 +4,28 @@ module Inferno
   module USCore311ProfileDefinitions
     class USCore311ImmunizationSequenceDefinitions
       MUST_SUPPORTS = {
-        extensions: [],
-        slices: [],
+        extensions: [].freeze,
+        slices: [].freeze,
         elements: [
           {
             path: 'status'
-          },
+          }.freeze,
           {
             path: 'statusReason'
-          },
+          }.freeze,
           {
             path: 'vaccineCode'
-          },
+          }.freeze,
           {
             path: 'patient'
-          },
+          }.freeze,
           {
             path: 'occurrence'
-          },
+          }.freeze,
           {
             path: 'primarySource'
-          }
-        ]
+          }.freeze
+        ].freeze
       }.freeze
 
       DELAYED_REFERENCES = [].freeze
@@ -36,19 +36,19 @@ module Inferno
           strength: 'required',
           system: 'http://hl7.org/fhir/ValueSet/immunization-status',
           path: 'status'
-        },
+        }.freeze,
         {
           type: 'CodeableConcept',
           strength: 'extensible',
           system: 'http://hl7.org/fhir/us/core/ValueSet/us-core-vaccines-cvx',
           path: 'vaccineCode'
-        },
+        }.freeze,
         {
           type: 'CodeableConcept',
           strength: 'extensible',
           system: 'http://hl7.org/fhir/ValueSet/immunization-function',
           path: 'performer.function'
-        }
+        }.freeze
       ].freeze
     end
   end

--- a/lib/modules/uscore_v3.1.1/profile_definitions/us_core_implantable_device_definitions.rb
+++ b/lib/modules/uscore_v3.1.1/profile_definitions/us_core_implantable_device_definitions.rb
@@ -4,37 +4,37 @@ module Inferno
   module USCore311ProfileDefinitions
     class USCore311ImplantableDeviceSequenceDefinitions
       MUST_SUPPORTS = {
-        extensions: [],
-        slices: [],
+        extensions: [].freeze,
+        slices: [].freeze,
         elements: [
           {
             path: 'udiCarrier'
-          },
+          }.freeze,
           {
             path: 'udiCarrier.deviceIdentifier'
-          },
+          }.freeze,
           {
             path: 'distinctIdentifier'
-          },
+          }.freeze,
           {
             path: 'manufactureDate'
-          },
+          }.freeze,
           {
             path: 'expirationDate'
-          },
+          }.freeze,
           {
             path: 'lotNumber'
-          },
+          }.freeze,
           {
             path: 'serialNumber'
-          },
+          }.freeze,
           {
             path: 'type'
-          },
+          }.freeze,
           {
             path: 'patient'
-          }
-        ]
+          }.freeze
+        ].freeze
       }.freeze
 
       DELAYED_REFERENCES = [].freeze
@@ -45,31 +45,31 @@ module Inferno
           strength: 'required',
           system: 'http://hl7.org/fhir/ValueSet/udi-entry-type',
           path: 'udiCarrier.entryType'
-        },
+        }.freeze,
         {
           type: 'code',
           strength: 'required',
           system: 'http://hl7.org/fhir/ValueSet/device-status',
           path: 'status'
-        },
+        }.freeze,
         {
           type: 'CodeableConcept',
           strength: 'extensible',
           system: 'http://hl7.org/fhir/ValueSet/device-status-reason',
           path: 'statusReason'
-        },
+        }.freeze,
         {
           type: 'code',
           strength: 'required',
           system: 'http://hl7.org/fhir/ValueSet/device-nametype',
           path: 'deviceName.type'
-        },
+        }.freeze,
         {
           type: 'CodeableConcept',
           strength: 'extensible',
           system: 'http://hl7.org/fhir/ValueSet/device-kind',
           path: 'type'
-        }
+        }.freeze
       ].freeze
     end
   end

--- a/lib/modules/uscore_v3.1.1/profile_definitions/us_core_location_definitions.rb
+++ b/lib/modules/uscore_v3.1.1/profile_definitions/us_core_location_definitions.rb
@@ -4,37 +4,37 @@ module Inferno
   module USCore311ProfileDefinitions
     class USCore311LocationSequenceDefinitions
       MUST_SUPPORTS = {
-        extensions: [],
-        slices: [],
+        extensions: [].freeze,
+        slices: [].freeze,
         elements: [
           {
             path: 'status'
-          },
+          }.freeze,
           {
             path: 'name'
-          },
+          }.freeze,
           {
             path: 'telecom'
-          },
+          }.freeze,
           {
             path: 'address'
-          },
+          }.freeze,
           {
             path: 'address.line'
-          },
+          }.freeze,
           {
             path: 'address.city'
-          },
+          }.freeze,
           {
             path: 'address.state'
-          },
+          }.freeze,
           {
             path: 'address.postalCode'
-          },
+          }.freeze,
           {
             path: 'managingOrganization'
-          }
-        ]
+          }.freeze
+        ].freeze
       }.freeze
 
       DELAYED_REFERENCES = [
@@ -42,8 +42,8 @@ module Inferno
           path: 'managingOrganization',
           resources: [
             'Organization'
-          ]
-        }
+          ].freeze
+        }.freeze
       ].freeze
 
       BINDINGS = [
@@ -52,43 +52,43 @@ module Inferno
           strength: 'required',
           system: 'http://hl7.org/fhir/ValueSet/location-status',
           path: 'status'
-        },
+        }.freeze,
         {
           type: 'code',
           strength: 'required',
           system: 'http://hl7.org/fhir/ValueSet/location-mode',
           path: 'mode'
-        },
+        }.freeze,
         {
           type: 'CodeableConcept',
           strength: 'extensible',
           system: 'http://terminology.hl7.org/ValueSet/v3-ServiceDeliveryLocationRoleType',
           path: 'type'
-        },
+        }.freeze,
         {
           type: 'code',
           strength: 'required',
           system: 'http://hl7.org/fhir/ValueSet/address-use',
           path: 'address.use'
-        },
+        }.freeze,
         {
           type: 'code',
           strength: 'required',
           system: 'http://hl7.org/fhir/ValueSet/address-type',
           path: 'address.type'
-        },
+        }.freeze,
         {
           type: 'string',
           strength: 'extensible',
           system: 'http://hl7.org/fhir/us/core/ValueSet/us-core-usps-state',
           path: 'address.state'
-        },
+        }.freeze,
         {
           type: 'code',
           strength: 'required',
           system: 'http://hl7.org/fhir/ValueSet/days-of-week',
           path: 'hoursOfOperation.daysOfWeek'
-        }
+        }.freeze
       ].freeze
     end
   end

--- a/lib/modules/uscore_v3.1.1/profile_definitions/us_core_medicationrequest_definitions.rb
+++ b/lib/modules/uscore_v3.1.1/profile_definitions/us_core_medicationrequest_definitions.rb
@@ -4,40 +4,40 @@ module Inferno
   module USCore311ProfileDefinitions
     class USCore311MedicationrequestSequenceDefinitions
       MUST_SUPPORTS = {
-        extensions: [],
-        slices: [],
+        extensions: [].freeze,
+        slices: [].freeze,
         elements: [
           {
             path: 'status'
-          },
+          }.freeze,
           {
             path: 'intent'
-          },
+          }.freeze,
           {
             path: 'reported'
-          },
+          }.freeze,
           {
             path: 'medication'
-          },
+          }.freeze,
           {
             path: 'subject'
-          },
+          }.freeze,
           {
             path: 'encounter'
-          },
+          }.freeze,
           {
             path: 'authoredOn'
-          },
+          }.freeze,
           {
             path: 'requester'
-          },
+          }.freeze,
           {
             path: 'dosageInstruction'
-          },
+          }.freeze,
           {
             path: 'dosageInstruction.text'
-          }
-        ]
+          }.freeze
+        ].freeze
       }.freeze
 
       DELAYED_REFERENCES = [
@@ -46,8 +46,8 @@ module Inferno
           resources: [
             'Practitioner',
             'Organization'
-          ]
-        }
+          ].freeze
+        }.freeze
       ].freeze
 
       BINDINGS = [
@@ -56,25 +56,25 @@ module Inferno
           strength: 'required',
           system: 'http://hl7.org/fhir/ValueSet/medicationrequest-status',
           path: 'status'
-        },
+        }.freeze,
         {
           type: 'code',
           strength: 'required',
           system: 'http://hl7.org/fhir/ValueSet/medicationrequest-intent',
           path: 'intent'
-        },
+        }.freeze,
         {
           type: 'code',
           strength: 'required',
           system: 'http://hl7.org/fhir/ValueSet/request-priority',
           path: 'priority'
-        },
+        }.freeze,
         {
           type: 'CodeableConcept',
           strength: 'extensible',
           system: 'http://hl7.org/fhir/us/core/ValueSet/us-core-medication-codes',
           path: 'medication'
-        }
+        }.freeze
       ].freeze
     end
   end

--- a/lib/modules/uscore_v3.1.1/profile_definitions/us_core_observation_lab_definitions.rb
+++ b/lib/modules/uscore_v3.1.1/profile_definitions/us_core_observation_lab_definitions.rb
@@ -4,7 +4,7 @@ module Inferno
   module USCore311ProfileDefinitions
     class USCore311ObservationLabSequenceDefinitions
       MUST_SUPPORTS = {
-        extensions: [],
+        extensions: [].freeze,
         slices: [
           {
             name: 'Observation.category:Laboratory',
@@ -14,32 +14,32 @@ module Inferno
               path: '',
               code: 'laboratory',
               system: 'http://terminology.hl7.org/CodeSystem/observation-category'
-            }
-          }
-        ],
+            }.freeze
+          }.freeze
+        ].freeze,
         elements: [
           {
             path: 'status'
-          },
+          }.freeze,
           {
             path: 'category'
-          },
+          }.freeze,
           {
             path: 'code'
-          },
+          }.freeze,
           {
             path: 'subject'
-          },
+          }.freeze,
           {
             path: 'effective'
-          },
+          }.freeze,
           {
             path: 'value'
-          },
+          }.freeze,
           {
             path: 'dataAbsentReason'
-          }
-        ]
+          }.freeze
+        ].freeze
       }.freeze
 
       DELAYED_REFERENCES = [].freeze
@@ -50,37 +50,37 @@ module Inferno
           strength: 'required',
           system: 'http://hl7.org/fhir/ValueSet/observation-status',
           path: 'status'
-        },
+        }.freeze,
         {
           type: 'CodeableConcept',
           strength: 'extensible',
           system: 'http://hl7.org/fhir/ValueSet/observation-codes',
           path: 'code'
-        },
+        }.freeze,
         {
           type: 'CodeableConcept',
           strength: 'extensible',
           system: 'http://hl7.org/fhir/ValueSet/data-absent-reason',
           path: 'dataAbsentReason'
-        },
+        }.freeze,
         {
           type: 'CodeableConcept',
           strength: 'extensible',
           system: 'http://hl7.org/fhir/ValueSet/observation-interpretation',
           path: 'interpretation'
-        },
+        }.freeze,
         {
           type: 'CodeableConcept',
           strength: 'extensible',
           system: 'http://hl7.org/fhir/ValueSet/data-absent-reason',
           path: 'component.dataAbsentReason'
-        },
+        }.freeze,
         {
           type: 'CodeableConcept',
           strength: 'extensible',
           system: 'http://hl7.org/fhir/ValueSet/observation-interpretation',
           path: 'component.interpretation'
-        }
+        }.freeze
       ].freeze
     end
   end

--- a/lib/modules/uscore_v3.1.1/profile_definitions/us_core_organization_definitions.rb
+++ b/lib/modules/uscore_v3.1.1/profile_definitions/us_core_organization_definitions.rb
@@ -4,7 +4,7 @@ module Inferno
   module USCore311ProfileDefinitions
     class USCore311OrganizationSequenceDefinitions
       MUST_SUPPORTS = {
-        extensions: [],
+        extensions: [].freeze,
         slices: [
           {
             name: 'Organization.identifier:NPI',
@@ -13,47 +13,47 @@ module Inferno
               type: 'patternIdentifier',
               path: '',
               system: 'http://hl7.org/fhir/sid/us-npi'
-            }
-          }
-        ],
+            }.freeze
+          }.freeze
+        ].freeze,
         elements: [
           {
             path: 'identifier'
-          },
+          }.freeze,
           {
             path: 'identifier.system'
-          },
+          }.freeze,
           {
             path: 'identifier.value'
-          },
+          }.freeze,
           {
             path: 'active'
-          },
+          }.freeze,
           {
             path: 'name'
-          },
+          }.freeze,
           {
             path: 'telecom'
-          },
+          }.freeze,
           {
             path: 'address'
-          },
+          }.freeze,
           {
             path: 'address.line'
-          },
+          }.freeze,
           {
             path: 'address.city'
-          },
+          }.freeze,
           {
             path: 'address.state'
-          },
+          }.freeze,
           {
             path: 'address.postalCode'
-          },
+          }.freeze,
           {
             path: 'address.country'
-          }
-        ]
+          }.freeze
+        ].freeze
       }.freeze
 
       DELAYED_REFERENCES = [].freeze
@@ -64,37 +64,37 @@ module Inferno
           strength: 'required',
           system: 'http://hl7.org/fhir/ValueSet/identifier-use',
           path: 'identifier.use'
-        },
+        }.freeze,
         {
           type: 'CodeableConcept',
           strength: 'extensible',
           system: 'http://hl7.org/fhir/ValueSet/identifier-type',
           path: 'identifier.type'
-        },
+        }.freeze,
         {
           type: 'code',
           strength: 'required',
           system: 'http://hl7.org/fhir/ValueSet/address-use',
           path: 'address.use'
-        },
+        }.freeze,
         {
           type: 'code',
           strength: 'required',
           system: 'http://hl7.org/fhir/ValueSet/address-type',
           path: 'address.type'
-        },
+        }.freeze,
         {
           type: 'string',
           strength: 'extensible',
           system: 'http://hl7.org/fhir/us/core/ValueSet/us-core-usps-state',
           path: 'address.state'
-        },
+        }.freeze,
         {
           type: 'CodeableConcept',
           strength: 'extensible',
           system: 'http://hl7.org/fhir/ValueSet/contactentity-type',
           path: 'contact.purpose'
-        }
+        }.freeze
       ].freeze
     end
   end

--- a/lib/modules/uscore_v3.1.1/profile_definitions/us_core_patient_definitions.rb
+++ b/lib/modules/uscore_v3.1.1/profile_definitions/us_core_patient_definitions.rb
@@ -8,79 +8,79 @@ module Inferno
           {
             id: 'Patient.extension:race',
             url: 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-race'
-          },
+          }.freeze,
           {
             id: 'Patient.extension:ethnicity',
             url: 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity'
-          },
+          }.freeze,
           {
             id: 'Patient.extension:birthsex',
             url: 'http://hl7.org/fhir/us/core/StructureDefinition/us-core-birthsex'
-          }
-        ],
-        slices: [],
+          }.freeze
+        ].freeze,
+        slices: [].freeze,
         elements: [
           {
             path: 'identifier'
-          },
+          }.freeze,
           {
             path: 'identifier.system'
-          },
+          }.freeze,
           {
             path: 'identifier.value'
-          },
+          }.freeze,
           {
             path: 'name'
-          },
+          }.freeze,
           {
             path: 'name.family'
-          },
+          }.freeze,
           {
             path: 'name.given'
-          },
+          }.freeze,
           {
             path: 'telecom'
-          },
+          }.freeze,
           {
             path: 'telecom.system'
-          },
+          }.freeze,
           {
             path: 'telecom.value'
-          },
+          }.freeze,
           {
             path: 'telecom.use'
-          },
+          }.freeze,
           {
             path: 'gender'
-          },
+          }.freeze,
           {
             path: 'birthDate'
-          },
+          }.freeze,
           {
             path: 'address'
-          },
+          }.freeze,
           {
             path: 'address.line'
-          },
+          }.freeze,
           {
             path: 'address.city'
-          },
+          }.freeze,
           {
             path: 'address.state'
-          },
+          }.freeze,
           {
             path: 'address.postalCode'
-          },
+          }.freeze,
           {
             path: 'address.period'
-          },
+          }.freeze,
           {
             path: 'communication'
-          },
+          }.freeze,
           {
             path: 'communication.language'
-          }
-        ]
+          }.freeze
+        ].freeze
       }.freeze
 
       DELAYED_REFERENCES = [].freeze
@@ -91,85 +91,85 @@ module Inferno
           strength: 'required',
           system: 'http://hl7.org/fhir/ValueSet/identifier-use',
           path: 'identifier.use'
-        },
+        }.freeze,
         {
           type: 'CodeableConcept',
           strength: 'extensible',
           system: 'http://hl7.org/fhir/ValueSet/identifier-type',
           path: 'identifier.type'
-        },
+        }.freeze,
         {
           type: 'code',
           strength: 'required',
           system: 'http://hl7.org/fhir/ValueSet/name-use',
           path: 'name.use'
-        },
+        }.freeze,
         {
           type: 'code',
           strength: 'required',
           system: 'http://hl7.org/fhir/ValueSet/contact-point-system',
           path: 'telecom.system'
-        },
+        }.freeze,
         {
           type: 'code',
           strength: 'required',
           system: 'http://hl7.org/fhir/ValueSet/contact-point-use',
           path: 'telecom.use'
-        },
+        }.freeze,
         {
           type: 'code',
           strength: 'required',
           system: 'http://hl7.org/fhir/ValueSet/administrative-gender',
           path: 'gender'
-        },
+        }.freeze,
         {
           type: 'code',
           strength: 'required',
           system: 'http://hl7.org/fhir/ValueSet/address-use',
           path: 'address.use'
-        },
+        }.freeze,
         {
           type: 'code',
           strength: 'required',
           system: 'http://hl7.org/fhir/ValueSet/address-type',
           path: 'address.type'
-        },
+        }.freeze,
         {
           type: 'string',
           strength: 'extensible',
           system: 'http://hl7.org/fhir/us/core/ValueSet/us-core-usps-state',
           path: 'address.state'
-        },
+        }.freeze,
         {
           type: 'CodeableConcept',
           strength: 'extensible',
           system: 'http://hl7.org/fhir/ValueSet/marital-status',
           path: 'maritalStatus'
-        },
+        }.freeze,
         {
           type: 'CodeableConcept',
           strength: 'extensible',
           system: 'http://hl7.org/fhir/ValueSet/patient-contactrelationship',
           path: 'contact.relationship'
-        },
+        }.freeze,
         {
           type: 'code',
           strength: 'required',
           system: 'http://hl7.org/fhir/ValueSet/administrative-gender',
           path: 'contact.gender'
-        },
+        }.freeze,
         {
           type: 'CodeableConcept',
           strength: 'extensible',
           system: 'http://hl7.org/fhir/us/core/ValueSet/simple-language',
           path: 'communication.language'
-        },
+        }.freeze,
         {
           type: 'code',
           strength: 'required',
           system: 'http://hl7.org/fhir/ValueSet/link-type',
           path: 'link.type'
-        },
+        }.freeze,
         {
           type: 'Coding',
           strength: 'required',
@@ -178,8 +178,8 @@ module Inferno
           extensions: [
             'http://hl7.org/fhir/us/core/StructureDefinition/us-core-race',
             'ombCategory'
-          ]
-        },
+          ].freeze
+        }.freeze,
         {
           type: 'Coding',
           strength: 'required',
@@ -188,8 +188,8 @@ module Inferno
           extensions: [
             'http://hl7.org/fhir/us/core/StructureDefinition/us-core-race',
             'detailed'
-          ]
-        },
+          ].freeze
+        }.freeze,
         {
           type: 'Coding',
           strength: 'required',
@@ -198,8 +198,8 @@ module Inferno
           extensions: [
             'http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity',
             'ombCategory'
-          ]
-        },
+          ].freeze
+        }.freeze,
         {
           type: 'Coding',
           strength: 'required',
@@ -208,8 +208,8 @@ module Inferno
           extensions: [
             'http://hl7.org/fhir/us/core/StructureDefinition/us-core-ethnicity',
             'detailed'
-          ]
-        },
+          ].freeze
+        }.freeze,
         {
           type: 'code',
           strength: 'required',
@@ -217,8 +217,8 @@ module Inferno
           path: 'value',
           extensions: [
             'http://hl7.org/fhir/us/core/StructureDefinition/us-core-birthsex'
-          ]
-        }
+          ].freeze
+        }.freeze
       ].freeze
     end
   end

--- a/lib/modules/uscore_v3.1.1/profile_definitions/us_core_practitioner_definitions.rb
+++ b/lib/modules/uscore_v3.1.1/profile_definitions/us_core_practitioner_definitions.rb
@@ -4,7 +4,7 @@ module Inferno
   module USCore311ProfileDefinitions
     class USCore311PractitionerSequenceDefinitions
       MUST_SUPPORTS = {
-        extensions: [],
+        extensions: [].freeze,
         slices: [
           {
             name: 'Practitioner.identifier:NPI',
@@ -13,26 +13,26 @@ module Inferno
               type: 'patternIdentifier',
               path: '',
               system: 'http://hl7.org/fhir/sid/us-npi'
-            }
-          }
-        ],
+            }.freeze
+          }.freeze
+        ].freeze,
         elements: [
           {
             path: 'identifier'
-          },
+          }.freeze,
           {
             path: 'identifier.system'
-          },
+          }.freeze,
           {
             path: 'identifier.value'
-          },
+          }.freeze,
           {
             path: 'name'
-          },
+          }.freeze,
           {
             path: 'name.family'
-          }
-        ]
+          }.freeze
+        ].freeze
       }.freeze
 
       DELAYED_REFERENCES = [].freeze
@@ -43,25 +43,25 @@ module Inferno
           strength: 'required',
           system: 'http://hl7.org/fhir/ValueSet/identifier-use',
           path: 'identifier.use'
-        },
+        }.freeze,
         {
           type: 'CodeableConcept',
           strength: 'extensible',
           system: 'http://hl7.org/fhir/ValueSet/identifier-type',
           path: 'identifier.type'
-        },
+        }.freeze,
         {
           type: 'code',
           strength: 'required',
           system: 'http://hl7.org/fhir/ValueSet/name-use',
           path: 'name.use'
-        },
+        }.freeze,
         {
           type: 'code',
           strength: 'required',
           system: 'http://hl7.org/fhir/ValueSet/administrative-gender',
           path: 'gender'
-        }
+        }.freeze
       ].freeze
     end
   end

--- a/lib/modules/uscore_v3.1.1/profile_definitions/us_core_practitionerrole_definitions.rb
+++ b/lib/modules/uscore_v3.1.1/profile_definitions/us_core_practitionerrole_definitions.rb
@@ -4,37 +4,37 @@ module Inferno
   module USCore311ProfileDefinitions
     class USCore311PractitionerroleSequenceDefinitions
       MUST_SUPPORTS = {
-        extensions: [],
-        slices: [],
+        extensions: [].freeze,
+        slices: [].freeze,
         elements: [
           {
             path: 'practitioner'
-          },
+          }.freeze,
           {
             path: 'organization'
-          },
+          }.freeze,
           {
             path: 'code'
-          },
+          }.freeze,
           {
             path: 'specialty'
-          },
+          }.freeze,
           {
             path: 'location'
-          },
+          }.freeze,
           {
             path: 'telecom'
-          },
+          }.freeze,
           {
             path: 'telecom.system'
-          },
+          }.freeze,
           {
             path: 'telecom.value'
-          },
+          }.freeze,
           {
             path: 'endpoint'
-          }
-        ]
+          }.freeze
+        ].freeze
       }.freeze
 
       DELAYED_REFERENCES = [
@@ -42,14 +42,14 @@ module Inferno
           path: 'practitioner',
           resources: [
             'Practitioner'
-          ]
-        },
+          ].freeze
+        }.freeze,
         {
           path: 'organization',
           resources: [
             'Organization'
-          ]
-        }
+          ].freeze
+        }.freeze
       ].freeze
 
       BINDINGS = [
@@ -58,31 +58,31 @@ module Inferno
           strength: 'extensible',
           system: 'http://hl7.org/fhir/us/core/ValueSet/us-core-provider-role',
           path: 'code'
-        },
+        }.freeze,
         {
           type: 'CodeableConcept',
           strength: 'extensible',
           system: 'http://hl7.org/fhir/us/core/ValueSet/us-core-provider-specialty',
           path: 'specialty'
-        },
+        }.freeze,
         {
           type: 'code',
           strength: 'required',
           system: 'http://hl7.org/fhir/ValueSet/contact-point-system',
           path: 'telecom.system'
-        },
+        }.freeze,
         {
           type: 'code',
           strength: 'required',
           system: 'http://hl7.org/fhir/ValueSet/contact-point-use',
           path: 'telecom.use'
-        },
+        }.freeze,
         {
           type: 'code',
           strength: 'required',
           system: 'http://hl7.org/fhir/ValueSet/days-of-week',
           path: 'availableTime.daysOfWeek'
-        }
+        }.freeze
       ].freeze
     end
   end

--- a/lib/modules/uscore_v3.1.1/profile_definitions/us_core_procedure_definitions.rb
+++ b/lib/modules/uscore_v3.1.1/profile_definitions/us_core_procedure_definitions.rb
@@ -4,22 +4,22 @@ module Inferno
   module USCore311ProfileDefinitions
     class USCore311ProcedureSequenceDefinitions
       MUST_SUPPORTS = {
-        extensions: [],
-        slices: [],
+        extensions: [].freeze,
+        slices: [].freeze,
         elements: [
           {
             path: 'status'
-          },
+          }.freeze,
           {
             path: 'code'
-          },
+          }.freeze,
           {
             path: 'subject'
-          },
+          }.freeze,
           {
             path: 'performed'
-          }
-        ]
+          }.freeze
+        ].freeze
       }.freeze
 
       DELAYED_REFERENCES = [].freeze
@@ -30,13 +30,13 @@ module Inferno
           strength: 'required',
           system: 'http://hl7.org/fhir/ValueSet/event-status',
           path: 'status'
-        },
+        }.freeze,
         {
           type: 'CodeableConcept',
           strength: 'extensible',
           system: 'http://hl7.org/fhir/us/core/ValueSet/us-core-procedure-code',
           path: 'code'
-        }
+        }.freeze
       ].freeze
     end
   end

--- a/lib/modules/uscore_v3.1.1/profile_definitions/us_core_provenance_definitions.rb
+++ b/lib/modules/uscore_v3.1.1/profile_definitions/us_core_provenance_definitions.rb
@@ -4,7 +4,7 @@ module Inferno
   module USCore311ProfileDefinitions
     class USCore311ProvenanceSequenceDefinitions
       MUST_SUPPORTS = {
-        extensions: [],
+        extensions: [].freeze,
         slices: [
           {
             name: 'Provenance.agent:ProvenanceAuthor',
@@ -14,8 +14,8 @@ module Inferno
               path: 'type',
               code: 'author',
               system: 'http://terminology.hl7.org/CodeSystem/provenance-participant-type'
-            }
-          },
+            }.freeze
+          }.freeze,
           {
             name: 'Provenance.agent:ProvenanceTransmitter',
             path: 'agent',
@@ -24,37 +24,37 @@ module Inferno
               path: 'type',
               code: 'transmitter',
               system: 'http://hl7.org/fhir/us/core/CodeSystem/us-core-provenance-participant-type'
-            }
-          }
-        ],
+            }.freeze
+          }.freeze
+        ].freeze,
         elements: [
           {
             path: 'target'
-          },
+          }.freeze,
           {
             path: 'recorded'
-          },
+          }.freeze,
           {
             path: 'agent'
-          },
+          }.freeze,
           {
             path: 'agent.type'
-          },
+          }.freeze,
           {
             path: 'agent.who'
-          },
+          }.freeze,
           {
             path: 'agent.onBehalfOf'
-          },
+          }.freeze,
           {
             path: 'agent.type.coding.code',
             fixed_value: 'author'
-          },
+          }.freeze,
           {
             path: 'agent.type.coding.code',
             fixed_value: 'transmitter'
-          }
-        ]
+          }.freeze
+        ].freeze
       }.freeze
 
       DELAYED_REFERENCES = [
@@ -63,14 +63,14 @@ module Inferno
           resources: [
             'Practitioner',
             'Organization'
-          ]
-        },
+          ].freeze
+        }.freeze,
         {
           path: 'agent.onBehalfOf',
           resources: [
             'Organization'
-          ]
-        }
+          ].freeze
+        }.freeze
       ].freeze
 
       BINDINGS = [
@@ -79,37 +79,37 @@ module Inferno
           strength: 'extensible',
           system: 'http://terminology.hl7.org/ValueSet/v3-PurposeOfUse',
           path: 'reason'
-        },
+        }.freeze,
         {
           type: 'CodeableConcept',
           strength: 'extensible',
           system: 'http://hl7.org/fhir/ValueSet/provenance-activity-type',
           path: 'activity'
-        },
+        }.freeze,
         {
           type: 'CodeableConcept',
           strength: 'extensible',
           system: 'http://hl7.org/fhir/us/core/ValueSet/us-core-provenance-participant-type',
           path: 'agent.type'
-        },
+        }.freeze,
         {
           type: 'CodeableConcept',
           strength: 'extensible',
           system: 'http://hl7.org/fhir/ValueSet/provenance-agent-type',
           path: 'agent.type'
-        },
+        }.freeze,
         {
           type: 'CodeableConcept',
           strength: 'extensible',
           system: 'http://hl7.org/fhir/ValueSet/provenance-agent-type',
           path: 'agent.type'
-        },
+        }.freeze,
         {
           type: 'code',
           strength: 'required',
           system: 'http://hl7.org/fhir/ValueSet/provenance-entity-role',
           path: 'entity.role'
-        }
+        }.freeze
       ].freeze
     end
   end

--- a/lib/modules/uscore_v3.1.1/profile_definitions/us_core_pulse_oximetry_definitions.rb
+++ b/lib/modules/uscore_v3.1.1/profile_definitions/us_core_pulse_oximetry_definitions.rb
@@ -4,7 +4,7 @@ module Inferno
   module USCore311ProfileDefinitions
     class USCore311PulseOximetrySequenceDefinitions
       MUST_SUPPORTS = {
-        extensions: [],
+        extensions: [].freeze,
         slices: [
           {
             name: 'Observation.category:VSCat',
@@ -15,14 +15,14 @@ module Inferno
                 {
                   path: 'coding.code',
                   value: 'vital-signs'
-                },
+                }.freeze,
                 {
                   path: 'coding.system',
                   value: 'http://terminology.hl7.org/CodeSystem/observation-category'
-                }
-              ]
-            }
-          },
+                }.freeze
+              ].freeze
+            }.freeze
+          }.freeze,
           {
             name: 'Observation.code.coding:PulseOx',
             path: 'code.coding',
@@ -32,22 +32,22 @@ module Inferno
                 {
                   path: 'code',
                   value: '59408-5'
-                },
+                }.freeze,
                 {
                   path: 'system',
                   value: 'http://loinc.org'
-                }
-              ]
-            }
-          },
+                }.freeze
+              ].freeze
+            }.freeze
+          }.freeze,
           {
             name: 'Observation.value[x]:valueQuantity',
             path: 'value',
             discriminator: {
               type: 'type',
               code: 'Quantity'
-            }
-          },
+            }.freeze
+          }.freeze,
           {
             name: 'Observation.component:FlowRate',
             path: 'component',
@@ -56,8 +56,8 @@ module Inferno
               path: 'code',
               code: '3151-8',
               system: 'http://loinc.org'
-            }
-          },
+            }.freeze
+          }.freeze,
           {
             name: 'Observation.component:Concentration',
             path: 'component',
@@ -66,106 +66,106 @@ module Inferno
               path: 'code',
               code: '3150-0',
               system: 'http://loinc.org'
-            }
-          }
-        ],
+            }.freeze
+          }.freeze
+        ].freeze,
         elements: [
           {
             path: 'status'
-          },
+          }.freeze,
           {
             path: 'category'
-          },
+          }.freeze,
           {
             path: 'category.coding'
-          },
+          }.freeze,
           {
             path: 'category.coding.system',
             fixed_value: 'http://terminology.hl7.org/CodeSystem/observation-category'
-          },
+          }.freeze,
           {
             path: 'category.coding.code',
             fixed_value: 'vital-signs'
-          },
+          }.freeze,
           {
             path: 'code'
-          },
+          }.freeze,
           {
             path: 'code.coding'
-          },
+          }.freeze,
           {
             path: 'code.coding.system',
             fixed_value: 'http://loinc.org'
-          },
+          }.freeze,
           {
             path: 'code.coding.code',
             fixed_value: '59408-5'
-          },
+          }.freeze,
           {
             path: 'subject'
-          },
+          }.freeze,
           {
             path: 'effective'
-          },
+          }.freeze,
           {
             path: 'value'
-          },
+          }.freeze,
           {
             path: 'value.value'
-          },
+          }.freeze,
           {
             path: 'value.unit'
-          },
+          }.freeze,
           {
             path: 'value.system',
             fixed_value: 'http://unitsofmeasure.org'
-          },
+          }.freeze,
           {
             path: 'value.code',
             fixed_value: '%'
-          },
+          }.freeze,
           {
             path: 'dataAbsentReason'
-          },
+          }.freeze,
           {
             path: 'component'
-          },
+          }.freeze,
           {
             path: 'component.code'
-          },
+          }.freeze,
           {
             path: 'component.code.coding.code',
             fixed_value: '3151-8'
-          },
+          }.freeze,
           {
             path: 'component.value.system',
             fixed_value: 'http://unitsofmeasure.org'
-          },
+          }.freeze,
           {
             path: 'component.value.code',
             fixed_value: 'L/min'
-          },
+          }.freeze,
           {
             path: 'component.code.coding.code',
             fixed_value: '3150-0'
-          },
+          }.freeze,
           {
             path: 'component.value'
-          },
+          }.freeze,
           {
             path: 'component.value.value'
-          },
+          }.freeze,
           {
             path: 'component.value.unit'
-          },
+          }.freeze,
           {
             path: 'component.value.code',
             fixed_value: '%'
-          },
+          }.freeze,
           {
             path: 'component.dataAbsentReason'
-          }
-        ]
+          }.freeze
+        ].freeze
       }.freeze
 
       DELAYED_REFERENCES = [].freeze
@@ -176,97 +176,97 @@ module Inferno
           strength: 'required',
           system: 'http://hl7.org/fhir/ValueSet/observation-status',
           path: 'status'
-        },
+        }.freeze,
         {
           type: 'CodeableConcept',
           strength: 'extensible',
           system: 'http://hl7.org/fhir/ValueSet/observation-vitalsignresult',
           path: 'code'
-        },
+        }.freeze,
         {
           type: 'code',
           strength: 'required',
           system: 'http://hl7.org/fhir/ValueSet/quantity-comparator',
           path: 'value.comparator'
-        },
+        }.freeze,
         {
           type: 'CodeableConcept',
           strength: 'extensible',
           system: 'http://hl7.org/fhir/ValueSet/data-absent-reason',
           path: 'dataAbsentReason'
-        },
+        }.freeze,
         {
           type: 'CodeableConcept',
           strength: 'extensible',
           system: 'http://hl7.org/fhir/ValueSet/observation-interpretation',
           path: 'interpretation'
-        },
+        }.freeze,
         {
           type: 'CodeableConcept',
           strength: 'extensible',
           system: 'http://hl7.org/fhir/ValueSet/observation-vitalsignresult',
           path: 'component.code'
-        },
+        }.freeze,
         {
           type: 'CodeableConcept',
           strength: 'extensible',
           system: 'http://hl7.org/fhir/ValueSet/data-absent-reason',
           path: 'component.dataAbsentReason'
-        },
+        }.freeze,
         {
           type: 'CodeableConcept',
           strength: 'extensible',
           system: 'http://hl7.org/fhir/ValueSet/observation-interpretation',
           path: 'component.interpretation'
-        },
+        }.freeze,
         {
           type: 'CodeableConcept',
           strength: 'extensible',
           system: 'http://hl7.org/fhir/ValueSet/observation-vitalsignresult',
           path: 'component.code'
-        },
+        }.freeze,
         {
           type: 'code',
           strength: 'required',
           system: 'http://hl7.org/fhir/ValueSet/quantity-comparator',
           path: 'component.value.comparator'
-        },
+        }.freeze,
         {
           type: 'CodeableConcept',
           strength: 'extensible',
           system: 'http://hl7.org/fhir/ValueSet/data-absent-reason',
           path: 'component.dataAbsentReason'
-        },
+        }.freeze,
         {
           type: 'CodeableConcept',
           strength: 'extensible',
           system: 'http://hl7.org/fhir/ValueSet/observation-interpretation',
           path: 'component.interpretation'
-        },
+        }.freeze,
         {
           type: 'CodeableConcept',
           strength: 'extensible',
           system: 'http://hl7.org/fhir/ValueSet/observation-vitalsignresult',
           path: 'component.code'
-        },
+        }.freeze,
         {
           type: 'code',
           strength: 'required',
           system: 'http://hl7.org/fhir/ValueSet/quantity-comparator',
           path: 'component.value.comparator'
-        },
+        }.freeze,
         {
           type: 'CodeableConcept',
           strength: 'extensible',
           system: 'http://hl7.org/fhir/ValueSet/data-absent-reason',
           path: 'component.dataAbsentReason'
-        },
+        }.freeze,
         {
           type: 'CodeableConcept',
           strength: 'extensible',
           system: 'http://hl7.org/fhir/ValueSet/observation-interpretation',
           path: 'component.interpretation'
-        }
+        }.freeze
       ].freeze
     end
   end

--- a/lib/modules/uscore_v3.1.1/profile_definitions/us_core_smokingstatus_definitions.rb
+++ b/lib/modules/uscore_v3.1.1/profile_definitions/us_core_smokingstatus_definitions.rb
@@ -4,7 +4,7 @@ module Inferno
   module USCore311ProfileDefinitions
     class USCore311SmokingstatusSequenceDefinitions
       MUST_SUPPORTS = {
-        extensions: [],
+        extensions: [].freeze,
         slices: [
           {
             name: 'Observation.value[x]:valueCodeableConcept',
@@ -12,23 +12,23 @@ module Inferno
             discriminator: {
               type: 'type',
               code: 'CodeableConcept'
-            }
-          }
-        ],
+            }.freeze
+          }.freeze
+        ].freeze,
         elements: [
           {
             path: 'status'
-          },
+          }.freeze,
           {
             path: 'code'
-          },
+          }.freeze,
           {
             path: 'subject'
-          },
+          }.freeze,
           {
             path: 'issued'
-          }
-        ]
+          }.freeze
+        ].freeze
       }.freeze
 
       DELAYED_REFERENCES = [].freeze
@@ -39,37 +39,37 @@ module Inferno
           strength: 'required',
           system: 'http://hl7.org/fhir/us/core/ValueSet/us-core-observation-smoking-status-status',
           path: 'status'
-        },
+        }.freeze,
         {
           type: 'CodeableConcept',
           strength: 'extensible',
           system: 'http://hl7.org/fhir/us/core/ValueSet/us-core-smoking-status-observation-codes',
           path: 'code'
-        },
+        }.freeze,
         {
           type: 'CodeableConcept',
           strength: 'extensible',
           system: 'http://hl7.org/fhir/ValueSet/data-absent-reason',
           path: 'dataAbsentReason'
-        },
+        }.freeze,
         {
           type: 'CodeableConcept',
           strength: 'extensible',
           system: 'http://hl7.org/fhir/ValueSet/observation-interpretation',
           path: 'interpretation'
-        },
+        }.freeze,
         {
           type: 'CodeableConcept',
           strength: 'extensible',
           system: 'http://hl7.org/fhir/ValueSet/data-absent-reason',
           path: 'component.dataAbsentReason'
-        },
+        }.freeze,
         {
           type: 'CodeableConcept',
           strength: 'extensible',
           system: 'http://hl7.org/fhir/ValueSet/observation-interpretation',
           path: 'component.interpretation'
-        }
+        }.freeze
       ].freeze
     end
   end


### PR DESCRIPTION
# Summary
Addresses #355. The bulk group validation sequence was modifying the US Core profile definitions. Any MS field found in that sequence would not be checked in any future test runs.

## Code changes

- US Core profile definitions are now deep frozen, so any attempt to modify them will raise an error
- The bulk group validation sequence now deep dups the profile definitions so that the originals will not be modified

## Testing guidance

- Run the single patient API tests with patient 85. USCDR-13 should skip.
- Run the bulk tests
- Run the single patient API tests with patient 85 again. USCDR-13 should still skip. If you follow these three steps on main, it will pass.