### PR TITLE
FI-1379 Filter validator errors ending with "(must be one of [])"

### DIFF
--- a/lib/app/utils/hl7_validator.rb
+++ b/lib/app/utils/hl7_validator.rb
@@ -8,7 +8,7 @@ module Inferno
     ISSUE_DETAILS_FILTER = [
       %r{^Sub-extension url 'introspect' is not defined by the Extension http://fhir-registry\.smarthealthit\.org/StructureDefinition/oauth-uris$},
       %r{^Sub-extension url 'revoke' is not defined by the Extension http://fhir-registry\.smarthealthit\.org/StructureDefinition/oauth-uris$},
-      /is not a valid Target for this element \(must be one of \[\]\)$/, # This is fix at v5.3.8
+      /is not a valid Target for this element \(must be one of \[\]\)$/, # This is fixed in FHIR Validator v5.3.8
       /^vs-1: if Observation\.effective\[x\] is dateTime and has a value then that value shall be precise to the day/, # Invalid invariant in FHIR v4.0.1
       /^us-core-1: Datetime must be at least to day/ # Invalid invariant in US Core v3.1.1
     ].freeze

--- a/lib/app/utils/hl7_validator.rb
+++ b/lib/app/utils/hl7_validator.rb
@@ -8,6 +8,7 @@ module Inferno
     ISSUE_DETAILS_FILTER = [
       %r{^Sub-extension url 'introspect' is not defined by the Extension http://fhir-registry\.smarthealthit\.org/StructureDefinition/oauth-uris$},
       %r{^Sub-extension url 'revoke' is not defined by the Extension http://fhir-registry\.smarthealthit\.org/StructureDefinition/oauth-uris$},
+      /is not a valid Target for this element \(must be one of \[\]\)$/, # This is fix at v5.3.8
       /^vs-1: if Observation\.effective\[x\] is dateTime and has a value then that value shall be precise to the day/, # Invalid invariant in FHIR v4.0.1
       /^us-core-1: Datetime must be at least to day/ # Invalid invariant in US Core v3.1.1
     ].freeze

--- a/test/fixtures/hl7_validator_operation_outcome.json
+++ b/test/fixtures/hl7_validator_operation_outcome.json
@@ -30,6 +30,16 @@
     },
     {
       "severity": "error",
+      "code": "structure",
+      "details": {
+        "text": "The type 'DocumentReference' is not a valid Target for this element (must be one of [])"
+      },
+      "expression": [
+        "Observation.extension[0].value.ofType(Reference)"
+      ]
+    },
+    {
+      "severity": "error",
       "code": "code-invalid",
       "details": {
         "text": "This is a code-invalid error"

--- a/test/unit/hl7_validator_test.rb
+++ b/test/unit/hl7_validator_test.rb
@@ -45,7 +45,7 @@ describe Inferno::HL7Validator do
       result = @validator.validate(@resource, FHIR, @profile)
       assert_equal 2, result[:errors].length
       assert_equal 1, result[:warnings].length
-      assert_equal 4, result[:information].length
+      assert_equal 5, result[:information].length
     end
 
     it 'adds Resource id error' do


### PR DESCRIPTION
# Summary
This is a fix of GitHub issue #411 

HL7 validator v5.2.10 has a bug which causing validator error when the target profile is a reference, and that reference returns an empty list of target profiles

This is fixed in HL7 validator [v5.3.8](https://github.com/hapifhir/org.hl7.fhir.core/releases/tag/5.3.8)

Inferno program uses FHIR validator wrapper v1.2.0 which is based on HL7 validator v5.2.10.

Inferno suppresses validator errors ending with "... is not a valid Target for this element (must be one of [])" 

## New behavior
Inferno suppresses validator errors ending with "... is not a valid Target for this element (must be one of [])" 

## Code changes
Add exclude pattern to HL7Validator

## Testing guidance
Add unit test for HL7Validator
