### PR TITLE
FI-1351 Allow server grants additional scopes

### DIFF
--- a/lib/modules/onc_program/onc_ehr_launch_sequence.rb
+++ b/lib/modules/onc_program/onc_ehr_launch_sequence.rb
@@ -54,7 +54,8 @@ module Inferno
           'PractitionerRole',
           'Procedure',
           'Provenance',
-          'RelatedPerson'
+          'RelatedPerson',
+          'Person'
         ]
       end
 

--- a/lib/modules/onc_program/onc_standalone_launch_sequence.rb
+++ b/lib/modules/onc_program/onc_standalone_launch_sequence.rb
@@ -54,7 +54,8 @@ module Inferno
           'PractitionerRole',
           'Procedure',
           'Provenance',
-          'RelatedPerson'
+          'RelatedPerson',
+          'Person'
         ]
       end
 

--- a/lib/modules/onc_program/onc_standalone_public_launch_sequence.rb
+++ b/lib/modules/onc_program/onc_standalone_public_launch_sequence.rb
@@ -49,7 +49,8 @@ module Inferno
           'PractitionerRole',
           'Procedure',
           'Provenance',
-          'RelatedPerson'
+          'RelatedPerson',
+          'Person'
         ]
       end
 

--- a/lib/modules/onc_program/onc_standalone_restricted_launch_sequence.rb
+++ b/lib/modules/onc_program/onc_standalone_restricted_launch_sequence.rb
@@ -53,7 +53,8 @@ module Inferno
           'PractitionerRole',
           'Procedure',
           'Provenance',
-          'RelatedPerson'
+          'RelatedPerson',
+          'Person'
         ]
       end
 

--- a/lib/modules/onc_program/shared_onc_launch_tests.rb
+++ b/lib/modules/onc_program/shared_onc_launch_tests.rb
@@ -381,7 +381,11 @@ module Inferno
 
             skip_if_auth_failed
 
-            non_patient_compartment_resources = ['Device', 'Location', 'Medication', 'Organization', 'Practitioner', 'PractitionerRole'].freeze
+            # ONC CCG: health IT developers are permitted to scope US Core IG resources that do not exist in either the standard adopted at § 170.213 (USCDI version 1) 
+            # or the "Compartment Patient" section of the standard adopted at § 170.215(a)(1) (HLY FHIR Release 4.0.1) as either patient/[Resource] or user/[Resource]. 
+            # These resources include “Encounter,” “Device,” “Location,” “Medication,” “Organization,” “Practitioner,” and “PractitionerRole.” 
+            # Also add "Person" as it is not in USCDI either
+            non_patient_compartment_resources = ['Encounter', 'Device', 'Location', 'Medication', 'Organization', 'Practitioner', 'PractitionerRole', 'RelatedPerson', 'Person'].freeze
 
             patient_compartment_resources = valid_resource_types - non_patient_compartment_resources
 

--- a/lib/modules/onc_program/shared_onc_launch_tests.rb
+++ b/lib/modules/onc_program/shared_onc_launch_tests.rb
@@ -428,7 +428,7 @@ module Inferno
             skip_if_auth_failed
 
             # ONC CCG: health IT developers are permitted to scope US Core IG resources that do not exist in either the standard adopted at 170.213 (USCDI version 1)
