### PR TITLE
Add IE meta tag

### DIFF
--- a/lib/app/views/layout.erb
+++ b/lib/app/views/layout.erb
@@ -1,6 +1,9 @@
 <!doctype html>
 <html lang="en">
   <head>
+    <!-- Use the highest supported document mode of Internet Explorer -->
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+
     <title>Inferno</title>
     <!-- Required meta tags -->
     <meta charset="utf-8">


### PR DESCRIPTION
# Summary

Closes #437 

## New behavior

None.

## Code changes

Adding meta tag, single file, small change.

## Testing guidance

I cannot verify on a mac.  IE is EOL very soon anyway (2-3 months from now).  I took the meta tag from the issue, [cross-referenced to microsoft docs](https://docs.microsoft.com/en-us/previous-versions/windows/internet-explorer/ie-developer/compatibility/jj676915(v=vs.85)?redirectedfrom=MSDN) and read online.