### PR TITLE
Add info on how to restrict access to codesystem validation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,8 +163,6 @@ Running instances of Inferno can be configured to exclude terminology validation
 for codes based on applicable categories of additional restrictions, as defined
 by the [UMLS license
 agreement](https://www.nlm.nih.gov/research/umls/knowledge_sources/metathesaurus/release/license_agreement.html).
-instances of Inferno can be configured to not validate codes in CodeSystems
-based on these categories, or based on individual CodeSystems.
 
 By default, Inferno will not restrict validation of codes. To configure an
 instance of Inferno to exclude certain CodeSystems for validation, rename the

--- a/README.md
+++ b/README.md
@@ -157,6 +157,25 @@ Should return:
 ✓ http://snomed.info/sct|91935009  is in http://snomed.info/sct
 ```
 
+#### Restricting access to CodeSystems based on licensing terms
+
+Running instances of Inferno can be configured to exclude terminology validation
+for codes based on applicable categories of additional restrictions, as defined
+by the [UMLS license
+agreement](https://www.nlm.nih.gov/research/umls/knowledge_sources/metathesaurus/release/license_agreement.html).
+instances of Inferno can be configured to not validate codes in CodeSystems
+based on these categories, or based on individual CodeSystems.
+
+By default, Inferno will not restrict validation of codes. To configure an
+instance of Inferno to exclude certain CodeSystems for validation, rename the
+`resources/terminology/terminology_config.yml.example` to
+`terminology_config.yml`, and update the file based on the example content.
+Inferno will provide an informational message on the landing page that describes
+which CodeSystems will not be validated in this running instance based on this
+configuration file.  If Inferno tests receive a code from an excluded
+CodeSystem, a warning indicating that Inferno cannot validate the code will be
+provided along with the test result.
+
 #### Manual build instructions
 
 If this Docker-based method does not work based on your architecture, manual setup and creation of the terminology validators is documented [on this wiki page](https://github.com/onc-healthit/inferno/wiki/Installing-Terminology-Validators#building-the-validators-without-docker)

--- a/lib/app/views/restricted_codesystems.erb
+++ b/lib/app/views/restricted_codesystems.erb
@@ -5,7 +5,7 @@
         <div class="col-12">
           <div class="alert alert-secondary" role="alert" style="margin-top: 2rem; margin-bottom: 0;">
             This running instance of Inferno does not validate codes from the <%=@restricted_codesystems.join(', ')%> CodeSystem(s) due
-            to licensing restrictions.  A warning will presented within tests if codes from these CodeSystems are encountered.  Please visit
+            to licensing restrictions.  A warning will be presented within tests if codes from these CodeSystems are encountered.  Please visit
             <a href="https://github.com/onc-healthit/inferno-program#installation-and-deployment" target="_blank">the README</a> for information on downloading Inferno and loading these CodeSystems locally.
           </div>
         </div>


### PR DESCRIPTION
# Summary
Fixes typo in the info box when codesystems are restricted for validation, and adds section in README on how to configure this.

Please review language.
