### PR TITLE
FI-1367 Ensure operation outcomes are allowed in composite or search result.

### DIFF
--- a/generator/uscore/uscore_generator.rb
+++ b/generator/uscore/uscore_generator.rb
@@ -938,12 +938,10 @@ module Inferno
 
               reply = get_resource_by_params(versioned_resource_class('#{sequence[:resource]}'), search_params)
               validate_search_reply(versioned_resource_class('#{sequence[:resource]}'), reply, search_params)
-              assert_response_ok(reply)
               resources_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
-
-
+              applicable_resources_returned = resources_returned.reject { |entry| entry.class == FHIR::OperationOutcome }
               composite_or_parameters.each do |param|
-                missing_values[param.to_sym] = existing_values[param.to_sym] - resources_returned.map(&param.to_sym)
+                missing_values[param.to_sym] = existing_values[param.to_sym] - applicable_resources_returned.map(&param.to_sym)
               end
 
               missing_value_message = missing_values.reject { |_k, v| v.empty? }.map { |k, v| "\#{v.join(',')} values from \#{k}" }.join(' and ')

--- a/lib/modules/uscore_v3.1.1/us_core_careteam_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_careteam_sequence.rb
@@ -462,11 +462,10 @@ module Inferno
 
           reply = get_resource_by_params(versioned_resource_class('CareTeam'), search_params)
           validate_search_reply(versioned_resource_class('CareTeam'), reply, search_params)
-          assert_response_ok(reply)
           resources_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
-
+          applicable_resources_returned = resources_returned.reject { |entry| entry.class == FHIR::OperationOutcome }
           composite_or_parameters.each do |param|
-            missing_values[param.to_sym] = existing_values[param.to_sym] - resources_returned.map(&param.to_sym)
+            missing_values[param.to_sym] = existing_values[param.to_sym] - applicable_resources_returned.map(&param.to_sym)
           end
 
           missing_value_message = missing_values.reject { |_k, v| v.empty? }.map { |k, v| "#{v.join(',')} values from #{k}" }.join(' and ')

--- a/lib/modules/uscore_v3.1.1/us_core_medicationrequest_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_medicationrequest_sequence.rb
@@ -761,11 +761,10 @@ module Inferno
 
           reply = get_resource_by_params(versioned_resource_class('MedicationRequest'), search_params)
           validate_search_reply(versioned_resource_class('MedicationRequest'), reply, search_params)
-          assert_response_ok(reply)
           resources_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
-
+          applicable_resources_returned = resources_returned.reject { |entry| entry.class == FHIR::OperationOutcome }
           composite_or_parameters.each do |param|
-            missing_values[param.to_sym] = existing_values[param.to_sym] - resources_returned.map(&param.to_sym)
+            missing_values[param.to_sym] = existing_values[param.to_sym] - applicable_resources_returned.map(&param.to_sym)
           end
 
           missing_value_message = missing_values.reject { |_k, v| v.empty? }.map { |k, v| "#{v.join(',')} values from #{k}" }.join(' and ')
@@ -808,11 +807,10 @@ module Inferno
 
           reply = get_resource_by_params(versioned_resource_class('MedicationRequest'), search_params)
           validate_search_reply(versioned_resource_class('MedicationRequest'), reply, search_params)
-          assert_response_ok(reply)
           resources_returned = fetch_all_bundled_resources(reply, check_for_data_absent_reasons)
-
+          applicable_resources_returned = resources_returned.reject { |entry| entry.class == FHIR::OperationOutcome }
           composite_or_parameters.each do |param|
-            missing_values[param.to_sym] = existing_values[param.to_sym] - resources_returned.map(&param.to_sym)
+            missing_values[param.to_sym] = existing_values[param.to_sym] - applicable_resources_returned.map(&param.to_sym)
           end
 
           missing_value_message = missing_values.reject { |_k, v| v.empty? }.map { |k, v| "#{v.join(',')} values from #{k}" }.join(' and ')


### PR DESCRIPTION
# Summary

The updated logic in the composite or searches do not properly filter out OperationOutcomes prior to checking return values.  This results in improper errors if the system returns an OperationOutcome.

## New behavior

If a system returns an OperationOutcome, alone with the resource types being searched for, it will no longer improperly fail.

## Code changes

Added a simple filter based on logic that is now bypassed in this section of the composite or test.

## Testing guidance

Unfortunately, we do not have a unit test for composite or searches.  There is no straightforward way to test this right now with our setup, unless you can mock up a server endpoint that injects an operation outcome.  We may consider adding a unit test section for composite-ors prior to merging this.