### PR TITLE
FI-1364: Fix duplicated search

### DIFF
--- a/generator/uscore/uscore_generator.rb
+++ b/generator/uscore/uscore_generator.rb
@@ -1236,9 +1236,6 @@ module Inferno
               assert_bundle_response(reply)
 
               #{search_by_type_length_check unless sequence[:resource] == 'Device'}
-              search_with_type = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
-              search_with_type.select! { |resource| resource.resourceType == '#{sequence[:resource]}'}
-              assert search_with_type.length == resources_returned.length, 'Expected search by Patient/ID to have the same results as search by ID'
 
               # Search by POST variant
               reply = get_resource_by_params(versioned_resource_class('#{sequence[:resource]}'), search_params, search_method: :post)

--- a/lib/modules/uscore_v3.1.1/bodyheight_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/bodyheight_sequence.rb
@@ -237,10 +237,6 @@ module Inferno
             search_with_type.select! { |resource| resource.resourceType == 'Observation' }
             assert search_with_type.length == resources_returned.length, 'Expected search by Patient/ID to have the same results as search by ID'
 
-            search_with_type = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
-            search_with_type.select! { |resource| resource.resourceType == 'Observation' }
-            assert search_with_type.length == resources_returned.length, 'Expected search by Patient/ID to have the same results as search by ID'
-
             # Search by POST variant
             reply = get_resource_by_params(versioned_resource_class('Observation'), search_params, search_method: :post)
 

--- a/lib/modules/uscore_v3.1.1/bodytemp_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/bodytemp_sequence.rb
@@ -237,10 +237,6 @@ module Inferno
             search_with_type.select! { |resource| resource.resourceType == 'Observation' }
             assert search_with_type.length == resources_returned.length, 'Expected search by Patient/ID to have the same results as search by ID'
 
-            search_with_type = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
-            search_with_type.select! { |resource| resource.resourceType == 'Observation' }
-            assert search_with_type.length == resources_returned.length, 'Expected search by Patient/ID to have the same results as search by ID'
-
             # Search by POST variant
             reply = get_resource_by_params(versioned_resource_class('Observation'), search_params, search_method: :post)
 

--- a/lib/modules/uscore_v3.1.1/bodyweight_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/bodyweight_sequence.rb
@@ -237,10 +237,6 @@ module Inferno
             search_with_type.select! { |resource| resource.resourceType == 'Observation' }
             assert search_with_type.length == resources_returned.length, 'Expected search by Patient/ID to have the same results as search by ID'
 
-            search_with_type = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
-            search_with_type.select! { |resource| resource.resourceType == 'Observation' }
-            assert search_with_type.length == resources_returned.length, 'Expected search by Patient/ID to have the same results as search by ID'
-
             # Search by POST variant
             reply = get_resource_by_params(versioned_resource_class('Observation'), search_params, search_method: :post)
 

--- a/lib/modules/uscore_v3.1.1/bp_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/bp_sequence.rb
@@ -237,10 +237,6 @@ module Inferno
             search_with_type.select! { |resource| resource.resourceType == 'Observation' }
             assert search_with_type.length == resources_returned.length, 'Expected search by Patient/ID to have the same results as search by ID'
 
-            search_with_type = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
-            search_with_type.select! { |resource| resource.resourceType == 'Observation' }
-            assert search_with_type.length == resources_returned.length, 'Expected search by Patient/ID to have the same results as search by ID'
-
             # Search by POST variant
             reply = get_resource_by_params(versioned_resource_class('Observation'), search_params, search_method: :post)
 

--- a/lib/modules/uscore_v3.1.1/head_occipital_frontal_circumference_percentile_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/head_occipital_frontal_circumference_percentile_sequence.rb
@@ -237,10 +237,6 @@ module Inferno
             search_with_type.select! { |resource| resource.resourceType == 'Observation' }
             assert search_with_type.length == resources_returned.length, 'Expected search by Patient/ID to have the same results as search by ID'
 
-            search_with_type = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
-            search_with_type.select! { |resource| resource.resourceType == 'Observation' }
-            assert search_with_type.length == resources_returned.length, 'Expected search by Patient/ID to have the same results as search by ID'
-
             # Search by POST variant
             reply = get_resource_by_params(versioned_resource_class('Observation'), search_params, search_method: :post)
 

