### PR TITLE
Fix CLI invoked tests for bulk data.

### DIFF
--- a/lib/tasks/tasks.rake
+++ b/lib/tasks/tasks.rake
@@ -52,6 +52,14 @@ end
 def execute(instance, sequences)
   client = FHIR::Client.for_testing_instance(instance)
 
+  # ONC Program specific updates
+  # These are updates made to home.rb that should exist in a more central location,
+  # but since inferno-program is being sunsetted they are copied here instead of refactored.
+  instance.bulk_data_jwks = Inferno::App::Endpoint.settings.bulk_data_jwks.to_json if Inferno::App::Endpoint.settings.respond_to? :bulk_data_jwks
+  if Inferno::App::Endpoint.settings.respond_to? :disable_bulk_data_require_access_token_test
+    instance.disable_bulk_data_require_access_token_test = Inferno::App::Endpoint.settings.disable_bulk_data_require_access_token_test
+  end
+
   sequence_results = []
 
   fails = false


### PR DESCRIPTION
There was some code in `home.rb` that was necessary for bulk data tests to work, so if you ran them through the CLI the tests wouldn't work.

We should merge this, push a new image to inferno-program#latest, and update our reference server to test off `latest` instead of `release-latest`