### PR TITLE
FI-1350 update composite_or test

### DIFF
--- a/generator/uscore/uscore_generator.rb
+++ b/generator/uscore/uscore_generator.rb
@@ -929,19 +929,10 @@ module Inferno
               }
 
               composite_or_parameters.each do |param|
-                search_value = resolve_element_from_path(@#{sequence[:resource].underscore}_ary[patient], param, &:present?)
-
-                while search_value.present?
-                  existing_values[param.to_sym] << search_value
-
-                  search_value = resolve_element_from_path(@#{sequence[:resource].underscore}_ary[patient], param) do |value|
-                    value.present? && existing_values[param.to_sym].exclude?(value)
-                  end
-                end
+                existing_values[param.to_sym] = @#{sequence[:resource].underscore}_ary[patient].map(&param.to_sym).compact.uniq
               end
 
               next if existing_values.values.any?(&:empty?)
-
 
               resolved_one = true
 
@@ -952,9 +943,7 @@ module Inferno
 
 
               composite_or_parameters.each do |param|
-                missing_values[param.to_sym] = existing_values[param.to_sym].reject do |val|
-                  resolve_element_from_path(resources_returned, param) { |val_found| val_found == val }
-                end
+                missing_values[param.to_sym] = existing_values[param.to_sym] - resources_returned.map(&param.to_sym)
               end
 
               missing_value_message = missing_values.reject { |_k, v| v.empty? }.map { |k, v| "\#{v.join(',')} values from \#{k}" }.join(' and ')

--- a/lib/modules/uscore_v3.1.1/us_core_careteam_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_careteam_sequence.rb
@@ -453,15 +453,7 @@ module Inferno
           }
 
           composite_or_parameters.each do |param|
-            search_value = resolve_element_from_path(@care_team_ary[patient], param, &:present?)
-
-            while search_value.present?
-              existing_values[param.to_sym] << search_value
-
-              search_value = resolve_element_from_path(@care_team_ary[patient], param) do |value|
-                value.present? && existing_values[param.to_sym].exclude?(value)
-              end
-            end
+            existing_values[param.to_sym] = @care_team_ary[patient].map(&param.to_sym).compact.uniq
           end
 
           next if existing_values.values.any?(&:empty?)
@@ -474,9 +466,7 @@ module Inferno
           resources_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
 
           composite_or_parameters.each do |param|
-            missing_values[param.to_sym] = existing_values[param.to_sym].reject do |val|
-              resolve_element_from_path(resources_returned, param) { |val_found| val_found == val }
-            end
+            missing_values[param.to_sym] = existing_values[param.to_sym] - resources_returned.map(&param.to_sym)
           end
 
           missing_value_message = missing_values.reject { |_k, v| v.empty? }.map { |k, v| "#{v.join(',')} values from #{k}" }.join(' and ')

--- a/lib/modules/uscore_v3.1.1/us_core_careteam_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_careteam_sequence.rb
@@ -433,37 +433,52 @@ module Inferno
         end
 
         skip_if_known_search_not_supported('CareTeam', ['patient', 'status'])
-
         resolved_one = false
 
-        found_second_val = false
         patient_ids.each do |patient|
           next unless @care_team_ary[patient].present?
 
           search_params = {
             'patient': patient,
-            'status': get_value_for_search_param(resolve_element_from_path(@care_team_ary[patient], 'status') { |el| get_value_for_search_param(el).present? })
+            'status': 'proposed,active,suspended,inactive,entered-in-error'
           }
 
-          next if search_params.any? { |_param, value| value.nil? }
+          existing_values = {
+            status: []
+          }
+
+          missing_values = {
+            status: []
+          }
+
+          search_value = resolve_element_from_path(@care_team_ary[patient], 'status', &:present?)
+          next unless search_value.present?
+
+          existing_values[:status] << search_value
+
+          search_value = resolve_element_from_path(@care_team_ary[patient], 'status') do |value|
+            value.present? && existing_values[:status].exclude?(value)
+          end
+
+          existing_values[:status] << search_value if search_value.present?
 
           resolved_one = true
 
-          second_status_val = resolve_element_from_path(@care_team_ary[patient], 'status') { |el| get_value_for_search_param(el) != search_params[:status] }
-          next if second_status_val.nil?
-
-          found_second_val = true
-          search_params[:status] += ',' + get_value_for_search_param(second_status_val)
           reply = get_resource_by_params(versioned_resource_class('CareTeam'), search_params)
           validate_search_reply(versioned_resource_class('CareTeam'), reply, search_params)
           assert_response_ok(reply)
           resources_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
-          missing_values = search_params[:status].split(',').reject do |val|
+
+          missing_values[:status] = existing_values[:status].reject do |val|
             resolve_element_from_path(resources_returned, 'status') { |val_found| val_found == val }
           end
-          assert missing_values.blank?, "Could not find #{missing_values.join(',')} values from status in any of the resources returned"
+
+          missing_value_message = missing_values.reject { |_k, v| v.empty? }.map { |k, v| "#{v.join(',')} values from #{k}" }.join(' and ')
+
+          assert missing_value_message.blank?, "Could not find #{missing_value_message} in any of the resources returned"
+
+          break if resolved_one
         end
-        skip 'Cannot find second value for status to perform a multipleOr search' unless found_second_val
       end
 
       test 'Every reference within CareTeam resources can be read.' do

--- a/lib/modules/uscore_v3.1.1/us_core_medicationrequest_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_medicationrequest_sequence.rb
@@ -733,6 +733,7 @@ module Inferno
 
         skip_if_known_search_not_supported('MedicationRequest', ['patient', 'intent'])
         resolved_one = false
+        composite_or_parameters = ['intent']
 
         patient_ids.each do |patient|
           next unless @medication_request_ary[patient].present?
@@ -750,16 +751,19 @@ module Inferno
             intent: []
           }
 
