### PR TITLE
FI-1406 Allow case-insensitive comparison for token search

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -42,7 +42,7 @@ resource_validator: external
 
 # The url where the external validator can be reached. Ignored when using the
 # internal validator.
-external_resource_validator_url: http://validator_service:4567
+external_resource_validator_url: http://localhost:8888
 
 # The expected version of the external validator. The app will display a warning if
 # the found version doesn't match the expected version exactly.

--- a/config.yml
+++ b/config.yml
@@ -42,7 +42,7 @@ resource_validator: external
 
 # The url where the external validator can be reached. Ignored when using the
 # internal validator.
-external_resource_validator_url: http://localhost:8888
+external_resource_validator_url: http://validator_service:4567
 
 # The expected version of the external validator. The app will display a warning if
 # the found version doesn't match the expected version exactly.

--- a/generator/uscore/uscore_generator.rb
+++ b/generator/uscore/uscore_generator.rb
@@ -1450,9 +1450,9 @@ module Inferno
             coding_value = value.split('|').last
             match_found = values_found.any? do |codeable_concept|
               if value.include? '|'
-                codeable_concept.coding.any? { |coding| coding.system == coding_system && coding.code.casecmp?(coding_value) }
+                codeable_concept.coding.any? { |coding| coding.system == coding_system && coding.code&.casecmp?(coding_value) }
               else
-                codeable_concept.coding.any? { |coding| coding.code.casecmp?(value) }
+                codeable_concept.coding.any? { |coding| coding.code&.casecmp?(value) }
               end
             end)
         when 'Identifier'

--- a/generator/uscore/uscore_generator.rb
+++ b/generator/uscore/uscore_generator.rb
@@ -1450,9 +1450,9 @@ module Inferno
             coding_value = value.split('|').last
             match_found = values_found.any? do |codeable_concept|
               if value.include? '|'
-                codeable_concept.coding.any? { |coding| coding.system == coding_system && coding.code == coding_value }
+                codeable_concept.coding.any? { |coding| coding.system == coding_system && coding.code.casecmp?(coding_value) }
               else
-                codeable_concept.coding.any? { |coding| coding.code == value }
+                codeable_concept.coding.any? { |coding| coding.code.casecmp?(value) }
               end
             end)
         when 'Identifier'

--- a/lib/modules/uscore_v3.1.1/bodyheight_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/bodyheight_sequence.rb
@@ -83,9 +83,9 @@ module Inferno
           coding_value = value.split('|').last
           match_found = values_found.any? do |codeable_concept|
             if value.include? '|'
-              codeable_concept.coding.any? { |coding| coding.system == coding_system && coding.code.casecmp?(coding_value) }
+              codeable_concept.coding.any? { |coding| coding.system == coding_system && coding.code&.casecmp?(coding_value) }
             else
-              codeable_concept.coding.any? { |coding| coding.code.casecmp?(value) }
+              codeable_concept.coding.any? { |coding| coding.code&.casecmp?(value) }
             end
           end
           assert match_found, "category in Observation/#{resource.id} (#{values_found}) does not match category requested (#{value})"
@@ -96,9 +96,9 @@ module Inferno
           coding_value = value.split('|').last
           match_found = values_found.any? do |codeable_concept|
             if value.include? '|'
-              codeable_concept.coding.any? { |coding| coding.system == coding_system && coding.code.casecmp?(coding_value) }
+              codeable_concept.coding.any? { |coding| coding.system == coding_system && coding.code&.casecmp?(coding_value) }
             else
-              codeable_concept.coding.any? { |coding| coding.code.casecmp?(value) }
+              codeable_concept.coding.any? { |coding| coding.code&.casecmp?(value) }
             end
           end
           assert match_found, "code in Observation/#{resource.id} (#{values_found}) does not match code requested (#{value})"

--- a/lib/modules/uscore_v3.1.1/bodyheight_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/bodyheight_sequence.rb
@@ -83,9 +83,9 @@ module Inferno
           coding_value = value.split('|').last
           match_found = values_found.any? do |codeable_concept|
             if value.include? '|'
-              codeable_concept.coding.any? { |coding| coding.system == coding_system && coding.code == coding_value }
+              codeable_concept.coding.any? { |coding| coding.system == coding_system && coding.code.casecmp?(coding_value) }
             else
-              codeable_concept.coding.any? { |coding| coding.code == value }
+              codeable_concept.coding.any? { |coding| coding.code.casecmp?(value) }
             end
           end
           assert match_found, "category in Observation/#{resource.id} (#{values_found}) does not match category requested (#{value})"
@@ -96,9 +96,9 @@ module Inferno
           coding_value = value.split('|').last
           match_found = values_found.any? do |codeable_concept|
             if value.include? '|'
-              codeable_concept.coding.any? { |coding| coding.system == coding_system && coding.code == coding_value }
+              codeable_concept.coding.any? { |coding| coding.system == coding_system && coding.code.casecmp?(coding_value) }
             else
-              codeable_concept.coding.any? { |coding| coding.code == value }
+              codeable_concept.coding.any? { |coding| coding.code.casecmp?(value) }
             end
           end
           assert match_found, "code in Observation/#{resource.id} (#{values_found}) does not match code requested (#{value})"

--- a/lib/modules/uscore_v3.1.1/bodytemp_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/bodytemp_sequence.rb
@@ -83,9 +83,9 @@ module Inferno
           coding_value = value.split('|').last
           match_found = values_found.any? do |codeable_concept|
             if value.include? '|'
-              codeable_concept.coding.any? { |coding| coding.system == coding_system && coding.code.casecmp?(coding_value) }
+              codeable_concept.coding.any? { |coding| coding.system == coding_system && coding.code&.casecmp?(coding_value) }
             else
-              codeable_concept.coding.any? { |coding| coding.code.casecmp?(value) }
+              codeable_concept.coding.any? { |coding| coding.code&.casecmp?(value) }
             end
           end
           assert match_found, "category in Observation/#{resource.id} (#{values_found}) does not match category requested (#{value})"
@@ -96,9 +96,9 @@ module Inferno
           coding_value = value.split('|').last
           match_found = values_found.any? do |codeable_concept|
             if value.include? '|'
-              codeable_concept.coding.any? { |coding| coding.system == coding_system && coding.code.casecmp?(coding_value) }
+              codeable_concept.coding.any? { |coding| coding.system == coding_system && coding.code&.casecmp?(coding_value) }
             else
-              codeable_concept.coding.any? { |coding| coding.code.casecmp?(value) }
+              codeable_concept.coding.any? { |coding| coding.code&.casecmp?(value) }
             end
           end
           assert match_found, "code in Observation/#{resource.id} (#{values_found}) does not match code requested (#{value})"

--- a/lib/modules/uscore_v3.1.1/bodytemp_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/bodytemp_sequence.rb
@@ -83,9 +83,9 @@ module Inferno
           coding_value = value.split('|').last
           match_found = values_found.any? do |codeable_concept|
             if value.include? '|'
-              codeable_concept.coding.any? { |coding| coding.system == coding_system && coding.code == coding_value }
+              codeable_concept.coding.any? { |coding| coding.system == coding_system && coding.code.casecmp?(coding_value) }
             else
-              codeable_concept.coding.any? { |coding| coding.code == value }
+              codeable_concept.coding.any? { |coding| coding.code.casecmp?(value) }
             end
           end
           assert match_found, "category in Observation/#{resource.id} (#{values_found}) does not match category requested (#{value})"
@@ -96,9 +96,9 @@ module Inferno
           coding_value = value.split('|').last
           match_found = values_found.any? do |codeable_concept|
             if value.include? '|'
