### PR TITLE
FI-1366 BED-02 validate canonical url with version 

### DIFF
--- a/lib/modules/onc_program/bulk_data_export_sequence.rb
+++ b/lib/modules/onc_program/bulk_data_export_sequence.rb
@@ -47,7 +47,6 @@ module Inferno
         conformance = versioned_resource_class.from_contents(reply.body)
         assert conformance.present?, 'Cannot read server CapabilityStatement.'
 
-        # assert operation.present?, 'Server CapabilityStatement did not declare support for export operation in Group resource.'
         has_export = conformance.rest&.any? do |rest|
           rest.resource&.any? do |resource|
             resource.type == 'Group' &&

--- a/lib/modules/onc_program/bulk_data_export_sequence.rb
+++ b/lib/modules/onc_program/bulk_data_export_sequence.rb
@@ -51,7 +51,7 @@ module Inferno
           rest.resource&.any? do |resource|
             resource.type == 'Group' &&
               resource.respond_to?(:operation) &&
-              resource.operation&.find { |op| op.definition.match(%r{^http://hl7.org/fhir/uv/bulkdata/OperationDefinition/group-export(\|\S*)?}) }
+              resource.operation&.find { |op| op.definition.match(%r{^http://hl7.org/fhir/uv/bulkdata/OperationDefinition/group-export(\|\S+)?}) }
           end
         end
 

--- a/lib/modules/onc_program/bulk_data_export_sequence.rb
+++ b/lib/modules/onc_program/bulk_data_export_sequence.rb
@@ -47,18 +47,16 @@ module Inferno
         conformance = versioned_resource_class.from_contents(reply.body)
         assert conformance.present?, 'Cannot read server CapabilityStatement.'
 
-        operation = nil
-
-        conformance.rest&.each do |rest|
-          group = rest.resource&.find { |r| r.type == 'Group' && r.respond_to?(:operation) }
-
-          next if group.nil?
-
-          operation = group.operation&.find { |op| op.definition == 'http://hl7.org/fhir/uv/bulkdata/OperationDefinition/group-export' }
-          break if operation.present?
+        # assert operation.present?, 'Server CapabilityStatement did not declare support for export operation in Group resource.'
+        has_export = conformance.rest&.any? do |rest|
+          rest.resource&.any? do |resource|
+            resource.type == 'Group' &&
+              resource.respond_to?(:operation) &&
+              resource.operation&.find { |op| op.definition.match(%r{^http://hl7.org/fhir/uv/bulkdata/OperationDefinition/group-export(\|\S*)?}) }
+          end
         end
 
-        assert operation.present?, 'Server CapabilityStatement did not declare support for export operation in Group resource.'
+        assert has_export, 'Server CapabilityStatement did not declare support for export operation in Group resource.'
       end
 
       def check_export_kick_off


### PR DESCRIPTION
# Summary
This is a fix of #390 
FHIR canonical URL allows version number to be attached at the end of url. BED-02 validates that CapabilityStatement has an operation defined by canonical url "http://hl7.org/fhir/uv/bulkdata/OperationDefinition/group-export"

## New behavior
Using Regular Expression /^http://hl7.org/fhir/uv/bulkdata/OperationDefinition/group-export(\|\S*)?/ to validate canonical url

## Code changes

## Testing guidance
A new unit test is added to verify that BED-02 passed url with version
