### PR TITLE
FI-1327 Add UI input field for bulk_timeout

### DIFF
--- a/db/migrate/20211020161758_add_column_bulk_timeout.rb
+++ b/db/migrate/20211020161758_add_column_bulk_timeout.rb
@@ -1,0 +1,5 @@
+class AddColumnBulkTimeout < ActiveRecord::Migration[5.2]
+  def change
+    add_column :inferno_models_testing_instances, :bulk_timeout, :integer, :default => 180
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_08_04_135524) do
+ActiveRecord::Schema.define(version: 2021_10_20_161758) do
 
   create_table "inferno_models_information_messages", id: :string, limit: 500, force: :cascade do |t|
     t.text "message"
@@ -225,6 +225,7 @@ ActiveRecord::Schema.define(version: 2021_08_04_135524) do
     t.text "onc_visual_token_revocation_notes"
     t.string "onc_visual_native_application", limit: 50, default: "false"
     t.text "onc_visual_native_application_notes"
+    t.integer "bulk_timeout", default: 180
   end
 
 end

--- a/lib/app/models/testing_instance.rb
+++ b/lib/app/models/testing_instance.rb
@@ -15,7 +15,6 @@ module Inferno
     attribute :group_id, :string
     attribute :bulk_client_id, :string
     attribute :onc_sl_client_id, :string
-    attribute :bulk_timeout, :integer
 
     has_many :sequence_results
     has_many :resource_references

--- a/lib/app/models/testing_instance.rb
+++ b/lib/app/models/testing_instance.rb
@@ -15,6 +15,7 @@ module Inferno
     attribute :group_id, :string
     attribute :bulk_client_id, :string
     attribute :onc_sl_client_id, :string
+    attribute :bulk_timeout, :integer
 
     has_many :sequence_results
     has_many :resource_references

--- a/lib/app/views/onc_program.erb
+++ b/lib/app/views/onc_program.erb
@@ -744,7 +744,7 @@
               label: 'Export times out after',
               description: %(
                 While testing, Inferno waits for the server to complete the exporting task. Inferno calculates the timeout as: 
-                totalTime = currentTimestamp - startTimestamp + waitTime. If server supplies Retry-After header with a delay time in second, 
+                totalTime = currentTimestamp - startTimestamp + waitTime. If the server supplies a Retry-After header with a delay time in seconds, 
                 Inferno use Retry-After value as waitTime. If server does not supply Retry-After header, Inferno
                 uses exponential backoff approach mentioned in Bulk Data Export. If the calculated totalTime is greater than the timeout value
                 specified here, Inferno bulk client stops testing.

--- a/lib/app/views/onc_program.erb
+++ b/lib/app/views/onc_program.erb
@@ -746,7 +746,7 @@
                 While testing, Inferno waits for the server to complete the exporting task. Inferno calculates the timeout as: 
                 totalTime = currentTimestamp - startTimestamp + waitTime. If the server supplies a Retry-After header with a delay time in seconds, 
                 Inferno uses the Retry-After value as waitTime. If the server does not supply a Retry-After header, Inferno
-                uses exponential backoff approach mentioned in Bulk Data Export. If the calculated totalTime is greater than the timeout value
+                uses the exponential backoff approach mentioned in Bulk Data Export. If the calculated totalTime is greater than the timeout value
                 specified here, Inferno bulk client stops testing.
                 Please enter an integer for the maxium wait time (in seconds).                 
               ),              

--- a/lib/app/views/onc_program.erb
+++ b/lib/app/views/onc_program.erb
@@ -745,7 +745,7 @@
               description: %(
                 While testing, Inferno waits for the server to complete the exporting task. Inferno calculates the timeout as: 
                 totalTime = currentTimestamp - startTimestamp + waitTime. If the server supplies a Retry-After header with a delay time in seconds, 
-                Inferno use Retry-After value as waitTime. If server does not supply Retry-After header, Inferno
+                Inferno uses the Retry-After value as waitTime. If the server does not supply a Retry-After header, Inferno
                 uses exponential backoff approach mentioned in Bulk Data Export. If the calculated totalTime is greater than the timeout value
                 specified here, Inferno bulk client stops testing.
                 Please enter an integer for the maxium wait time (in seconds).                 

--- a/lib/app/views/onc_program.erb
+++ b/lib/app/views/onc_program.erb
@@ -739,6 +739,18 @@
               ),              
               value: instance.bulk_lines_to_validate}); %>
 
+        <%= erb(:prerequisite_field,{},{prerequisite: :bulk_timeout,
+              instance: instance,
+              label: 'Export times out after',
+              description: %(
+                While testing Inferno waits for the server to complete exporting task. Inferno calculate the timeout as: 
+                totalTime = currentTimestamp - startTimestamp + waitTime. If server supplies Retry-After header with a delay time in second, 
+                Inferno use Retry-After value as waitTime. If server does not supply Retry-After header, Inferno
+                uses exponential backoff approach mentioned in Bulk Data Export. If the calculated totalTime is greater than the timeout value
+                specified here, Inferno bulk client stops testing.
+                Please enter an integer for the maxium wait time (in seconds).                 
+              ),              
+              value: instance.bulk_timeout}); %>
 
      
       </div>