-              codeable_concept.coding.any? { |coding| coding.system == coding_system && coding.code == coding_value }
+              codeable_concept.coding.any? { |coding| coding.system == coding_system && coding.code.casecmp?(coding_value) }
             else
-              codeable_concept.coding.any? { |coding| coding.code == value }
+              codeable_concept.coding.any? { |coding| coding.code.casecmp?(value) }
             end
           end
           assert match_found, "code in Observation/#{resource.id} (#{values_found}) does not match code requested (#{value})"

--- a/lib/modules/uscore_v3.1.1/bodyweight_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/bodyweight_sequence.rb
@@ -83,9 +83,9 @@ module Inferno
           coding_value = value.split('|').last
           match_found = values_found.any? do |codeable_concept|
             if value.include? '|'
-              codeable_concept.coding.any? { |coding| coding.system == coding_system && coding.code.casecmp?(coding_value) }
+              codeable_concept.coding.any? { |coding| coding.system == coding_system && coding.code&.casecmp?(coding_value) }
             else
-              codeable_concept.coding.any? { |coding| coding.code.casecmp?(value) }
+              codeable_concept.coding.any? { |coding| coding.code&.casecmp?(value) }
             end
           end
           assert match_found, "category in Observation/#{resource.id} (#{values_found}) does not match category requested (#{value})"
@@ -96,9 +96,9 @@ module Inferno
           coding_value = value.split('|').last
           match_found = values_found.any? do |codeable_concept|
             if value.include? '|'
-              codeable_concept.coding.any? { |coding| coding.system == coding_system && coding.code.casecmp?(coding_value) }
+              codeable_concept.coding.any? { |coding| coding.system == coding_system && coding.code&.casecmp?(coding_value) }
             else
-              codeable_concept.coding.any? { |coding| coding.code.casecmp?(value) }
+              codeable_concept.coding.any? { |coding| coding.code&.casecmp?(value) }
             end
           end
           assert match_found, "code in Observation/#{resource.id} (#{values_found}) does not match code requested (#{value})"

--- a/lib/modules/uscore_v3.1.1/bodyweight_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/bodyweight_sequence.rb
@@ -83,9 +83,9 @@ module Inferno
           coding_value = value.split('|').last
           match_found = values_found.any? do |codeable_concept|
             if value.include? '|'
-              codeable_concept.coding.any? { |coding| coding.system == coding_system && coding.code == coding_value }
+              codeable_concept.coding.any? { |coding| coding.system == coding_system && coding.code.casecmp?(coding_value) }
             else
-              codeable_concept.coding.any? { |coding| coding.code == value }
+              codeable_concept.coding.any? { |coding| coding.code.casecmp?(value) }
             end
           end
           assert match_found, "category in Observation/#{resource.id} (#{values_found}) does not match category requested (#{value})"
@@ -96,9 +96,9 @@ module Inferno
           coding_value = value.split('|').last
           match_found = values_found.any? do |codeable_concept|
             if value.include? '|'
-              codeable_concept.coding.any? { |coding| coding.system == coding_system && coding.code == coding_value }
+              codeable_concept.coding.any? { |coding| coding.system == coding_system && coding.code.casecmp?(coding_value) }
             else
-              codeable_concept.coding.any? { |coding| coding.code == value }
+              codeable_concept.coding.any? { |coding| coding.code.casecmp?(value) }
             end
           end
           assert match_found, "code in Observation/#{resource.id} (#{values_found}) does not match code requested (#{value})"

--- a/lib/modules/uscore_v3.1.1/bp_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/bp_sequence.rb
@@ -83,9 +83,9 @@ module Inferno
           coding_value = value.split('|').last
           match_found = values_found.any? do |codeable_concept|
             if value.include? '|'
-              codeable_concept.coding.any? { |coding| coding.system == coding_system && coding.code.casecmp?(coding_value) }
+              codeable_concept.coding.any? { |coding| coding.system == coding_system && coding.code&.casecmp?(coding_value) }
             else
-              codeable_concept.coding.any? { |coding| coding.code.casecmp?(value) }
+              codeable_concept.coding.any? { |coding| coding.code&.casecmp?(value) }
             end
           end
           assert match_found, "category in Observation/#{resource.id} (#{values_found}) does not match category requested (#{value})"
@@ -96,9 +96,9 @@ module Inferno
           coding_value = value.split('|').last
           match_found = values_found.any? do |codeable_concept|
             if value.include? '|'
-              codeable_concept.coding.any? { |coding| coding.system == coding_system && coding.code.casecmp?(coding_value) }
+              codeable_concept.coding.any? { |coding| coding.system == coding_system && coding.code&.casecmp?(coding_value) }
             else
-              codeable_concept.coding.any? { |coding| coding.code.casecmp?(value) }
+              codeable_concept.coding.any? { |coding| coding.code&.casecmp?(value) }
             end
           end
           assert match_found, "code in Observation/#{resource.id} (#{values_found}) does not match code requested (#{value})"

--- a/lib/modules/uscore_v3.1.1/bp_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/bp_sequence.rb
@@ -83,9 +83,9 @@ module Inferno
           coding_value = value.split('|').last
           match_found = values_found.any? do |codeable_concept|
             if value.include? '|'
-              codeable_concept.coding.any? { |coding| coding.system == coding_system && coding.code == coding_value }
+              codeable_concept.coding.any? { |coding| coding.system == coding_system && coding.code.casecmp?(coding_value) }
             else
-              codeable_concept.coding.any? { |coding| coding.code == value }
+              codeable_concept.coding.any? { |coding| coding.code.casecmp?(value) }
             end
           end
           assert match_found, "category in Observation/#{resource.id} (#{values_found}) does not match category requested (#{value})"
@@ -96,9 +96,9 @@ module Inferno
           coding_value = value.split('|').last
           match_found = values_found.any? do |codeable_concept|
             if value.include? '|'
-              codeable_concept.coding.any? { |coding| coding.system == coding_system && coding.code == coding_value }
+              codeable_concept.coding.any? { |coding| coding.system == coding_system && coding.code.casecmp?(coding_value) }
             else
-              codeable_concept.coding.any? { |coding| coding.code == value }
+              codeable_concept.coding.any? { |coding| coding.code.casecmp?(value) }
             end
           end
           assert match_found, "code in Observation/#{resource.id} (#{values_found}) does not match code requested (#{value})"

--- a/lib/modules/uscore_v3.1.1/head_occipital_frontal_circumference_percentile_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/head_occipital_frontal_circumference_percentile_sequence.rb
@@ -83,9 +83,9 @@ module Inferno
           coding_value = value.split('|').last
           match_found = values_found.any? do |codeable_concept|
             if value.include? '|'
-              codeable_concept.coding.any? { |coding| coding.system == coding_system && coding.code.casecmp?(coding_value) }
+              codeable_concept.coding.any? { |coding| coding.system == coding_system && coding.code&.casecmp?(coding_value) }
             else
-              codeable_concept.coding.any? { |coding| coding.code.casecmp?(value) }
+              codeable_concept.coding.any? { |coding| coding.code&.casecmp?(value) }
             end
           end
           assert match_found, "category in Observation/#{resource.id} (#{values_found}) does not match category requested (#{value})"
@@ -96,9 +96,9 @@ module Inferno
           coding_value = value.split('|').last
           match_found = values_found.any? do |codeable_concept|
             if value.include? '|'
-              codeable_concept.coding.any? { |coding| coding.system == coding_system && coding.code.casecmp?(coding_value) }
+              codeable_concept.coding.any? { |coding| coding.system == coding_system && coding.code&.casecmp?(coding_value) }
             else