--- a/lib/modules/uscore_v3.1.1/heartrate_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/heartrate_sequence.rb
@@ -237,10 +237,6 @@ module Inferno
             search_with_type.select! { |resource| resource.resourceType == 'Observation' }
             assert search_with_type.length == resources_returned.length, 'Expected search by Patient/ID to have the same results as search by ID'
 
-            search_with_type = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
-            search_with_type.select! { |resource| resource.resourceType == 'Observation' }
-            assert search_with_type.length == resources_returned.length, 'Expected search by Patient/ID to have the same results as search by ID'
-
             # Search by POST variant
             reply = get_resource_by_params(versioned_resource_class('Observation'), search_params, search_method: :post)
 

--- a/lib/modules/uscore_v3.1.1/pediatric_bmi_for_age_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/pediatric_bmi_for_age_sequence.rb
@@ -237,10 +237,6 @@ module Inferno
             search_with_type.select! { |resource| resource.resourceType == 'Observation' }
             assert search_with_type.length == resources_returned.length, 'Expected search by Patient/ID to have the same results as search by ID'
 
-            search_with_type = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
-            search_with_type.select! { |resource| resource.resourceType == 'Observation' }
-            assert search_with_type.length == resources_returned.length, 'Expected search by Patient/ID to have the same results as search by ID'
-
             # Search by POST variant
             reply = get_resource_by_params(versioned_resource_class('Observation'), search_params, search_method: :post)
 

--- a/lib/modules/uscore_v3.1.1/pediatric_weight_for_height_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/pediatric_weight_for_height_sequence.rb
@@ -237,10 +237,6 @@ module Inferno
             search_with_type.select! { |resource| resource.resourceType == 'Observation' }
             assert search_with_type.length == resources_returned.length, 'Expected search by Patient/ID to have the same results as search by ID'
 
-            search_with_type = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
-            search_with_type.select! { |resource| resource.resourceType == 'Observation' }
-            assert search_with_type.length == resources_returned.length, 'Expected search by Patient/ID to have the same results as search by ID'
-
             # Search by POST variant
             reply = get_resource_by_params(versioned_resource_class('Observation'), search_params, search_method: :post)
 

--- a/lib/modules/uscore_v3.1.1/resprate_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/resprate_sequence.rb
@@ -237,10 +237,6 @@ module Inferno
             search_with_type.select! { |resource| resource.resourceType == 'Observation' }
             assert search_with_type.length == resources_returned.length, 'Expected search by Patient/ID to have the same results as search by ID'
 
-            search_with_type = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
-            search_with_type.select! { |resource| resource.resourceType == 'Observation' }
-            assert search_with_type.length == resources_returned.length, 'Expected search by Patient/ID to have the same results as search by ID'
-
             # Search by POST variant
             reply = get_resource_by_params(versioned_resource_class('Observation'), search_params, search_method: :post)
 

--- a/lib/modules/uscore_v3.1.1/us_core_careplan_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_careplan_sequence.rb
@@ -222,10 +222,6 @@ module Inferno
             search_with_type.select! { |resource| resource.resourceType == 'CarePlan' }
             assert search_with_type.length == resources_returned.length, 'Expected search by Patient/ID to have the same results as search by ID'
 
-            search_with_type = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
-            search_with_type.select! { |resource| resource.resourceType == 'CarePlan' }
-            assert search_with_type.length == resources_returned.length, 'Expected search by Patient/ID to have the same results as search by ID'
-
             # Search by POST variant
             reply = get_resource_by_params(versioned_resource_class('CarePlan'), search_params, search_method: :post)
 

--- a/lib/modules/uscore_v3.1.1/us_core_careteam_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_careteam_sequence.rb
@@ -195,10 +195,6 @@ module Inferno
             search_with_type.select! { |resource| resource.resourceType == 'CareTeam' }
             assert search_with_type.length == resources_returned.length, 'Expected search by Patient/ID to have the same results as search by ID'
 
-            search_with_type = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
-            search_with_type.select! { |resource| resource.resourceType == 'CareTeam' }
-            assert search_with_type.length == resources_returned.length, 'Expected search by Patient/ID to have the same results as search by ID'
-
             # Search by POST variant
             reply = get_resource_by_params(versioned_resource_class('CareTeam'), search_params, search_method: :post)
 

--- a/lib/modules/uscore_v3.1.1/us_core_diagnosticreport_lab_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_diagnosticreport_lab_sequence.rb
@@ -240,10 +240,6 @@ module Inferno
             search_with_type.select! { |resource| resource.resourceType == 'DiagnosticReport' }
             assert search_with_type.length == resources_returned.length, 'Expected search by Patient/ID to have the same results as search by ID'
 