--- a/lib/app/views/onc_program.erb
+++ b/lib/app/views/onc_program.erb
@@ -743,7 +743,7 @@
               instance: instance,
               label: 'Export times out after',
               description: %(
-                While testing Inferno waits for the server to complete exporting task. Inferno calculate the timeout as: 
+                While testing, Inferno waits for the server to complete the exporting task. Inferno calculates the timeout as: 
                 totalTime = currentTimestamp - startTimestamp + waitTime. If server supplies Retry-After header with a delay time in second, 
                 Inferno use Retry-After value as waitTime. If server does not supply Retry-After header, Inferno
                 uses exponential backoff approach mentioned in Bulk Data Export. If the calculated totalTime is greater than the timeout value

--- a/lib/app/views/onc_program.erb
+++ b/lib/app/views/onc_program.erb
@@ -747,7 +747,7 @@
                 totalTime = currentTimestamp - startTimestamp + waitTime. If the server supplies a Retry-After header with a delay time in seconds, 
                 Inferno uses the Retry-After value as waitTime. If the server does not supply a Retry-After header, Inferno
                 uses the exponential backoff approach mentioned in Bulk Data Export. If the calculated totalTime is greater than the timeout value
-                specified here, Inferno bulk client stops testing.
+                specified here, the Inferno bulk client stops testing.
                 Please enter an integer for the maxium wait time (in seconds).                 
               ),              
               value: instance.bulk_timeout}); %>

--- a/lib/modules/onc_program/bulk_data_export_sequence.rb
+++ b/lib/modules/onc_program/bulk_data_export_sequence.rb
@@ -91,7 +91,7 @@ module Inferno
 
       def check_export_status(url = @content_location, timeout: 180)
         skip 'Server response did not have Content-Location in header' unless url.present?
-        
+
         timeout = @instance.bulk_timeout if @instance.bulk_timeout.positive?
         reply = export_status_check(url, timeout)
 

--- a/lib/modules/onc_program/bulk_data_export_sequence.rb
+++ b/lib/modules/onc_program/bulk_data_export_sequence.rb
@@ -15,7 +15,7 @@ module Inferno
 
       test_id_prefix 'BDE'
 
-      requires :bulk_url, :bulk_access_token, :bulk_lines_to_validate
+      requires :bulk_url, :bulk_access_token, :bulk_lines_to_validate, :bulk_timeout
 
       attr_accessor :run_all_kick_off_tests
 
@@ -91,6 +91,8 @@ module Inferno
 
       def check_export_status(url = @content_location, timeout: 180)
         skip 'Server response did not have Content-Location in header' unless url.present?
+        
+        timeout = @instance.bulk_timeout if @instance.bulk_timeout.positive?
         reply = export_status_check(url, timeout)
 
         # server response status code could be 202 (still processing), 200 (complete) or 4xx/5xx error code

--- a/lib/modules/onc_program/bulk_data_group_export_sequence.rb
+++ b/lib/modules/onc_program/bulk_data_group_export_sequence.rb
@@ -15,7 +15,7 @@ module Inferno
 
       test_id_prefix 'BDGE'
 
-      requires :group_id, :bulk_url, :bulk_access_token, :bulk_lines_to_validate
+      requires :group_id, :bulk_url, :bulk_access_token, :bulk_lines_to_validate, :bulk_timeout
 
       def endpoint
         'Group'

--- a/lib/modules/onc_program/bulk_data_patient_export_sequence.rb
+++ b/lib/modules/onc_program/bulk_data_patient_export_sequence.rb
@@ -15,7 +15,7 @@ module Inferno
 
       test_id_prefix 'Patient'
 
-      requires :bulk_access_token, :bulk_lines_to_validate
+      requires :bulk_access_token, :bulk_lines_to_validate, :bulk_timeout
       conformance_supports :Patient
 
       def endpoint

--- a/lib/modules/onc_program/test/bulk_patient_export_sequence_test.rb
+++ b/lib/modules/onc_program/test/bulk_patient_export_sequence_test.rb
@@ -234,7 +234,8 @@ class BulkDataPatientExportSequenceTest < MiniTest::Test
       oauth_authorize_endpoint: 'http://oauth_reg.example.com/authorize',
       oauth_token_endpoint: 'http://oauth_reg.example.com/token',
       scopes: 'launch openid patient/*.* profile',
-      bulk_access_token: 99_897_979
+      bulk_access_token: 99_897_979,
+      bulk_timeout: 0
     )
 
     @instance.instance_variable_set(:'@module', OpenStruct.new(fhir_version: 'r4'))


### PR DESCRIPTION
# Summary
This PR address GitHub issue #359 

We added a UI input field for Bulk Data export status check timeout value

## New behavior
Tester can specify maximum timeout value for Bulk Data export status check.
If tester input value less than 1 or NAN, Inferno uses default 180 seconds.

## Code changes

## Testing guidance
When starting a Multi-Patient API test, the "Export times out after" shows at the bottom of popup dialog with default value 180.