-              codeable_concept.coding.any? { |coding| coding.code.casecmp?(value) }
+              codeable_concept.coding.any? { |coding| coding.code&.casecmp?(value) }
             end
           end
           assert match_found, "code in Observation/#{resource.id} (#{values_found}) does not match code requested (#{value})"

--- a/lib/modules/uscore_v3.1.1/head_occipital_frontal_circumference_percentile_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/head_occipital_frontal_circumference_percentile_sequence.rb
@@ -83,9 +83,9 @@ module Inferno
           coding_value = value.split('|').last
           match_found = values_found.any? do |codeable_concept|
             if value.include? '|'
-              codeable_concept.coding.any? { |coding| coding.system == coding_system && coding.code == coding_value }
+              codeable_concept.coding.any? { |coding| coding.system == coding_system && coding.code.casecmp?(coding_value) }
             else
-              codeable_concept.coding.any? { |coding| coding.code == value }
+              codeable_concept.coding.any? { |coding| coding.code.casecmp?(value) }
             end
           end
           assert match_found, "category in Observation/#{resource.id} (#{values_found}) does not match category requested (#{value})"
@@ -96,9 +96,9 @@ module Inferno
           coding_value = value.split('|').last
           match_found = values_found.any? do |codeable_concept|
             if value.include? '|'
-              codeable_concept.coding.any? { |coding| coding.system == coding_system && coding.code == coding_value }
+              codeable_concept.coding.any? { |coding| coding.system == coding_system && coding.code.casecmp?(coding_value) }
             else
-              codeable_concept.coding.any? { |coding| coding.code == value }
+              codeable_concept.coding.any? { |coding| coding.code.casecmp?(value) }
             end
           end
           assert match_found, "code in Observation/#{resource.id} (#{values_found}) does not match code requested (#{value})"

--- a/lib/modules/uscore_v3.1.1/heartrate_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/heartrate_sequence.rb
@@ -83,9 +83,9 @@ module Inferno
           coding_value = value.split('|').last
           match_found = values_found.any? do |codeable_concept|
             if value.include? '|'
-              codeable_concept.coding.any? { |coding| coding.system == coding_system && coding.code.casecmp?(coding_value) }
+              codeable_concept.coding.any? { |coding| coding.system == coding_system && coding.code&.casecmp?(coding_value) }
             else
-              codeable_concept.coding.any? { |coding| coding.code.casecmp?(value) }
+              codeable_concept.coding.any? { |coding| coding.code&.casecmp?(value) }
             end
           end
           assert match_found, "category in Observation/#{resource.id} (#{values_found}) does not match category requested (#{value})"
@@ -96,9 +96,9 @@ module Inferno
           coding_value = value.split('|').last
           match_found = values_found.any? do |codeable_concept|
             if value.include? '|'
-              codeable_concept.coding.any? { |coding| coding.system == coding_system && coding.code.casecmp?(coding_value) }
+              codeable_concept.coding.any? { |coding| coding.system == coding_system && coding.code&.casecmp?(coding_value) }
             else
-              codeable_concept.coding.any? { |coding| coding.code.casecmp?(value) }
+              codeable_concept.coding.any? { |coding| coding.code&.casecmp?(value) }
             end
           end
           assert match_found, "code in Observation/#{resource.id} (#{values_found}) does not match code requested (#{value})"

--- a/lib/modules/uscore_v3.1.1/heartrate_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/heartrate_sequence.rb
@@ -83,9 +83,9 @@ module Inferno
           coding_value = value.split('|').last
           match_found = values_found.any? do |codeable_concept|
             if value.include? '|'
-              codeable_concept.coding.any? { |coding| coding.system == coding_system && coding.code == coding_value }
+              codeable_concept.coding.any? { |coding| coding.system == coding_system && coding.code.casecmp?(coding_value) }
             else
-              codeable_concept.coding.any? { |coding| coding.code == value }
+              codeable_concept.coding.any? { |coding| coding.code.casecmp?(value) }
             end
           end
           assert match_found, "category in Observation/#{resource.id} (#{values_found}) does not match category requested (#{value})"
@@ -96,9 +96,9 @@ module Inferno
           coding_value = value.split('|').last
           match_found = values_found.any? do |codeable_concept|
             if value.include? '|'
-              codeable_concept.coding.any? { |coding| coding.system == coding_system && coding.code == coding_value }
+              codeable_concept.coding.any? { |coding| coding.system == coding_system && coding.code.casecmp?(coding_value) }
             else
-              codeable_concept.coding.any? { |coding| coding.code == value }
+              codeable_concept.coding.any? { |coding| coding.code.casecmp?(value) }
             end
           end
           assert match_found, "code in Observation/#{resource.id} (#{values_found}) does not match code requested (#{value})"

--- a/lib/modules/uscore_v3.1.1/pediatric_bmi_for_age_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/pediatric_bmi_for_age_sequence.rb
@@ -83,9 +83,9 @@ module Inferno
           coding_value = value.split('|').last
           match_found = values_found.any? do |codeable_concept|
             if value.include? '|'
-              codeable_concept.coding.any? { |coding| coding.system == coding_system && coding.code.casecmp?(coding_value) }
+              codeable_concept.coding.any? { |coding| coding.system == coding_system && coding.code&.casecmp?(coding_value) }
             else
-              codeable_concept.coding.any? { |coding| coding.code.casecmp?(value) }
+              codeable_concept.coding.any? { |coding| coding.code&.casecmp?(value) }
             end
           end
           assert match_found, "category in Observation/#{resource.id} (#{values_found}) does not match category requested (#{value})"
@@ -96,9 +96,9 @@ module Inferno
           coding_value = value.split('|').last
           match_found = values_found.any? do |codeable_concept|
             if value.include? '|'
-              codeable_concept.coding.any? { |coding| coding.system == coding_system && coding.code.casecmp?(coding_value) }
+              codeable_concept.coding.any? { |coding| coding.system == coding_system && coding.code&.casecmp?(coding_value) }
             else
-              codeable_concept.coding.any? { |coding| coding.code.casecmp?(value) }
+              codeable_concept.coding.any? { |coding| coding.code&.casecmp?(value) }
             end
           end
           assert match_found, "code in Observation/#{resource.id} (#{values_found}) does not match code requested (#{value})"

--- a/lib/modules/uscore_v3.1.1/pediatric_bmi_for_age_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/pediatric_bmi_for_age_sequence.rb
@@ -83,9 +83,9 @@ module Inferno
           coding_value = value.split('|').last
           match_found = values_found.any? do |codeable_concept|
             if value.include? '|'
-              codeable_concept.coding.any? { |coding| coding.system == coding_system && coding.code == coding_value }
+              codeable_concept.coding.any? { |coding| coding.system == coding_system && coding.code.casecmp?(coding_value) }
             else
-              codeable_concept.coding.any? { |coding| coding.code == value }
+              codeable_concept.coding.any? { |coding| coding.code.casecmp?(value) }
             end
           end
           assert match_found, "category in Observation/#{resource.id} (#{values_found}) does not match category requested (#{value})"
@@ -96,9 +96,9 @@ module Inferno
           coding_value = value.split('|').last
           match_found = values_found.any? do |codeable_concept|
             if value.include? '|'
-              codeable_concept.coding.any? { |coding| coding.system == coding_system && coding.code == coding_value }
+              codeable_concept.coding.any? { |coding| coding.system == coding_system && coding.code.casecmp?(coding_value) }
             else
-              codeable_concept.coding.any? { |coding| coding.code == value }
+              codeable_concept.coding.any? { |coding| coding.code.casecmp?(value) }
             end
           end
           assert match_found, "code in Observation/#{resource.id} (#{values_found}) does not match code requested (#{value})"