-            # or the "Compartment Patient" section of the standard adopted at 170.215(a)(1) (HLY FHIR Release 4.0.1) as either patient/[Resource] or user/[Resource].
+            # or the "Compartment Patient" section of the standard adopted at 170.215(a)(1) (HL7 FHIR Release 4.0.1) as either patient/[Resource] or user/[Resource].
             patient_compartment_resource_types = [
               '*',
               'Patient',

--- a/lib/modules/onc_program/shared_onc_launch_tests.rb
+++ b/lib/modules/onc_program/shared_onc_launch_tests.rb
@@ -381,7 +381,7 @@ module Inferno
 
             skip_if_auth_failed
 
-            non_patient_compartment_resources = ['Encounter', 'Device', 'Location', 'Medication', 'Organization', 'Practitioner', 'PractitionerRole', 'RelatedPerson'].freeze
+            non_patient_compartment_resources = ['Device', 'Location', 'Medication', 'Organization', 'Practitioner', 'PractitionerRole'].freeze
 
             patient_compartment_resources = valid_resource_types - non_patient_compartment_resources
 
@@ -402,8 +402,10 @@ module Inferno
               assert missing_scopes.empty?, "Required scopes were not #{received_or_requested}: #{missing_scopes.join(', ')}"
 
               scopes -= required_scopes
-              # Other 'okay' scopes. Also scopes may include both 'launch' and 'launch/patient' for EHR launch and Standalone launch
-              scopes -= ['online_access', 'launch', 'launch/patient']
+
+              # Other 'okay' scopes. Also scopes may include both 'launch' and 'launch/patient' for EHR launch and Standalone launch.
+              # 'launch/encounter' is mentioned by SMART App Launch though not in (g)(10) test procedure
+              scopes -= ['online_access', 'launch', 'launch/patient', 'launch/encounter']
 
               patient_scope_found = false
 

--- a/lib/modules/onc_program/shared_onc_launch_tests.rb
+++ b/lib/modules/onc_program/shared_onc_launch_tests.rb
@@ -146,6 +146,52 @@ module Inferno
         skip_if @params.blank? || @params['error'].present?, oauth_redirect_failed_message
       end
 
+      def requested_scope_test(scopes, patient_compartment_resource_types, patient_or_user)
+        patient_scope_found = false
+
+        scopes.each do |scope|
+          bad_format_message = "Requested scope '#{scope}' does not follow the format: `#{patient_or_user}/[ resource | * ].[ read | * ]`"
+
+          scope_pieces = scope.split('/')
+          assert scope_pieces.count == 2, bad_format_message
+
+          resource_access = scope_pieces[1].split('.')
+          bad_resource_message = "'#{resource_access[0]}' must be either a valid resource type or '*'"
+
+          if patient_or_user == 'patient' && patient_compartment_resource_types.exclude?(resource_access[0])
+            assert ['user', 'patient'].include?(scope_pieces[0]), "Requested scope '#{scope}' must begin with either 'user/' or 'patient/'"
+          else
+            assert scope_pieces[0] == patient_or_user, bad_format_message
+          end
+
+          assert resource_access.count == 2, bad_format_message
+          assert valid_resource_types.include?(resource_access[0]), bad_resource_message
+          assert resource_access[1] =~ /^(\*|read)/, bad_format_message
+
+          patient_scope_found = true
+        end
+
+        assert patient_scope_found, "#{patient_or_user.capitalize}-level scope in the format: `#{patient_or_user}/[ resource | * ].[ read | *]` was not requested."
+      end
+
+      def received_scope_test(scopes, patient_compartment_resource_types)
+        granted_resource_types = []
+
+        scopes.each do |scope|
+          scope_pieces = scope.split('/')
+          next unless scope_pieces.count == 2
+
+          resource_access = scope_pieces[1].split('.')
+          next unless resource_access.count == 2
+
+          granted_resource_types << resource_access[0] if resource_access[1] =~ /^(\*|read)/
+        end
+
+        missing_resource_types = granted_resource_types.include?('*') ? [] : (patient_compartment_resource_types - granted_resource_types - ['*'])
+
+        assert missing_resource_types.empty?, "Request scopes #{missing_resource_types.join(', ')} were not granted by authorization server."
+      end
+
       module ClassMethods
         def auth_endpoint_tls_test(index:)
           test :auth_endpoint_tls do
@@ -381,13 +427,24 @@ module Inferno
 
             skip_if_auth_failed
 
-            # ONC CCG: health IT developers are permitted to scope US Core IG resources that do not exist in either the standard adopted at § 170.213 (USCDI version 1) 
-            # or the "Compartment Patient" section of the standard adopted at § 170.215(a)(1) (HLY FHIR Release 4.0.1) as either patient/[Resource] or user/[Resource]. 
-            # These resources include “Encounter,” “Device,” “Location,” “Medication,” “Organization,” “Practitioner,” and “PractitionerRole.” 
-            # Also add "Person" as it is not in USCDI either
-            non_patient_compartment_resources = ['Encounter', 'Device', 'Location', 'Medication', 'Organization', 'Practitioner', 'PractitionerRole', 'RelatedPerson', 'Person'].freeze
-
-            patient_compartment_resources = valid_resource_types - non_patient_compartment_resources
+            # ONC CCG: health IT developers are permitted to scope US Core IG resources that do not exist in either the standard adopted at 170.213 (USCDI version 1)
+            # or the "Compartment Patient" section of the standard adopted at 170.215(a)(1) (HLY FHIR Release 4.0.1) as either patient/[Resource] or user/[Resource].
+            patient_compartment_resource_types = [
+              '*',
+              'Patient',
+              'AllergyIntolerance',
+              'CarePlan',
+              'CareTeam',
+              'Condition',
+              'DiagnosticReport',
+              'DocumentReference',
+              'Goal',
+              'Immunization',
+              'MedicationRequest',
+              'Observation',
+              'Procedure',
+              'Provenance'
+            ].freeze
 
             [
               {
@@ -411,31 +468,11 @@ module Inferno
               # 'launch/encounter' is mentioned by SMART App Launch though not in (g)(10) test procedure
               scopes -= ['online_access', 'launch', 'launch/patient', 'launch/encounter']
 
-              patient_scope_found = false
-
-              scopes.each do |scope|
-                bad_format_message = "#{received_or_requested.capitalize} scope '#{scope}' does not follow the format: `#{patient_or_user}/[ resource | * ].[ read | * ]`"
-                scope_pieces = scope.split('/')
-
-                assert scope_pieces.count == 2, bad_format_message
-
-                resource_access = scope_pieces[1].split('.')
-                bad_resource_message = "'#{resource_access[0]}' must be either a valid resource type or '*'"
-
-                if patient_or_user == 'patient' && patient_compartment_resources.exclude?(resource_access[0])
-                  assert ['user', 'patient'].include?(scope_pieces[0]), "#{received_or_requested.capitalize} scope '#{scope}' must begin with either 'user/' or 'patient/'"
-                else
-                  assert scope_pieces[0] == patient_or_user, bad_format_message
-                end
-
-                assert resource_access.count == 2, bad_format_message
-                assert valid_resource_types.include?(resource_access[0]) || received_or_requested == 'received', bad_resource_message
-                assert resource_access[1] =~ /^(\*|read)/, bad_format_message
-
-                patient_scope_found ||= valid_resource_types.include?(resource_access[0])
+              if received_or_requested == 'requested'
+                requested_scope_test(scopes, patient_compartment_resource_types, patient_or_user)
+              else
+                received_scope_test(scopes, patient_compartment_resource_types)
               end
-
-              assert patient_scope_found, "#{patient_or_user.capitalize}-level scope for US Core resource types in the format: `#{patient_or_user}/[ resource | * ].[ read | *]` was not #{received_or_requested}."
             end
           end
         end

--- a/lib/modules/onc_program/test/onc_ehr_launch_sequence_test.rb
+++ b/lib/modules/onc_program/test/onc_ehr_launch_sequence_test.rb
@@ -51,7 +51,7 @@ describe Inferno::Sequence::OncEHRLaunchSequence do
       @instance.scopes = @sequence.required_scopes.join(' ')
       exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
 
-      assert_equal 'User-level scope in the format: `user/[ resource | * ].[ read | *]` was not requested.', exception.message
+      assert_equal 'User-level scope for US Core resource types in the format: `user/[ resource | * ].[ read | *]` was not requested.', exception.message
     end
 
     it 'fails when no user-level scope was received' do
@@ -59,7 +59,7 @@ describe Inferno::Sequence::OncEHRLaunchSequence do
       @instance.received_scopes = @sequence.required_scopes.join(' ')
       exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
 
-      assert_equal 'User-level scope in the format: `user/[ resource | * ].[ read | *]` was not received.', exception.message
+      assert_equal 'User-level scope for US Core resource types in the format: `user/[ resource | * ].[ read | *]` was not received.', exception.message
     end
 
     it 'fails when a badly formatted scope was requested' do
@@ -94,7 +94,19 @@ describe Inferno::Sequence::OncEHRLaunchSequence do
       @instance.received_scopes = @sequence.required_scopes.join(' ') + " user/#{bad_resource_type}.*"
       exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
 
-      assert_equal "'#{bad_resource_type}' must be either a valid resource type or '*'", exception.message
+      assert_equal 'User-level scope for US Core resource types in the format: `user/[ resource | * ].[ read | *]` was not received.', exception.message
+    end
+
+    it 'succeeds when server grants additional user scopes' do
+      @instance.scopes = good_scopes
+      @instance.received_scopes = @sequence.required_scopes.join(' ') + ' user/Patient.read user/ValueSet.read'
+      @sequence.run_test(@test)
+    end
+
+    it 'succeeds when server grants launch/patient scope' do
+      @instance.scopes = good_scopes
+      @instance.received_scopes = @sequence.required_scopes.join(' ') + ' launch/patient user/Patient.read'
+      @sequence.run_test(@test)
     end
 
     it 'succeeds when the required scopes and a user-level scope are present' do

--- a/lib/modules/onc_program/test/onc_ehr_launch_sequence_test.rb
+++ b/lib/modules/onc_program/test/onc_ehr_launch_sequence_test.rb
@@ -51,7 +51,7 @@ describe Inferno::Sequence::OncEHRLaunchSequence do
       @instance.scopes = @sequence.required_scopes.join(' ')
       exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
 
-      assert_equal 'User-level scope for US Core resource types in the format: `user/[ resource | * ].[ read | *]` was not requested.', exception.message
+      assert_equal 'User-level scope in the format: `user/[ resource | * ].[ read | *]` was not requested.', exception.message
     end
 
     it 'fails when no user-level scope was received' do
@@ -59,7 +59,7 @@ describe Inferno::Sequence::OncEHRLaunchSequence do
       @instance.received_scopes = @sequence.required_scopes.join(' ')
       exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
 
-      assert_equal 'User-level scope for US Core resource types in the format: `user/[ resource | * ].[ read | *]` was not received.', exception.message
+      assert_match(/^Request scopes .* were not granted by authorization server./, exception.message)
     end
 
     it 'fails when a badly formatted scope was requested' do
@@ -80,32 +80,28 @@ describe Inferno::Sequence::OncEHRLaunchSequence do
     end
 
     it 'fails when a badly formatted scope was received' do
-      bad_scopes = ['user/*/*', 'patient/*.read', 'user/*.*.*', 'user/*.write']
+      scopes = ['abc', 'patient/*/*', 'patient/.', 'patient/*.', 'patient/*.*.*', 'patient/*.write']
       @instance.scopes = good_scopes
 
-      bad_scopes.each do |scope|
-        @instance.received_scopes = (@sequence.required_scopes + [scope]).join(' ')
-        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
-
-        assert_equal "Received scope '#{scope}' does not follow the format: `user/[ resource | * ].[ read | * ]`", exception.message
-      end
-
-      bad_resource_type = 'ValueSet'
-      @instance.received_scopes = @sequence.required_scopes.join(' ') + " user/#{bad_resource_type}.*"
+      @instance.received_scopes = (@sequence.required_scopes + scopes).join(' ')
       exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
 
-      assert_equal 'User-level scope for US Core resource types in the format: `user/[ resource | * ].[ read | *]` was not received.', exception.message
+      assert_match(/^Request scopes .* were not granted by authorization server./, exception.message)
+    end
+
+    it 'fails when not all patient compartment scopes were received' do
+      scopes = ['patient/Patient.read', 'patient/Condition.read', 'patient/Obervation.read']
+      @instance.scopes = good_scopes
+
+      @instance.received_scopes = (@sequence.required_scopes + scopes).join(' ')
+      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
+
+      assert_match(/^Request scopes .* were not granted by authorization server./, exception.message)
     end
 
     it 'succeeds when server grants additional user scopes' do
       @instance.scopes = good_scopes
-      @instance.received_scopes = @sequence.required_scopes.join(' ') + ' user/Patient.read user/ValueSet.read'
-      @sequence.run_test(@test)
-    end
-
-    it 'succeeds when server grants launch/patient scope' do
-      @instance.scopes = good_scopes
-      @instance.received_scopes = @sequence.required_scopes.join(' ') + ' launch/patient user/Patient.read'
+      @instance.received_scopes = good_scopes + ' launch/patient launch/encounter user/ValueSet.read'
       @sequence.run_test(@test)
     end
 

--- a/lib/modules/onc_program/test/onc_ehr_launch_sequence_test.rb
+++ b/lib/modules/onc_program/test/onc_ehr_launch_sequence_test.rb
@@ -79,16 +79,6 @@ describe Inferno::Sequence::OncEHRLaunchSequence do
       assert_equal "'#{bad_resource_type}' must be either a valid resource type or '*'", exception.message
     end
 
-    it 'fails when a badly formatted scope was received' do
-      scopes = ['abc', 'patient/*/*', 'patient/.', 'patient/*.', 'patient/*.*.*', 'patient/*.write']
-      @instance.scopes = good_scopes
-
-      @instance.received_scopes = (@sequence.required_scopes + scopes).join(' ')
-      exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
-
-      assert_match(/^Request scopes .* were not granted by authorization server./, exception.message)
-    end
-
     it 'fails when not all patient compartment scopes were received' do
       scopes = ['patient/Patient.read', 'patient/Condition.read', 'patient/Obervation.read']
       @instance.scopes = good_scopes
@@ -101,7 +91,15 @@ describe Inferno::Sequence::OncEHRLaunchSequence do
 
     it 'succeeds when server grants additional user scopes' do
       @instance.scopes = good_scopes
-      @instance.received_scopes = good_scopes + ' launch/patient launch/encounter user/ValueSet.read'
+      @instance.received_scopes = good_scopes + ' launch/patient launch/encounter user/Binary.read user/ValueSet.read'
+      @sequence.run_test(@test)
+    end
+
+    it 'succeeds when server grants additional non standard SMART scopes' do
+      scopes = ['abc', 'patient/*/*', 'patient/.', 'patient/*.', 'patient/*.*.*', 'patient/*.write']
+      @instance.scopes = good_scopes
+
+      @instance.received_scopes = good_scopes + " #{scopes.join(' ')}"
       @sequence.run_test(@test)
     end
 

--- a/lib/modules/onc_program/test/onc_standalone_launch_sequence_test.rb
+++ b/lib/modules/onc_program/test/onc_standalone_launch_sequence_test.rb
@@ -79,18 +79,6 @@ describe Inferno::Sequence::OncStandaloneLaunchSequence do
       assert_equal "'#{bad_resource_type}' must be either a valid resource type or '*'", exception.message
     end
 
-    it 'fails when a badly formatted scope was received' do
-      bad_scopes = ['abc', 'patient/*/*', 'patient/.', 'patient/*.', 'patient/*.*.*', 'patient/*.write']
-      @instance.onc_sl_scopes = good_scopes
-
-      bad_scopes.each do |scope|
-        @instance.received_scopes = (@sequence.required_scopes + [scope]).join(' ')
-        exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
-
-        assert_match(/^Request scopes .* were not granted by authorization server./, exception.message)
-      end
-    end
-
     it 'fails when not all patient compartment scopes were received' do
       scopes = ['patient/Patient.read', 'patient/Condition.read', 'patient/Obervation.read']
       @instance.onc_sl_scopes = good_scopes
@@ -103,7 +91,15 @@ describe Inferno::Sequence::OncStandaloneLaunchSequence do
 
     it 'succeeds when server grants additional scopes' do
       @instance.onc_sl_scopes = good_scopes
-      @instance.received_scopes = good_scopes + ' launch launch/encounter user/ValueSet.read'
+      @instance.received_scopes = good_scopes + ' launch launch/encounter patient/Binary.read user/ValueSet.read'
+      @sequence.run_test(@test)
+    end
+
+    it 'succeeds when server grants additional non standard SMART scopes' do
+      scopes = ['abc', 'patient/*/*', 'patient/.', 'patient/*.', 'patient/*.*.*', 'patient/*.write']
+      @instance.onc_sl_scopes = good_scopes
+
+      @instance.received_scopes = good_scopes + " #{scopes.join(' ')}"
       @sequence.run_test(@test)
     end
 

--- a/lib/modules/onc_program/test/onc_standalone_launch_sequence_test.rb
+++ b/lib/modules/onc_program/test/onc_standalone_launch_sequence_test.rb
@@ -51,7 +51,7 @@ describe Inferno::Sequence::OncStandaloneLaunchSequence do
       @instance.onc_sl_scopes = @sequence.required_scopes.join(' ')
       exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
 
-      assert_equal 'Patient-level scope in the format: `patient/[ resource | * ].[ read | *]` was not requested.', exception.message
+      assert_equal 'Patient-level scope for US Core resource types in the format: `patient/[ resource | * ].[ read | *]` was not requested.', exception.message
     end
 
     it 'fails when no patient-level scope was received' do
@@ -59,7 +59,7 @@ describe Inferno::Sequence::OncStandaloneLaunchSequence do
       @instance.received_scopes = @sequence.required_scopes.join(' ')
       exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
 
-      assert_equal 'Patient-level scope in the format: `patient/[ resource | * ].[ read | *]` was not received.', exception.message
+      assert_equal 'Patient-level scope for US Core resource types in the format: `patient/[ resource | * ].[ read | *]` was not received.', exception.message
     end
 
     it 'fails when a badly formatted scope was requested' do
@@ -94,7 +94,19 @@ describe Inferno::Sequence::OncStandaloneLaunchSequence do
       @instance.received_scopes = @sequence.required_scopes.join(' ') + " patient/#{bad_resource_type}.*"
       exception = assert_raises(Inferno::AssertionException) { @sequence.run_test(@test) }
 
-      assert_equal "'#{bad_resource_type}' must be either a valid resource type or '*'", exception.message
+      assert_equal 'Patient-level scope for US Core resource types in the format: `patient/[ resource | * ].[ read | *]` was not received.', exception.message
+    end
+
+    it 'succeeds when server grants additional patient scopes' do
+      @instance.onc_sl_scopes = good_scopes
+      @instance.received_scopes = @sequence.required_scopes.join(' ') + ' patient/Patient.read patient/ValueSet.read'
+      @sequence.run_test(@test)
+    end
+
+    it 'succeeds when server grants launch scope' do
+      @instance.onc_sl_scopes = good_scopes
+      @instance.received_scopes = @sequence.required_scopes.join(' ') + ' launch patient/Patient.read'
+      @sequence.run_test(@test)
     end
 
     it 'succeeds when the required scopes and a patient-level scope are present' do


### PR DESCRIPTION
# Summary
This PR addresses two GitHub Issues: #372 and #353 

1) SMART App Launch IG specifically mentioned `Person` as a possible resource type for `fhirUser` claim. So this PR added `Person` to the whitelist of predefined request scopes. Though Inferno test client does not list patient/Person.read by default, tester can add this scope as needed

2) RFC-6749 section 3.3 allows server to grant additional scopes beyond client's request. This PR relaxes the scope validations for received scopes

## New behavior

## Code changes

## Testing guidance
Verify that tester can manually add patient/Person.read to the Standalone Patient Scope at "Standalone Patient App" test
Server returns additional scope is tested by new unit tests.
