### PR TITLE
FI-1380 Update validator service to v2.1.0

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -46,7 +46,7 @@ external_resource_validator_url: http://validator_service:4567
 
 # The expected version of the external validator. The app will display a warning if
 # the found version doesn't match the expected version exactly.
-external_resource_validator_version: '1.2.1'
+external_resource_validator_version: '2.1.0'
 
 # The list of testing modules which will be made available. These entries must
 # match the "name" field in the .yml files in lib/modules.

--- a/docker-compose.postgres.yml
+++ b/docker-compose.postgres.yml
@@ -28,7 +28,7 @@ services:
       POSTGRES_HOST_AUTH_METHOD: trust
       POSTGRES_USER: postgres
   validator_service:
-    image: infernocommunity/fhir-validator-service:v1.2.1
+    image: infernocommunity/fhir-validator-service:v2.1.0
     restart: unless-stopped
     networks:
       - inferno-production

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
     depends_on:
       - validator_service
   validator_service:
-    image: infernocommunity/fhir-validator-service:v1.2.1
+    image: infernocommunity/fhir-validator-service:v2.1.0
     environment:
       DISABLE_TX: 'true'
   nginx:

--- a/lib/app/utils/hl7_validator.rb
+++ b/lib/app/utils/hl7_validator.rb
@@ -6,11 +6,14 @@ module Inferno
   # A validator that calls out to the HL7 validator API
   class HL7Validator
     ISSUE_DETAILS_FILTER = [
+      # This will be fixed with https://jira.hl7.org/browse/FHIR-28099
       %r{^Sub-extension url 'introspect' is not defined by the Extension http://fhir-registry\.smarthealthit\.org/StructureDefinition/oauth-uris$},
+      # This will be fixed with https://jira.hl7.org/browse/FHIR-28099
       %r{^Sub-extension url 'revoke' is not defined by the Extension http://fhir-registry\.smarthealthit\.org/StructureDefinition/oauth-uris$},
-      /is not a valid Target for this element \(must be one of \[\]\)$/, # This is fixed in FHIR Validator v5.3.8
-      /^vs-1: if Observation\.effective\[x\] is dateTime and has a value then that value shall be precise to the day/, # Invalid invariant in FHIR v4.0.1
-      /^us-core-1: Datetime must be at least to day/ # Invalid invariant in US Core v3.1.1
+      # Invalid invariant in FHIR v4.0.1
+      /^vs-1: 'if Observation\.effective\[x\] is dateTime and has a value then that value shall be precise to the day'/,
+      # Invalid invariant in US Core v3.1.1
+      /^us-core-1: 'Datetime must be at least to day.'/
     ].freeze
     @validator_url = nil
     attr_accessor :expected_version

--- a/lib/app/utils/hl7_validator.rb
+++ b/lib/app/utils/hl7_validator.rb
@@ -34,29 +34,7 @@ module Inferno
       result = RestClient.post "#{@validator_url}/validate", resource.source_contents, params: { profile: profile_url }
       outcome = fhir_models_klass.from_contents(result.body)
 
-      result = issues_by_severity(outcome.issue)
-
-      id_errors = validate_resource_id(resource)
-
-      result[:errors].concat(id_errors)
-
-      result
-    end
-
-    # FHIR validator does not valid Resource.id /^[A-Za-z0-9\-\.]{1,64}$/
-    # So Inferno has to check Resource.id against this regex.
-    # This should be removed after FHIR validator fix
-    def validate_resource_id(resource)
-      errors = []
-
-      walk_resource(resource) do |value, meta, path|
-        next unless meta['type'] == 'id'
-        next unless value.present?
-
-        errors << "#{resource.resourceType}.#{path}: FHIR id value shall match Regex /^[A-Za-z0-9\-\.]{1,64}$/" unless value.match?(/^[A-Za-z0-9\-\.]{1,64}$/)
-      end
-
-      errors
+      issues_by_severity(outcome.issue)
     end
 
     # @return [String] the version of the validator currently being used or nil

--- a/test/unit/hl7_validator_test.rb
+++ b/test/unit/hl7_validator_test.rb
@@ -43,27 +43,9 @@ describe Inferno::HL7Validator do
         )
 
       result = @validator.validate(@resource, FHIR, @profile)
-      assert_equal 2, result[:errors].length
+      assert_equal 3, result[:errors].length
       assert_equal 1, result[:warnings].length
-      assert_equal 5, result[:information].length
-    end
-
-    it 'adds Resource id error' do
-      outcome = load_fixture('hl7_validator_operation_outcome')
-      @resource.id = '1234567890123456789012345678901234567890123456789012345678901234567890'
-
-      stub_request(:post, "#{@validator_url}/validate")
-        .with(
-          query: { 'profile': @profile },
-          body: @resource.source_contents
-        )
-        .to_return(
-          status: 200,
-          body: outcome
-        )
-
-      result = @validator.validate(@resource, FHIR, @profile)
-      assert(result[:errors].any? { |err| err.match?(/FHIR id value shall match Regex/) })
+      assert_equal 4, result[:information].length
     end
   end
 
@@ -79,50 +61,6 @@ describe Inferno::HL7Validator do
       stub_request(:get, "#{@validator_url}/version")
         .to_return(status: 404)
       assert_nil @validator.version
-    end
-  end
-
-  describe 'Validating Resource ID' do
-    before do
-      @resource = FHIR::Patient.new
-    end
-
-    it 'catches Resource id longer than 64 characters' do
-      @resource.id = '1234567890123456789012345678901234567890123456789012345678901234567890'
-      result = @validator.validate_resource_id(@resource)
-
-      refute result.empty?
-      assert result.first.match?(/^Patient\.id: FHIR id value shall match Regex/)
-    end
-
-    it 'catches Resource id with invalid character' do
-      @resource.id = '1234567890$'
-      result = @validator.validate_resource_id(@resource)
-
-      refute result.empty?
-      assert result.first.match?(/^Patient\.id: FHIR id value shall match Regex/)
-    end
-
-    it 'catches Resource id in internal resource' do
-      @resource.id = '1234567890123456789012345678901234567890123456789012345678901234567890'
-      bundle = wrap_resources_in_bundle(@resource)
-      bundle.id = '1234567890$'
-      result = @validator.validate_resource_id(bundle)
-
-      assert result.size == 2
-    end
-
-    it 'passes Resource without id' do
-      result = @validator.validate_resource_id(@resource)
-
-      assert result.empty?
-    end
-
-    it 'passes Resource with valid id' do
-      @resource.id = 'A-123.b'
-      result = @validator.validate_resource_id(@resource)
-
-      assert result.empty?
     end
   end
 end


### PR DESCRIPTION
# Summary
This PR fix Github issue #414 

Update validator service dependency from v1.2.1 to v2.1.0

## New behavior

## Code changes
Removed validate_resource_id since this is handled by FHIR validator now. 

## Testing guidance