--- a/lib/modules/uscore_v3.1.1/pediatric_weight_for_height_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/pediatric_weight_for_height_sequence.rb
@@ -83,9 +83,9 @@ module Inferno
           coding_value = value.split('|').last
           match_found = values_found.any? do |codeable_concept|
             if value.include? '|'
-              codeable_concept.coding.any? { |coding| coding.system == coding_system && coding.code.casecmp?(coding_value) }
+              codeable_concept.coding.any? { |coding| coding.system == coding_system && coding.code&.casecmp?(coding_value) }
             else
-              codeable_concept.coding.any? { |coding| coding.code.casecmp?(value) }
+              codeable_concept.coding.any? { |coding| coding.code&.casecmp?(value) }
             end
           end
           assert match_found, "category in Observation/#{resource.id} (#{values_found}) does not match category requested (#{value})"
@@ -96,9 +96,9 @@ module Inferno
           coding_value = value.split('|').last
           match_found = values_found.any? do |codeable_concept|
             if value.include? '|'
-              codeable_concept.coding.any? { |coding| coding.system == coding_system && coding.code.casecmp?(coding_value) }
+              codeable_concept.coding.any? { |coding| coding.system == coding_system && coding.code&.casecmp?(coding_value) }
             else
-              codeable_concept.coding.any? { |coding| coding.code.casecmp?(value) }
+              codeable_concept.coding.any? { |coding| coding.code&.casecmp?(value) }
             end
           end
           assert match_found, "code in Observation/#{resource.id} (#{values_found}) does not match code requested (#{value})"

--- a/lib/modules/uscore_v3.1.1/pediatric_weight_for_height_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/pediatric_weight_for_height_sequence.rb
@@ -83,9 +83,9 @@ module Inferno
           coding_value = value.split('|').last
           match_found = values_found.any? do |codeable_concept|
             if value.include? '|'
-              codeable_concept.coding.any? { |coding| coding.system == coding_system && coding.code == coding_value }
+              codeable_concept.coding.any? { |coding| coding.system == coding_system && coding.code.casecmp?(coding_value) }
             else
-              codeable_concept.coding.any? { |coding| coding.code == value }
+              codeable_concept.coding.any? { |coding| coding.code.casecmp?(value) }
             end
           end
           assert match_found, "category in Observation/#{resource.id} (#{values_found}) does not match category requested (#{value})"
@@ -96,9 +96,9 @@ module Inferno
           coding_value = value.split('|').last
           match_found = values_found.any? do |codeable_concept|
             if value.include? '|'
-              codeable_concept.coding.any? { |coding| coding.system == coding_system && coding.code == coding_value }
+              codeable_concept.coding.any? { |coding| coding.system == coding_system && coding.code.casecmp?(coding_value) }
             else
-              codeable_concept.coding.any? { |coding| coding.code == value }
+              codeable_concept.coding.any? { |coding| coding.code.casecmp?(value) }
             end
           end
           assert match_found, "code in Observation/#{resource.id} (#{values_found}) does not match code requested (#{value})"

--- a/lib/modules/uscore_v3.1.1/resprate_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/resprate_sequence.rb
@@ -83,9 +83,9 @@ module Inferno
           coding_value = value.split('|').last
           match_found = values_found.any? do |codeable_concept|
             if value.include? '|'
-              codeable_concept.coding.any? { |coding| coding.system == coding_system && coding.code.casecmp?(coding_value) }
+              codeable_concept.coding.any? { |coding| coding.system == coding_system && coding.code&.casecmp?(coding_value) }
             else
-              codeable_concept.coding.any? { |coding| coding.code.casecmp?(value) }
+              codeable_concept.coding.any? { |coding| coding.code&.casecmp?(value) }
             end
           end
           assert match_found, "category in Observation/#{resource.id} (#{values_found}) does not match category requested (#{value})"
@@ -96,9 +96,9 @@ module Inferno
           coding_value = value.split('|').last
           match_found = values_found.any? do |codeable_concept|
             if value.include? '|'
-              codeable_concept.coding.any? { |coding| coding.system == coding_system && coding.code.casecmp?(coding_value) }
+              codeable_concept.coding.any? { |coding| coding.system == coding_system && coding.code&.casecmp?(coding_value) }
             else
-              codeable_concept.coding.any? { |coding| coding.code.casecmp?(value) }
+              codeable_concept.coding.any? { |coding| coding.code&.casecmp?(value) }
             end
           end
           assert match_found, "code in Observation/#{resource.id} (#{values_found}) does not match code requested (#{value})"

--- a/lib/modules/uscore_v3.1.1/resprate_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/resprate_sequence.rb
@@ -83,9 +83,9 @@ module Inferno
           coding_value = value.split('|').last
           match_found = values_found.any? do |codeable_concept|
             if value.include? '|'
-              codeable_concept.coding.any? { |coding| coding.system == coding_system && coding.code == coding_value }
+              codeable_concept.coding.any? { |coding| coding.system == coding_system && coding.code.casecmp?(coding_value) }
             else
-              codeable_concept.coding.any? { |coding| coding.code == value }
+              codeable_concept.coding.any? { |coding| coding.code.casecmp?(value) }
             end
           end
           assert match_found, "category in Observation/#{resource.id} (#{values_found}) does not match category requested (#{value})"
@@ -96,9 +96,9 @@ module Inferno
           coding_value = value.split('|').last
           match_found = values_found.any? do |codeable_concept|
             if value.include? '|'
-              codeable_concept.coding.any? { |coding| coding.system == coding_system && coding.code == coding_value }
+              codeable_concept.coding.any? { |coding| coding.system == coding_system && coding.code.casecmp?(coding_value) }
             else
-              codeable_concept.coding.any? { |coding| coding.code == value }
+              codeable_concept.coding.any? { |coding| coding.code.casecmp?(value) }
             end
           end
           assert match_found, "code in Observation/#{resource.id} (#{values_found}) does not match code requested (#{value})"

--- a/lib/modules/uscore_v3.1.1/us_core_allergyintolerance_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_allergyintolerance_sequence.rb
@@ -75,9 +75,9 @@ module Inferno
           coding_value = value.split('|').last
           match_found = values_found.any? do |codeable_concept|
             if value.include? '|'
-              codeable_concept.coding.any? { |coding| coding.system == coding_system && coding.code == coding_value }
+              codeable_concept.coding.any? { |coding| coding.system == coding_system && coding.code.casecmp?(coding_value) }
             else
-              codeable_concept.coding.any? { |coding| coding.code == value }
+              codeable_concept.coding.any? { |coding| coding.code.casecmp?(value) }
             end
           end
           assert match_found, "clinical-status in AllergyIntolerance/#{resource.id} (#{values_found}) does not match clinical-status requested (#{value})"

--- a/lib/modules/uscore_v3.1.1/us_core_allergyintolerance_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_allergyintolerance_sequence.rb
@@ -75,9 +75,9 @@ module Inferno
           coding_value = value.split('|').last
           match_found = values_found.any? do |codeable_concept|
             if value.include? '|'
-              codeable_concept.coding.any? { |coding| coding.system == coding_system && coding.code.casecmp?(coding_value) }
+              codeable_concept.coding.any? { |coding| coding.system == coding_system && coding.code&.casecmp?(coding_value) }
             else
-              codeable_concept.coding.any? { |coding| coding.code.casecmp?(value) }
+              codeable_concept.coding.any? { |coding| coding.code&.casecmp?(value) }
             end
           end
           assert match_found, "clinical-status in AllergyIntolerance/#{resource.id} (#{values_found}) does not match clinical-status requested (#{value})"