-            search_with_type = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
-            search_with_type.select! { |resource| resource.resourceType == 'DiagnosticReport' }
-            assert search_with_type.length == resources_returned.length, 'Expected search by Patient/ID to have the same results as search by ID'
-
             # Search by POST variant
             reply = get_resource_by_params(versioned_resource_class('DiagnosticReport'), search_params, search_method: :post)
 

--- a/lib/modules/uscore_v3.1.1/us_core_diagnosticreport_note_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_diagnosticreport_note_sequence.rb
@@ -240,10 +240,6 @@ module Inferno
             search_with_type.select! { |resource| resource.resourceType == 'DiagnosticReport' }
             assert search_with_type.length == resources_returned.length, 'Expected search by Patient/ID to have the same results as search by ID'
 
-            search_with_type = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
-            search_with_type.select! { |resource| resource.resourceType == 'DiagnosticReport' }
-            assert search_with_type.length == resources_returned.length, 'Expected search by Patient/ID to have the same results as search by ID'
-
             # Search by POST variant
             reply = get_resource_by_params(versioned_resource_class('DiagnosticReport'), search_params, search_method: :post)
 

--- a/lib/modules/uscore_v3.1.1/us_core_medicationrequest_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_medicationrequest_sequence.rb
@@ -252,10 +252,6 @@ module Inferno
             search_with_type.select! { |resource| resource.resourceType == 'MedicationRequest' }
             assert search_with_type.length == resources_returned.length, 'Expected search by Patient/ID to have the same results as search by ID'
 
-            search_with_type = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
-            search_with_type.select! { |resource| resource.resourceType == 'MedicationRequest' }
-            assert search_with_type.length == resources_returned.length, 'Expected search by Patient/ID to have the same results as search by ID'
-
             # Search by POST variant
             reply = get_resource_by_params(versioned_resource_class('MedicationRequest'), search_params, search_method: :post)
 

--- a/lib/modules/uscore_v3.1.1/us_core_observation_lab_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_observation_lab_sequence.rb
@@ -237,10 +237,6 @@ module Inferno
             search_with_type.select! { |resource| resource.resourceType == 'Observation' }
             assert search_with_type.length == resources_returned.length, 'Expected search by Patient/ID to have the same results as search by ID'
 
-            search_with_type = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
-            search_with_type.select! { |resource| resource.resourceType == 'Observation' }
-            assert search_with_type.length == resources_returned.length, 'Expected search by Patient/ID to have the same results as search by ID'
-
             # Search by POST variant
             reply = get_resource_by_params(versioned_resource_class('Observation'), search_params, search_method: :post)
 

--- a/lib/modules/uscore_v3.1.1/us_core_pulse_oximetry_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_pulse_oximetry_sequence.rb
@@ -237,10 +237,6 @@ module Inferno
             search_with_type.select! { |resource| resource.resourceType == 'Observation' }
             assert search_with_type.length == resources_returned.length, 'Expected search by Patient/ID to have the same results as search by ID'
 
-            search_with_type = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
-            search_with_type.select! { |resource| resource.resourceType == 'Observation' }
-            assert search_with_type.length == resources_returned.length, 'Expected search by Patient/ID to have the same results as search by ID'
-
             # Search by POST variant
             reply = get_resource_by_params(versioned_resource_class('Observation'), search_params, search_method: :post)
 

--- a/lib/modules/uscore_v3.1.1/us_core_smokingstatus_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_smokingstatus_sequence.rb
@@ -241,10 +241,6 @@ module Inferno
             search_with_type.select! { |resource| resource.resourceType == 'Observation' }
             assert search_with_type.length == resources_returned.length, 'Expected search by Patient/ID to have the same results as search by ID'
 
-            search_with_type = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
-            search_with_type.select! { |resource| resource.resourceType == 'Observation' }
-            assert search_with_type.length == resources_returned.length, 'Expected search by Patient/ID to have the same results as search by ID'
-
             # Search by POST variant
             reply = get_resource_by_params(versioned_resource_class('Observation'), search_params, search_method: :post)
 


### PR DESCRIPTION
# Summary
It looks like at some point the generator code for testing reference searches with types was extracted into a variable, but that code wasn't removed from its original location, so these searches were being tested twice.

## Testing guidance
This change should not cause any behavior changes, other than the search not being performed twice.