-          search_value = resolve_element_from_path(@medication_request_ary[patient], 'intent', &:present?)
-          next unless search_value.present?
+          composite_or_parameters.each do |param|
+            search_value = resolve_element_from_path(@medication_request_ary[patient], param, &:present?)
 
-          existing_values[:intent] << search_value
+            while search_value.present?
+              existing_values[param.to_sym] << search_value
 
-          search_value = resolve_element_from_path(@medication_request_ary[patient], 'intent') do |value|
-            value.present? && existing_values[:intent].exclude?(value)
+              search_value = resolve_element_from_path(@medication_request_ary[patient], param) do |value|
+                value.present? && existing_values[param.to_sym].exclude?(value)
+              end
+            end
           end
 
-          existing_values[:intent] << search_value if search_value.present?
+          next if existing_values.values.any?(&:empty?)
 
           resolved_one = true
 
@@ -768,8 +772,10 @@ module Inferno
           assert_response_ok(reply)
           resources_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
 
-          missing_values[:intent] = existing_values[:intent].reject do |val|
-            resolve_element_from_path(resources_returned, 'intent') { |val_found| val_found == val }
+          composite_or_parameters.each do |param|
+            missing_values[param.to_sym] = existing_values[param.to_sym].reject do |val|
+              resolve_element_from_path(resources_returned, param) { |val_found| val_found == val }
+            end
           end
 
           missing_value_message = missing_values.reject { |_k, v| v.empty? }.map { |k, v| "#{v.join(',')} values from #{k}" }.join(' and ')
@@ -781,6 +787,7 @@ module Inferno
 
         skip_if_known_search_not_supported('MedicationRequest', ['patient', 'intent', 'status'])
         resolved_one = false
+        composite_or_parameters = ['intent', 'status']
 
         patient_ids.each do |patient|
           next unless @medication_request_ary[patient].present?
@@ -801,27 +808,20 @@ module Inferno
             status: []
           }
 