--- a/lib/modules/uscore_v3.1.1/us_core_careplan_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_careplan_sequence.rb
@@ -75,9 +75,9 @@ module Inferno
           coding_value = value.split('|').last
           match_found = values_found.any? do |codeable_concept|
             if value.include? '|'
-              codeable_concept.coding.any? { |coding| coding.system == coding_system && coding.code.casecmp?(coding_value) }
+              codeable_concept.coding.any? { |coding| coding.system == coding_system && coding.code&.casecmp?(coding_value) }
             else
-              codeable_concept.coding.any? { |coding| coding.code.casecmp?(value) }
+              codeable_concept.coding.any? { |coding| coding.code&.casecmp?(value) }
             end
           end
           assert match_found, "category in CarePlan/#{resource.id} (#{values_found}) does not match category requested (#{value})"

--- a/lib/modules/uscore_v3.1.1/us_core_careplan_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_careplan_sequence.rb
@@ -75,9 +75,9 @@ module Inferno
           coding_value = value.split('|').last
           match_found = values_found.any? do |codeable_concept|
             if value.include? '|'
-              codeable_concept.coding.any? { |coding| coding.system == coding_system && coding.code == coding_value }
+              codeable_concept.coding.any? { |coding| coding.system == coding_system && coding.code.casecmp?(coding_value) }
             else
-              codeable_concept.coding.any? { |coding| coding.code == value }
+              codeable_concept.coding.any? { |coding| coding.code.casecmp?(value) }
             end
           end
           assert match_found, "category in CarePlan/#{resource.id} (#{values_found}) does not match category requested (#{value})"

--- a/lib/modules/uscore_v3.1.1/us_core_condition_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_condition_sequence.rb
@@ -75,9 +75,9 @@ module Inferno
           coding_value = value.split('|').last
           match_found = values_found.any? do |codeable_concept|
             if value.include? '|'
-              codeable_concept.coding.any? { |coding| coding.system == coding_system && coding.code.casecmp?(coding_value) }
+              codeable_concept.coding.any? { |coding| coding.system == coding_system && coding.code&.casecmp?(coding_value) }
             else
-              codeable_concept.coding.any? { |coding| coding.code.casecmp?(value) }
+              codeable_concept.coding.any? { |coding| coding.code&.casecmp?(value) }
             end
           end
           assert match_found, "category in Condition/#{resource.id} (#{values_found}) does not match category requested (#{value})"
@@ -88,9 +88,9 @@ module Inferno
           coding_value = value.split('|').last
           match_found = values_found.any? do |codeable_concept|
             if value.include? '|'
-              codeable_concept.coding.any? { |coding| coding.system == coding_system && coding.code.casecmp?(coding_value) }
+              codeable_concept.coding.any? { |coding| coding.system == coding_system && coding.code&.casecmp?(coding_value) }
             else
-              codeable_concept.coding.any? { |coding| coding.code.casecmp?(value) }
+              codeable_concept.coding.any? { |coding| coding.code&.casecmp?(value) }
             end
           end
           assert match_found, "clinical-status in Condition/#{resource.id} (#{values_found}) does not match clinical-status requested (#{value})"
@@ -112,9 +112,9 @@ module Inferno
           coding_value = value.split('|').last
           match_found = values_found.any? do |codeable_concept|
             if value.include? '|'
-              codeable_concept.coding.any? { |coding| coding.system == coding_system && coding.code.casecmp?(coding_value) }
+              codeable_concept.coding.any? { |coding| coding.system == coding_system && coding.code&.casecmp?(coding_value) }
             else
-              codeable_concept.coding.any? { |coding| coding.code.casecmp?(value) }
+              codeable_concept.coding.any? { |coding| coding.code&.casecmp?(value) }
             end
           end
           assert match_found, "code in Condition/#{resource.id} (#{values_found}) does not match code requested (#{value})"

--- a/lib/modules/uscore_v3.1.1/us_core_condition_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_condition_sequence.rb
@@ -75,9 +75,9 @@ module Inferno
           coding_value = value.split('|').last
           match_found = values_found.any? do |codeable_concept|
             if value.include? '|'
-              codeable_concept.coding.any? { |coding| coding.system == coding_system && coding.code == coding_value }
+              codeable_concept.coding.any? { |coding| coding.system == coding_system && coding.code.casecmp?(coding_value) }
             else
-              codeable_concept.coding.any? { |coding| coding.code == value }
+              codeable_concept.coding.any? { |coding| coding.code.casecmp?(value) }
             end
           end
           assert match_found, "category in Condition/#{resource.id} (#{values_found}) does not match category requested (#{value})"
@@ -88,9 +88,9 @@ module Inferno
           coding_value = value.split('|').last
           match_found = values_found.any? do |codeable_concept|
             if value.include? '|'
-              codeable_concept.coding.any? { |coding| coding.system == coding_system && coding.code == coding_value }
+              codeable_concept.coding.any? { |coding| coding.system == coding_system && coding.code.casecmp?(coding_value) }
             else
-              codeable_concept.coding.any? { |coding| coding.code == value }
+              codeable_concept.coding.any? { |coding| coding.code.casecmp?(value) }
             end
           end
           assert match_found, "clinical-status in Condition/#{resource.id} (#{values_found}) does not match clinical-status requested (#{value})"
@@ -112,9 +112,9 @@ module Inferno
           coding_value = value.split('|').last
           match_found = values_found.any? do |codeable_concept|
             if value.include? '|'
-              codeable_concept.coding.any? { |coding| coding.system == coding_system && coding.code == coding_value }
+              codeable_concept.coding.any? { |coding| coding.system == coding_system && coding.code.casecmp?(coding_value) }
             else
-              codeable_concept.coding.any? { |coding| coding.code == value }
+              codeable_concept.coding.any? { |coding| coding.code.casecmp?(value) }
             end
           end
           assert match_found, "code in Condition/#{resource.id} (#{values_found}) does not match code requested (#{value})"

--- a/lib/modules/uscore_v3.1.1/us_core_diagnosticreport_lab_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_diagnosticreport_lab_sequence.rb
@@ -92,9 +92,9 @@ module Inferno
           coding_value = value.split('|').last
           match_found = values_found.any? do |codeable_concept|
             if value.include? '|'
-              codeable_concept.coding.any? { |coding| coding.system == coding_system && coding.code == coding_value }
+              codeable_concept.coding.any? { |coding| coding.system == coding_system && coding.code.casecmp?(coding_value) }
             else
-              codeable_concept.coding.any? { |coding| coding.code == value }
+              codeable_concept.coding.any? { |coding| coding.code.casecmp?(value) }
             end
           end
           assert match_found, "category in DiagnosticReport/#{resource.id} (#{values_found}) does not match category requested (#{value})"
@@ -105,9 +105,9 @@ module Inferno
           coding_value = value.split('|').last
           match_found = values_found.any? do |codeable_concept|
             if value.include? '|'
-              codeable_concept.coding.any? { |coding| coding.system == coding_system && coding.code == coding_value }
+              codeable_concept.coding.any? { |coding| coding.system == coding_system && coding.code.casecmp?(coding_value) }
             else
-              codeable_concept.coding.any? { |coding| coding.code == value }
+              codeable_concept.coding.any? { |coding| coding.code.casecmp?(value) }
             end
           end
           assert match_found, "code in DiagnosticReport/#{resource.id} (#{values_found}) does not match code requested (#{value})"

--- a/lib/modules/uscore_v3.1.1/us_core_diagnosticreport_lab_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_diagnosticreport_lab_sequence.rb
@@ -92,9 +92,9 @@ module Inferno
           coding_value = value.split('|').last
           match_found = values_found.any? do |codeable_concept|
             if value.include? '|'
-              codeable_concept.coding.any? { |coding| coding.system == coding_system && coding.code.casecmp?(coding_value) }
+              codeable_concept.coding.any? { |coding| coding.system == coding_system && coding.code&.casecmp?(coding_value) }
             else
-              codeable_concept.coding.any? { |coding| coding.code.casecmp?(value) }
+              codeable_concept.coding.any? { |coding| coding.code&.casecmp?(value) }
             end
           end
           assert match_found, "category in DiagnosticReport/#{resource.id} (#{values_found}) does not match category requested (#{value})"
@@ -105,9 +105,9 @@ module Inferno
           coding_value = value.split('|').last
           match_found = values_found.any? do |codeable_concept|
             if value.include? '|'
-              codeable_concept.coding.any? { |coding| coding.system == coding_system && coding.code.casecmp?(coding_value) }
+              codeable_concept.coding.any? { |coding| coding.system == coding_system && coding.code&.casecmp?(coding_value) }
             else
-              codeable_concept.coding.any? { |coding| coding.code.casecmp?(value) }
+              codeable_concept.coding.any? { |coding| coding.code&.casecmp?(value) }
             end
           end
           assert match_found, "code in DiagnosticReport/#{resource.id} (#{values_found}) does not match code requested (#{value})"

--- a/lib/modules/uscore_v3.1.1/us_core_diagnosticreport_note_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_diagnosticreport_note_sequence.rb
@@ -92,9 +92,9 @@ module Inferno
           coding_value = value.split('|').last
           match_found = values_found.any? do |codeable_concept|
             if value.include? '|'
-              codeable_concept.coding.any? { |coding| coding.system == coding_system && coding.code == coding_value }
+              codeable_concept.coding.any? { |coding| coding.system == coding_system && coding.code.casecmp?(coding_value) }
             else
-              codeable_concept.coding.any? { |coding| coding.code == value }
+              codeable_concept.coding.any? { |coding| coding.code.casecmp?(value) }
             end
           end
           assert match_found, "category in DiagnosticReport/#{resource.id} (#{values_found}) does not match category requested (#{value})"
@@ -105,9 +105,9 @@ module Inferno
           coding_value = value.split('|').last
           match_found = values_found.any? do |codeable_concept|
             if value.include? '|'
-              codeable_concept.coding.any? { |coding| coding.system == coding_system && coding.code == coding_value }
+              codeable_concept.coding.any? { |coding| coding.system == coding_system && coding.code.casecmp?(coding_value) }
             else
-              codeable_concept.coding.any? { |coding| coding.code == value }
+              codeable_concept.coding.any? { |coding| coding.code.casecmp?(value) }
             end
           end
           assert match_found, "code in DiagnosticReport/#{resource.id} (#{values_found}) does not match code requested (#{value})"

--- a/lib/modules/uscore_v3.1.1/us_core_diagnosticreport_note_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_diagnosticreport_note_sequence.rb
@@ -92,9 +92,9 @@ module Inferno
           coding_value = value.split('|').last
           match_found = values_found.any? do |codeable_concept|
             if value.include? '|'
-              codeable_concept.coding.any? { |coding| coding.system == coding_system && coding.code.casecmp?(coding_value) }
+              codeable_concept.coding.any? { |coding| coding.system == coding_system && coding.code&.casecmp?(coding_value) }
             else
-              codeable_concept.coding.any? { |coding| coding.code.casecmp?(value) }
+              codeable_concept.coding.any? { |coding| coding.code&.casecmp?(value) }
             end
           end
           assert match_found, "category in DiagnosticReport/#{resource.id} (#{values_found}) does not match category requested (#{value})"
@@ -105,9 +105,9 @@ module Inferno
           coding_value = value.split('|').last
           match_found = values_found.any? do |codeable_concept|
             if value.include? '|'
-              codeable_concept.coding.any? { |coding| coding.system == coding_system && coding.code.casecmp?(coding_value) }
+              codeable_concept.coding.any? { |coding| coding.system == coding_system && coding.code&.casecmp?(coding_value) }
             else
-              codeable_concept.coding.any? { |coding| coding.code.casecmp?(value) }
+              codeable_concept.coding.any? { |coding| coding.code&.casecmp?(value) }
             end
           end
           assert match_found, "code in DiagnosticReport/#{resource.id} (#{values_found}) does not match code requested (#{value})"

--- a/lib/modules/uscore_v3.1.1/us_core_documentreference_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_documentreference_sequence.rb
@@ -97,9 +97,9 @@ module Inferno
           coding_value = value.split('|').last
           match_found = values_found.any? do |codeable_concept|
             if value.include? '|'
-              codeable_concept.coding.any? { |coding| coding.system == coding_system && coding.code.casecmp?(coding_value) }
+              codeable_concept.coding.any? { |coding| coding.system == coding_system && coding.code&.casecmp?(coding_value) }
             else
-              codeable_concept.coding.any? { |coding| coding.code.casecmp?(value) }
+              codeable_concept.coding.any? { |coding| coding.code&.casecmp?(value) }
             end
           end
           assert match_found, "category in DocumentReference/#{resource.id} (#{values_found}) does not match category requested (#{value})"
@@ -110,9 +110,9 @@ module Inferno
           coding_value = value.split('|').last
           match_found = values_found.any? do |codeable_concept|
             if value.include? '|'
-              codeable_concept.coding.any? { |coding| coding.system == coding_system && coding.code.casecmp?(coding_value) }
+              codeable_concept.coding.any? { |coding| coding.system == coding_system && coding.code&.casecmp?(coding_value) }
             else
-              codeable_concept.coding.any? { |coding| coding.code.casecmp?(value) }
+              codeable_concept.coding.any? { |coding| coding.code&.casecmp?(value) }
             end
           end
           assert match_found, "type in DocumentReference/#{resource.id} (#{values_found}) does not match type requested (#{value})"

--- a/lib/modules/uscore_v3.1.1/us_core_documentreference_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_documentreference_sequence.rb
@@ -97,9 +97,9 @@ module Inferno
           coding_value = value.split('|').last
           match_found = values_found.any? do |codeable_concept|
             if value.include? '|'
-              codeable_concept.coding.any? { |coding| coding.system == coding_system && coding.code == coding_value }
+              codeable_concept.coding.any? { |coding| coding.system == coding_system && coding.code.casecmp?(coding_value) }
             else
-              codeable_concept.coding.any? { |coding| coding.code == value }
+              codeable_concept.coding.any? { |coding| coding.code.casecmp?(value) }
             end
           end
           assert match_found, "category in DocumentReference/#{resource.id} (#{values_found}) does not match category requested (#{value})"
@@ -110,9 +110,9 @@ module Inferno
           coding_value = value.split('|').last
           match_found = values_found.any? do |codeable_concept|
             if value.include? '|'
-              codeable_concept.coding.any? { |coding| coding.system == coding_system && coding.code == coding_value }
+              codeable_concept.coding.any? { |coding| coding.system == coding_system && coding.code.casecmp?(coding_value) }
             else
-              codeable_concept.coding.any? { |coding| coding.code == value }
+              codeable_concept.coding.any? { |coding| coding.code.casecmp?(value) }
             end
           end
           assert match_found, "type in DocumentReference/#{resource.id} (#{values_found}) does not match type requested (#{value})"

--- a/lib/modules/uscore_v3.1.1/us_core_encounter_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_encounter_sequence.rb
@@ -98,9 +98,9 @@ module Inferno
           coding_value = value.split('|').last
           match_found = values_found.any? do |codeable_concept|
             if value.include? '|'