-          search_value = resolve_element_from_path(@medication_request_ary[patient], 'intent', &:present?)
-          next unless search_value.present?
+          composite_or_parameters.each do |param|
+            search_value = resolve_element_from_path(@medication_request_ary[patient], param, &:present?)
 
-          existing_values[:intent] << search_value
+            while search_value.present?
+              existing_values[param.to_sym] << search_value
 
-          search_value = resolve_element_from_path(@medication_request_ary[patient], 'intent') do |value|
-            value.present? && existing_values[:intent].exclude?(value)
+              search_value = resolve_element_from_path(@medication_request_ary[patient], param) do |value|
+                value.present? && existing_values[param.to_sym].exclude?(value)
+              end
+            end
           end
 
-          existing_values[:intent] << search_value if search_value.present?
-
-          search_value = resolve_element_from_path(@medication_request_ary[patient], 'status', &:present?)
-          next unless search_value.present?
-
-          existing_values[:status] << search_value
-
-          search_value = resolve_element_from_path(@medication_request_ary[patient], 'status') do |value|
-            value.present? && existing_values[:status].exclude?(value)
-          end
-
-          existing_values[:status] << search_value if search_value.present?
+          binding.pry 
+          next if existing_values.values.any?(&:empty?)
 
           resolved_one = true
 
@@ -830,12 +830,10 @@ module Inferno
           assert_response_ok(reply)
           resources_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
 
-          missing_values[:intent] = existing_values[:intent].reject do |val|
-            resolve_element_from_path(resources_returned, 'intent') { |val_found| val_found == val }
-          end
-
-          missing_values[:status] = existing_values[:status].reject do |val|
-            resolve_element_from_path(resources_returned, 'status') { |val_found| val_found == val }
+          composite_or_parameters.each do |param|
+            missing_values[param.to_sym] = existing_values[param.to_sym].reject do |val|
+              resolve_element_from_path(resources_returned, param) { |val_found| val_found == val }
+            end
           end
 
           missing_value_message = missing_values.reject { |_k, v| v.empty? }.map { |k, v| "#{v.join(',')} values from #{k}" }.join(' and ')

--- a/lib/modules/uscore_v3.1.1/us_core_medicationrequest_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_medicationrequest_sequence.rb
@@ -731,76 +731,119 @@ module Inferno
           versions :r4
         end
 
-        skip_if_known_search_not_supported('MedicationRequest', ['patient', 'intent', 'status'])
-
-        resolved_one = false
-
-        found_second_val = false
-        patient_ids.each do |patient|
-          next unless @medication_request_ary[patient].present?
-
-          Array.wrap(@medication_request_ary[patient]).each do |medication_request|
-            search_params = {
-              'patient': patient,
-              'intent': get_value_for_search_param(resolve_element_from_path(medication_request, 'intent') { |el| get_value_for_search_param(el).present? }),
-              'status': get_value_for_search_param(resolve_element_from_path(medication_request, 'status') { |el| get_value_for_search_param(el).present? })
-            }
-
-            next if search_params.any? { |_param, value| value.nil? }
-
-            resolved_one = true
-
-            second_status_val = resolve_element_from_path(@medication_request_ary[patient], 'status') { |el| get_value_for_search_param(el) != search_params[:status] }
-            next if second_status_val.nil?
-
-            found_second_val = true
-            search_params[:status] += ',' + get_value_for_search_param(second_status_val)
-            reply = get_resource_by_params(versioned_resource_class('MedicationRequest'), search_params)
-            validate_search_reply(versioned_resource_class('MedicationRequest'), reply, search_params)
-            assert_response_ok(reply)
-            resources_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
-            missing_values = search_params[:status].split(',').reject do |val|
-              resolve_element_from_path(resources_returned, 'status') { |val_found| val_found == val }
-            end
-            assert missing_values.blank?, "Could not find #{missing_values.join(',')} values from status in any of the resources returned"
-
-            break if resolved_one
-          end
-        end
-        skip 'Cannot find second value for status to perform a multipleOr search' unless found_second_val
-
         skip_if_known_search_not_supported('MedicationRequest', ['patient', 'intent'])