-              codeable_concept.coding.any? { |coding| coding.system == coding_system && coding.code.casecmp?(coding_value) }
+              codeable_concept.coding.any? { |coding| coding.system == coding_system && coding.code&.casecmp?(coding_value) }
             else
-              codeable_concept.coding.any? { |coding| coding.code.casecmp?(value) }
+              codeable_concept.coding.any? { |coding| coding.code&.casecmp?(value) }
             end
           end
           assert match_found, "type in Encounter/#{resource.id} (#{values_found}) does not match type requested (#{value})"

--- a/lib/modules/uscore_v3.1.1/us_core_encounter_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_encounter_sequence.rb
@@ -98,9 +98,9 @@ module Inferno
           coding_value = value.split('|').last
           match_found = values_found.any? do |codeable_concept|
             if value.include? '|'
-              codeable_concept.coding.any? { |coding| coding.system == coding_system && coding.code == coding_value }
+              codeable_concept.coding.any? { |coding| coding.system == coding_system && coding.code.casecmp?(coding_value) }
             else
-              codeable_concept.coding.any? { |coding| coding.code == value }
+              codeable_concept.coding.any? { |coding| coding.code.casecmp?(value) }
             end
           end
           assert match_found, "type in Encounter/#{resource.id} (#{values_found}) does not match type requested (#{value})"

--- a/lib/modules/uscore_v3.1.1/us_core_implantable_device_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_implantable_device_sequence.rb
@@ -84,9 +84,9 @@ module Inferno
           coding_value = value.split('|').last
           match_found = values_found.any? do |codeable_concept|
             if value.include? '|'
-              codeable_concept.coding.any? { |coding| coding.system == coding_system && coding.code.casecmp?(coding_value) }
+              codeable_concept.coding.any? { |coding| coding.system == coding_system && coding.code&.casecmp?(coding_value) }
             else
-              codeable_concept.coding.any? { |coding| coding.code.casecmp?(value) }
+              codeable_concept.coding.any? { |coding| coding.code&.casecmp?(value) }
             end
           end
           assert match_found, "type in Device/#{resource.id} (#{values_found}) does not match type requested (#{value})"

--- a/lib/modules/uscore_v3.1.1/us_core_implantable_device_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_implantable_device_sequence.rb
@@ -84,9 +84,9 @@ module Inferno
           coding_value = value.split('|').last
           match_found = values_found.any? do |codeable_concept|
             if value.include? '|'
-              codeable_concept.coding.any? { |coding| coding.system == coding_system && coding.code == coding_value }
+              codeable_concept.coding.any? { |coding| coding.system == coding_system && coding.code.casecmp?(coding_value) }
             else
-              codeable_concept.coding.any? { |coding| coding.code == value }
+              codeable_concept.coding.any? { |coding| coding.code.casecmp?(value) }
             end
           end
           assert match_found, "type in Device/#{resource.id} (#{values_found}) does not match type requested (#{value})"

--- a/lib/modules/uscore_v3.1.1/us_core_observation_lab_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_observation_lab_sequence.rb
@@ -83,9 +83,9 @@ module Inferno
           coding_value = value.split('|').last
           match_found = values_found.any? do |codeable_concept|
             if value.include? '|'
-              codeable_concept.coding.any? { |coding| coding.system == coding_system && coding.code.casecmp?(coding_value) }
+              codeable_concept.coding.any? { |coding| coding.system == coding_system && coding.code&.casecmp?(coding_value) }
             else
-              codeable_concept.coding.any? { |coding| coding.code.casecmp?(value) }
+              codeable_concept.coding.any? { |coding| coding.code&.casecmp?(value) }
             end
           end
           assert match_found, "category in Observation/#{resource.id} (#{values_found}) does not match category requested (#{value})"
@@ -96,9 +96,9 @@ module Inferno
           coding_value = value.split('|').last
           match_found = values_found.any? do |codeable_concept|
             if value.include? '|'
-              codeable_concept.coding.any? { |coding| coding.system == coding_system && coding.code.casecmp?(coding_value) }
+              codeable_concept.coding.any? { |coding| coding.system == coding_system && coding.code&.casecmp?(coding_value) }
             else
-              codeable_concept.coding.any? { |coding| coding.code.casecmp?(value) }
+              codeable_concept.coding.any? { |coding| coding.code&.casecmp?(value) }
             end
           end
           assert match_found, "code in Observation/#{resource.id} (#{values_found}) does not match code requested (#{value})"

--- a/lib/modules/uscore_v3.1.1/us_core_observation_lab_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_observation_lab_sequence.rb
@@ -83,9 +83,9 @@ module Inferno
           coding_value = value.split('|').last
           match_found = values_found.any? do |codeable_concept|
             if value.include? '|'
-              codeable_concept.coding.any? { |coding| coding.system == coding_system && coding.code == coding_value }
+              codeable_concept.coding.any? { |coding| coding.system == coding_system && coding.code.casecmp?(coding_value) }
             else
-              codeable_concept.coding.any? { |coding| coding.code == value }
+              codeable_concept.coding.any? { |coding| coding.code.casecmp?(value) }
             end
           end
           assert match_found, "category in Observation/#{resource.id} (#{values_found}) does not match category requested (#{value})"
@@ -96,9 +96,9 @@ module Inferno
           coding_value = value.split('|').last
           match_found = values_found.any? do |codeable_concept|
             if value.include? '|'
-              codeable_concept.coding.any? { |coding| coding.system == coding_system && coding.code == coding_value }
+              codeable_concept.coding.any? { |coding| coding.system == coding_system && coding.code.casecmp?(coding_value) }
             else
-              codeable_concept.coding.any? { |coding| coding.code == value }
+              codeable_concept.coding.any? { |coding| coding.code.casecmp?(value) }
             end
           end
           assert match_found, "code in Observation/#{resource.id} (#{values_found}) does not match code requested (#{value})"

--- a/lib/modules/uscore_v3.1.1/us_core_practitionerrole_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_practitionerrole_sequence.rb
@@ -60,9 +60,9 @@ module Inferno
           coding_value = value.split('|').last
           match_found = values_found.any? do |codeable_concept|
             if value.include? '|'
-              codeable_concept.coding.any? { |coding| coding.system == coding_system && coding.code.casecmp?(coding_value) }
+              codeable_concept.coding.any? { |coding| coding.system == coding_system && coding.code&.casecmp?(coding_value) }
             else
-              codeable_concept.coding.any? { |coding| coding.code.casecmp?(value) }
+              codeable_concept.coding.any? { |coding| coding.code&.casecmp?(value) }
             end
           end
           assert match_found, "specialty in PractitionerRole/#{resource.id} (#{values_found}) does not match specialty requested (#{value})"

--- a/lib/modules/uscore_v3.1.1/us_core_practitionerrole_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_practitionerrole_sequence.rb
@@ -60,9 +60,9 @@ module Inferno
           coding_value = value.split('|').last
           match_found = values_found.any? do |codeable_concept|
             if value.include? '|'
-              codeable_concept.coding.any? { |coding| coding.system == coding_system && coding.code == coding_value }
+              codeable_concept.coding.any? { |coding| coding.system == coding_system && coding.code.casecmp?(coding_value) }
             else
-              codeable_concept.coding.any? { |coding| coding.code == value }
+              codeable_concept.coding.any? { |coding| coding.code.casecmp?(value) }
             end
           end
           assert match_found, "specialty in PractitionerRole/#{resource.id} (#{values_found}) does not match specialty requested (#{value})"

--- a/lib/modules/uscore_v3.1.1/us_core_procedure_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_procedure_sequence.rb
@@ -93,9 +93,9 @@ module Inferno
           coding_value = value.split('|').last
           match_found = values_found.any? do |codeable_concept|
             if value.include? '|'