-
         resolved_one = false
 
-        found_second_val = false
         patient_ids.each do |patient|
           next unless @medication_request_ary[patient].present?
 
           search_params = {
             'patient': patient,
-            'intent': get_value_for_search_param(resolve_element_from_path(@medication_request_ary[patient], 'intent') { |el| get_value_for_search_param(el).present? })
+            'intent': 'proposal,plan,order,original-order,reflex-order,filler-order,instance-order,option'
           }
 
-          next if search_params.any? { |_param, value| value.nil? }
+          existing_values = {
+            intent: []
+          }
+
+          missing_values = {
+            intent: []
+          }
+
+          search_value = resolve_element_from_path(@medication_request_ary[patient], 'intent', &:present?)
+          next unless search_value.present?
+
+          existing_values[:intent] << search_value
+
+          search_value = resolve_element_from_path(@medication_request_ary[patient], 'intent') do |value|
+            value.present? && existing_values[:intent].exclude?(value)
+          end
+
+          existing_values[:intent] << search_value if search_value.present?
 
           resolved_one = true
 
-          second_intent_val = resolve_element_from_path(@medication_request_ary[patient], 'intent') { |el| get_value_for_search_param(el) != search_params[:intent] }
-          next if second_intent_val.nil?
-
-          found_second_val = true
-          search_params[:intent] += ',' + get_value_for_search_param(second_intent_val)
           reply = get_resource_by_params(versioned_resource_class('MedicationRequest'), search_params)
           validate_search_reply(versioned_resource_class('MedicationRequest'), reply, search_params)
           assert_response_ok(reply)
           resources_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
-          missing_values = search_params[:intent].split(',').reject do |val|
+
+          missing_values[:intent] = existing_values[:intent].reject do |val|
             resolve_element_from_path(resources_returned, 'intent') { |val_found| val_found == val }
           end
-          assert missing_values.blank?, "Could not find #{missing_values.join(',')} values from intent in any of the resources returned"
+
+          missing_value_message = missing_values.reject { |_k, v| v.empty? }.map { |k, v| "#{v.join(',')} values from #{k}" }.join(' and ')
+
+          assert missing_value_message.blank?, "Could not find #{missing_value_message} in any of the resources returned"
+
+          break if resolved_one
         end
-        skip 'Cannot find second value for intent to perform a multipleOr search' unless found_second_val
+
+        skip_if_known_search_not_supported('MedicationRequest', ['patient', 'intent', 'status'])
+        resolved_one = false
+
+        patient_ids.each do |patient|
+          next unless @medication_request_ary[patient].present?
+
+          search_params = {
+            'patient': patient,
+            'intent': 'proposal,plan,order,original-order,reflex-order,filler-order,instance-order,option',
+            'status': 'active,on-hold,cancelled,completed,entered-in-error,stopped,draft,unknown'
+          }
+
+          existing_values = {
+            intent: [],
+            status: []
+          }
+
+          missing_values = {
+            intent: [],
+            status: []
+          }
+
+          search_value = resolve_element_from_path(@medication_request_ary[patient], 'intent', &:present?)
+          next unless search_value.present?
+
+          existing_values[:intent] << search_value
+
+          search_value = resolve_element_from_path(@medication_request_ary[patient], 'intent') do |value|
+            value.present? && existing_values[:intent].exclude?(value)
+          end
+
+          existing_values[:intent] << search_value if search_value.present?
+
+          search_value = resolve_element_from_path(@medication_request_ary[patient], 'status', &:present?)
+          next unless search_value.present?
+
+          existing_values[:status] << search_value
+
+          search_value = resolve_element_from_path(@medication_request_ary[patient], 'status') do |value|
+            value.present? && existing_values[:status].exclude?(value)
+          end
+
+          existing_values[:status] << search_value if search_value.present?
+
+          resolved_one = true
+
+          reply = get_resource_by_params(versioned_resource_class('MedicationRequest'), search_params)
+          validate_search_reply(versioned_resource_class('MedicationRequest'), reply, search_params)
+          assert_response_ok(reply)
+          resources_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
+
+          missing_values[:intent] = existing_values[:intent].reject do |val|
+            resolve_element_from_path(resources_returned, 'intent') { |val_found| val_found == val }
+          end
+
+          missing_values[:status] = existing_values[:status].reject do |val|
+            resolve_element_from_path(resources_returned, 'status') { |val_found| val_found == val }
+          end
+
+          missing_value_message = missing_values.reject { |_k, v| v.empty? }.map { |k, v| "#{v.join(',')} values from #{k}" }.join(' and ')
+
+          assert missing_value_message.blank?, "Could not find #{missing_value_message} in any of the resources returned"
+
+          break if resolved_one
+        end
       end
 
       test 'Every reference within MedicationRequest resources can be read.' do