-              codeable_concept.coding.any? { |coding| coding.system == coding_system && coding.code.casecmp?(coding_value) }
+              codeable_concept.coding.any? { |coding| coding.system == coding_system && coding.code&.casecmp?(coding_value) }
             else
-              codeable_concept.coding.any? { |coding| coding.code.casecmp?(value) }
+              codeable_concept.coding.any? { |coding| coding.code&.casecmp?(value) }
             end
           end
           assert match_found, "code in Procedure/#{resource.id} (#{values_found}) does not match code requested (#{value})"

--- a/lib/modules/uscore_v3.1.1/us_core_procedure_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_procedure_sequence.rb
@@ -93,9 +93,9 @@ module Inferno
           coding_value = value.split('|').last
           match_found = values_found.any? do |codeable_concept|
             if value.include? '|'
-              codeable_concept.coding.any? { |coding| coding.system == coding_system && coding.code == coding_value }
+              codeable_concept.coding.any? { |coding| coding.system == coding_system && coding.code.casecmp?(coding_value) }
             else
-              codeable_concept.coding.any? { |coding| coding.code == value }
+              codeable_concept.coding.any? { |coding| coding.code.casecmp?(value) }
             end
           end
           assert match_found, "code in Procedure/#{resource.id} (#{values_found}) does not match code requested (#{value})"

--- a/lib/modules/uscore_v3.1.1/us_core_pulse_oximetry_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_pulse_oximetry_sequence.rb
@@ -83,9 +83,9 @@ module Inferno
           coding_value = value.split('|').last
           match_found = values_found.any? do |codeable_concept|
             if value.include? '|'
-              codeable_concept.coding.any? { |coding| coding.system == coding_system && coding.code.casecmp?(coding_value) }
+              codeable_concept.coding.any? { |coding| coding.system == coding_system && coding.code&.casecmp?(coding_value) }
             else
-              codeable_concept.coding.any? { |coding| coding.code.casecmp?(value) }
+              codeable_concept.coding.any? { |coding| coding.code&.casecmp?(value) }
             end
           end
           assert match_found, "category in Observation/#{resource.id} (#{values_found}) does not match category requested (#{value})"
@@ -96,9 +96,9 @@ module Inferno
           coding_value = value.split('|').last
           match_found = values_found.any? do |codeable_concept|
             if value.include? '|'
-              codeable_concept.coding.any? { |coding| coding.system == coding_system && coding.code.casecmp?(coding_value) }
+              codeable_concept.coding.any? { |coding| coding.system == coding_system && coding.code&.casecmp?(coding_value) }
             else
-              codeable_concept.coding.any? { |coding| coding.code.casecmp?(value) }
+              codeable_concept.coding.any? { |coding| coding.code&.casecmp?(value) }
             end
           end
           assert match_found, "code in Observation/#{resource.id} (#{values_found}) does not match code requested (#{value})"

--- a/lib/modules/uscore_v3.1.1/us_core_pulse_oximetry_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_pulse_oximetry_sequence.rb
@@ -83,9 +83,9 @@ module Inferno
           coding_value = value.split('|').last
           match_found = values_found.any? do |codeable_concept|
             if value.include? '|'
-              codeable_concept.coding.any? { |coding| coding.system == coding_system && coding.code == coding_value }
+              codeable_concept.coding.any? { |coding| coding.system == coding_system && coding.code.casecmp?(coding_value) }
             else
-              codeable_concept.coding.any? { |coding| coding.code == value }
+              codeable_concept.coding.any? { |coding| coding.code.casecmp?(value) }
             end
           end
           assert match_found, "category in Observation/#{resource.id} (#{values_found}) does not match category requested (#{value})"
@@ -96,9 +96,9 @@ module Inferno
           coding_value = value.split('|').last
           match_found = values_found.any? do |codeable_concept|
             if value.include? '|'
-              codeable_concept.coding.any? { |coding| coding.system == coding_system && coding.code == coding_value }
+              codeable_concept.coding.any? { |coding| coding.system == coding_system && coding.code.casecmp?(coding_value) }
             else
-              codeable_concept.coding.any? { |coding| coding.code == value }
+              codeable_concept.coding.any? { |coding| coding.code.casecmp?(value) }
             end
           end
           assert match_found, "code in Observation/#{resource.id} (#{values_found}) does not match code requested (#{value})"

--- a/lib/modules/uscore_v3.1.1/us_core_smokingstatus_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_smokingstatus_sequence.rb
@@ -87,9 +87,9 @@ module Inferno
           coding_value = value.split('|').last
           match_found = values_found.any? do |codeable_concept|
             if value.include? '|'
-              codeable_concept.coding.any? { |coding| coding.system == coding_system && coding.code.casecmp?(coding_value) }
+              codeable_concept.coding.any? { |coding| coding.system == coding_system && coding.code&.casecmp?(coding_value) }
             else
-              codeable_concept.coding.any? { |coding| coding.code.casecmp?(value) }
+              codeable_concept.coding.any? { |coding| coding.code&.casecmp?(value) }
             end
           end
           assert match_found, "category in Observation/#{resource.id} (#{values_found}) does not match category requested (#{value})"
@@ -100,9 +100,9 @@ module Inferno
           coding_value = value.split('|').last
           match_found = values_found.any? do |codeable_concept|
             if value.include? '|'
-              codeable_concept.coding.any? { |coding| coding.system == coding_system && coding.code.casecmp?(coding_value) }
+              codeable_concept.coding.any? { |coding| coding.system == coding_system && coding.code&.casecmp?(coding_value) }
             else
-              codeable_concept.coding.any? { |coding| coding.code.casecmp?(value) }
+              codeable_concept.coding.any? { |coding| coding.code&.casecmp?(value) }
             end
           end
           assert match_found, "code in Observation/#{resource.id} (#{values_found}) does not match code requested (#{value})"

--- a/lib/modules/uscore_v3.1.1/us_core_smokingstatus_sequence.rb
+++ b/lib/modules/uscore_v3.1.1/us_core_smokingstatus_sequence.rb
@@ -87,9 +87,9 @@ module Inferno
           coding_value = value.split('|').last
           match_found = values_found.any? do |codeable_concept|
             if value.include? '|'
-              codeable_concept.coding.any? { |coding| coding.system == coding_system && coding.code == coding_value }
+              codeable_concept.coding.any? { |coding| coding.system == coding_system && coding.code.casecmp?(coding_value) }
             else
-              codeable_concept.coding.any? { |coding| coding.code == value }
+              codeable_concept.coding.any? { |coding| coding.code.casecmp?(value) }
             end
           end
           assert match_found, "category in Observation/#{resource.id} (#{values_found}) does not match category requested (#{value})"
@@ -100,9 +100,9 @@ module Inferno
           coding_value = value.split('|').last
           match_found = values_found.any? do |codeable_concept|
             if value.include? '|'
-              codeable_concept.coding.any? { |coding| coding.system == coding_system && coding.code == coding_value }
+              codeable_concept.coding.any? { |coding| coding.system == coding_system && coding.code.casecmp?(coding_value) }
             else
-              codeable_concept.coding.any? { |coding| coding.code == value }
+              codeable_concept.coding.any? { |coding| coding.code.casecmp?(value) }
             end
           end
           assert match_found, "code in Observation/#{resource.id} (#{values_found}) does not match code requested (#{value})"


### PR DESCRIPTION
# Summary
This PR fixes GitHub Issue #412 

Inferno allows case-insensitive comparison on token value

## New behavior

## Code changes
Fix code generator for CodeableConcept data types in search_parameter_match_found method

## Testing guidance