--- a/lib/modules/uscore_v3.1.1/us_core_medicationrequest_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_medicationrequest_sequence.rb
@@ -752,15 +752,7 @@ module Inferno
           }
 
           composite_or_parameters.each do |param|
-            search_value = resolve_element_from_path(@medication_request_ary[patient], param, &:present?)
-
-            while search_value.present?
-              existing_values[param.to_sym] << search_value
-
-              search_value = resolve_element_from_path(@medication_request_ary[patient], param) do |value|
-                value.present? && existing_values[param.to_sym].exclude?(value)
-              end
-            end
+            existing_values[param.to_sym] = @medication_request_ary[patient].map(&param.to_sym).compact.uniq
           end
 
           next if existing_values.values.any?(&:empty?)
@@ -773,9 +765,7 @@ module Inferno
           resources_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
 
           composite_or_parameters.each do |param|
-            missing_values[param.to_sym] = existing_values[param.to_sym].reject do |val|
-              resolve_element_from_path(resources_returned, param) { |val_found| val_found == val }
-            end
+            missing_values[param.to_sym] = existing_values[param.to_sym] - resources_returned.map(&param.to_sym)
           end
 
           missing_value_message = missing_values.reject { |_k, v| v.empty? }.map { |k, v| "#{v.join(',')} values from #{k}" }.join(' and ')
@@ -809,18 +799,9 @@ module Inferno
           }
 
           composite_or_parameters.each do |param|
-            search_value = resolve_element_from_path(@medication_request_ary[patient], param, &:present?)
-
-            while search_value.present?
-              existing_values[param.to_sym] << search_value
-
-              search_value = resolve_element_from_path(@medication_request_ary[patient], param) do |value|
-                value.present? && existing_values[param.to_sym].exclude?(value)
-              end
-            end
+            existing_values[param.to_sym] = @medication_request_ary[patient].map(&param.to_sym).compact.uniq
           end
 
-          binding.pry 
           next if existing_values.values.any?(&:empty?)
 
           resolved_one = true
@@ -831,9 +812,7 @@ module Inferno
           resources_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
 
           composite_or_parameters.each do |param|
-            missing_values[param.to_sym] = existing_values[param.to_sym].reject do |val|
-              resolve_element_from_path(resources_returned, param) { |val_found| val_found == val }
-            end
+            missing_values[param.to_sym] = existing_values[param.to_sym] - resources_returned.map(&param.to_sym)
           end
 
           missing_value_message = missing_values.reject { |_k, v| v.empty? }.map { |k, v| "#{v.join(',')} values from #{k}" }.join(' and ')


### PR DESCRIPTION
# Summary
This PR fixes GitHub issue #312, #284

We updated composite-or search to
1) Generate search using all possible values for binding value set. All three composite-or searches have required binding for search element.
2) Collect expected values from previous seen resource.
3) Validate that the all expected values are seen in the composite-or search results 

## New behavior

## Code changes
Updates composite-or search in uscore_generator 

## Testing guidance
GitHub issue #312 has a sample MedicationRequest bundle.  